### PR TITLE
Fixed incorrect use of unique_ptr

### DIFF
--- a/WickedEngine/Utility/ScreenGrab.cpp
+++ b/WickedEngine/Utility/ScreenGrab.cpp
@@ -750,7 +750,7 @@ HRESULT DirectX::SaveDDSTextureToFile( _In_ ID3D11DeviceContext* pContext,
     }
 
     // Setup pixels
-    std::unique_ptr<uint8_t> pixels( new (std::nothrow) uint8_t[ slicePitch ] );
+    std::unique_ptr<uint8_t[]> pixels( new (std::nothrow) uint8_t[ slicePitch ] );
     if (!pixels)
         return E_OUTOFMEMORY;
 


### PR DESCRIPTION
I'm a member of the [Pinguem.ru](https://pinguem.ru) competition on finding errors in open source projects. The issue was found with [PVS-Studio](https://www.viva64.com/en/pvs-studio/):

- V554 Incorrect use of unique_ptr. The memory allocated with 'new []' will be cleaned using 'delete'. screengrab.cpp 753