### PR TITLE
fixed possible bug with dereferencing of the null pointer

### DIFF
--- a/WickedEngine/Vector_BindLua.cpp
+++ b/WickedEngine/Vector_BindLua.cpp
@@ -241,7 +241,7 @@ int Vector_BindLua::Multiply(lua_State* L)
 		}
 		else if (v2)
 		{
-			Luna<Vector_BindLua>::push(L, new Vector_BindLua(wiLua::SGetFloat(L, 1) * v1->vector));
+			Luna<Vector_BindLua>::push(L, new Vector_BindLua(wiLua::SGetFloat(L, 1) * v2->vector));
 			return 1;
 		}
 	}


### PR DESCRIPTION
I'm a member of the [Pinguem.ru](https://pinguem.ru) competition on finding errors in open source projects. The issue was found with [PVS-Studio](https://www.viva64.com/en/pvs-studio/):
* V522 Dereferencing of the null pointer 'v1' might take place. vector_bindlua.cpp 244