### PR TITLE
Use standard types where possible instead of WIN32 types.

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -1592,7 +1592,7 @@ void EditorComponent::Render() const
 
 		device->EventBegin("Editor - Selection Outline", cmd);
 
-		ViewPort vp;
+		Viewport vp;
 		vp.Width = (float)rt_selectionOutline[0].GetDesc().Width;
 		vp.Height = (float)rt_selectionOutline[0].GetDesc().Height;
 		device->BindViewports(1, &vp, cmd);

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -3,7 +3,8 @@
 
 // This is a helper include file pasted into all engine headers try to keep it minimal!
 // Do not include engine features in this file!
-
+#include <stddef.h>
+#include <stdint.h>
 
 // Platform specific:
 #define NOMINMAX
@@ -34,7 +35,6 @@ using namespace DirectX::PackedVector;
 #define SAFE_DELETE(a) {delete (a);(a)=nullptr;}
 #define SAFE_DELETE_ARRAY(a) {delete[](a);(a)=nullptr;}
 #define GFX_STRUCT struct alignas(16)
-#define GFX_CLASS class alignas(16)
 
 static const XMFLOAT4X4 IDENTITYMATRIX = XMFLOAT4X4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
 

--- a/WickedEngine/RenderPath2D.cpp
+++ b/WickedEngine/RenderPath2D.cpp
@@ -147,7 +147,7 @@ void RenderPath2D::Render() const
 	{
 		device->RenderPassBegin(&renderpass_stenciled, cmd);
 
-		ViewPort vp;
+		Viewport vp;
 		vp.Width = (float)rtStenciled.GetDesc().Width;
 		vp.Height = (float)rtStenciled.GetDesc().Height;
 		device->BindViewports(1, &vp, cmd);
@@ -170,7 +170,7 @@ void RenderPath2D::Render() const
 
 	device->RenderPassBegin(&renderpass_final, cmd);
 
-	ViewPort vp;
+	Viewport vp;
 	vp.Width = (float)rtFinal.GetDesc().Width;
 	vp.Height = (float)rtFinal.GetDesc().Height;
 	device->BindViewports(1, &vp, cmd);

--- a/WickedEngine/RenderPath3D.cpp
+++ b/WickedEngine/RenderPath3D.cpp
@@ -27,7 +27,7 @@ void RenderPath3D::ResizeBuffers()
 		device->CreateTexture(&desc, nullptr, &rtSSR);
 		device->SetName(&rtSSR, "rtSSR");
 
-		for (UINT i = 0; i < rtSSR.GetDesc().MipLevels; ++i)
+		for (uint32_t i = 0; i < rtSSR.GetDesc().MipLevels; ++i)
 		{
 			int subresource_index;
 			subresource_index = device->CreateSubresource(&rtSSR, SRV, 0, 1, i, 1);
@@ -80,7 +80,7 @@ void RenderPath3D::ResizeBuffers()
 		device->CreateTexture(&desc, nullptr, &rtSceneCopy);
 		device->SetName(&rtSceneCopy, "rtSceneCopy");
 
-		for (UINT i = 0; i < rtSceneCopy.GetDesc().MipLevels; ++i)
+		for (uint32_t i = 0; i < rtSceneCopy.GetDesc().MipLevels; ++i)
 		{
 			int subresource_index;
 			subresource_index = device->CreateSubresource(&rtSceneCopy, SRV, 0, 1, i, 1);
@@ -157,7 +157,7 @@ void RenderPath3D::ResizeBuffers()
 		device->CreateTexture(&desc, nullptr, &rtBloom);
 		device->SetName(&rtBloom, "rtBloom");
 
-		for (UINT i = 0; i < rtBloom.GetDesc().MipLevels; ++i)
+		for (uint32_t i = 0; i < rtBloom.GetDesc().MipLevels; ++i)
 		{
 			int subresource_index;
 			subresource_index = device->CreateSubresource(&rtBloom, SRV, 0, 1, i, 1);
@@ -345,10 +345,10 @@ void RenderPath3D::RenderFrameSetUp(CommandList cmd) const
 	device->BindResource(CS, &depthBuffer_Copy, TEXSLOT_DEPTH, cmd);
 	wiRenderer::UpdateRenderData(cmd);
 	
-	ViewPort viewPort;
-	viewPort.Width = (float)smallDepth.GetDesc().Width;
-	viewPort.Height = (float)smallDepth.GetDesc().Height;
-	device->BindViewports(1, &viewPort, cmd);
+	Viewport viewport;
+	viewport.Width = (float)smallDepth.GetDesc().Width;
+	viewport.Height = (float)smallDepth.GetDesc().Height;
+	device->BindViewports(1, &viewport, cmd);
 
 	device->RenderPassBegin(&renderpass_occlusionculling, cmd);
 
@@ -366,7 +366,7 @@ void RenderPath3D::RenderReflections(CommandList cmd) const
 
 		wiRenderer::UpdateCameraCB(wiRenderer::GetRefCamera(), cmd);
 
-		ViewPort vp;
+		Viewport vp;
 		vp.Width = (float)depthBuffer_Reflection.GetDesc().Width;
 		vp.Height = (float)depthBuffer_Reflection.GetDesc().Height;
 		device->BindViewports(1, &vp, cmd);
@@ -438,10 +438,10 @@ void RenderPath3D::DownsampleDepthBuffer(CommandList cmd) const
 {
 	GraphicsDevice* device = wiRenderer::GetDevice();
 
-	ViewPort viewPort;
-	viewPort.Width = (float)smallDepth.GetDesc().Width;
-	viewPort.Height = (float)smallDepth.GetDesc().Height;
-	device->BindViewports(1, &viewPort, cmd);
+	Viewport viewport;
+	viewport.Width = (float)smallDepth.GetDesc().Width;
+	viewport.Height = (float)smallDepth.GetDesc().Height;
+	device->BindViewports(1, &viewport, cmd);
 
 	device->RenderPassBegin(&renderpass_downsampledepthbuffer, cmd);
 
@@ -470,7 +470,7 @@ void RenderPath3D::RenderLightShafts(CommandList cmd) const
 		{
 			device->RenderPassBegin(&renderpass_lightshafts, cmd);
 
-			ViewPort vp;
+			Viewport vp;
 			vp.Width = (float)depthBuffer.GetDesc().Width;
 			vp.Height = (float)depthBuffer.GetDesc().Height;
 			device->BindViewports(1, &vp, cmd);
@@ -509,7 +509,7 @@ void RenderPath3D::RenderVolumetrics(CommandList cmd) const
 
 		device->RenderPassBegin(&renderpass_volumetriclight, cmd);
 
-		ViewPort vp;
+		Viewport vp;
 		vp.Width = (float)rtVolumetricLights.GetDesc().Width;
 		vp.Height = (float)rtVolumetricLights.GetDesc().Height;
 		device->BindViewports(1, &vp, cmd);
@@ -542,7 +542,7 @@ void RenderPath3D::RenderTransparents(const RenderPass& renderpass_transparent, 
 		// todo: refactor water ripples and avoid clear if there is none!
 		device->RenderPassBegin(&renderpass_waterripples, cmd);
 
-		ViewPort vp;
+		Viewport vp;
 		vp.Width = (float)rtWaterRipple.GetDesc().Width;
 		vp.Height = (float)rtWaterRipple.GetDesc().Height;
 		device->BindViewports(1, &vp, cmd);
@@ -557,7 +557,7 @@ void RenderPath3D::RenderTransparents(const RenderPass& renderpass_transparent, 
 
 	device->RenderPassBegin(&renderpass_transparent, cmd);
 
-	ViewPort vp;
+	Viewport vp;
 	vp.Width = (float)renderpass_transparent.desc.attachments[0].texture->GetDesc().Width;
 	vp.Height = (float)renderpass_transparent.desc.attachments[0].texture->GetDesc().Height;
 	device->BindViewports(1, &vp, cmd);
@@ -610,7 +610,7 @@ void RenderPath3D::RenderTransparents(const RenderPass& renderpass_transparent, 
 	{
 		device->RenderPassBegin(&renderpass_particledistortion, cmd);
 
-		ViewPort vp;
+		Viewport vp;
 		vp.Width = (float)rtParticleDistortion.GetDesc().Width;
 		vp.Height = (float)rtParticleDistortion.GetDesc().Height;
 		device->BindViewports(1, &vp, cmd);
@@ -658,7 +658,7 @@ void RenderPath3D::RenderBloom(const RenderPass& renderpass_bloom, CommandList c
 
 			device->RenderPassBegin(&renderpass_bloom, cmd);
 
-			ViewPort vp;
+			Viewport vp;
 			vp.Width = (float)renderpass_bloom.desc.attachments[0].texture->GetDesc().Width;
 			vp.Height = (float)renderpass_bloom.desc.attachments[0].texture->GetDesc().Height;
 			device->BindViewports(1, &vp, cmd);

--- a/WickedEngine/RenderPath3D.h
+++ b/WickedEngine/RenderPath3D.h
@@ -17,7 +17,7 @@ private:
 	float outlineThickness = 1.0f;
 	XMFLOAT4 outlineColor = XMFLOAT4(0, 0, 0, 1);
 	float ssaoRange = 1.0f;
-	UINT ssaoSampleCount = 16;
+	uint32_t ssaoSampleCount = 16;
 	float chromaticAberrationAmount = 2.0f;
 
 	bool fxaaEnabled = false;
@@ -41,7 +41,7 @@ private:
 
 	const wiGraphics::Texture* colorGradingTex = nullptr;
 
-	UINT msaaSampleCount = 1;
+	uint32_t msaaSampleCount = 1;
 
 protected:
 	wiGraphics::Texture rtReflection; // conains the scene rendered for planar reflections
@@ -119,7 +119,7 @@ public:
 	constexpr float getOutlineThickness() const { return outlineThickness; }
 	constexpr XMFLOAT4 getOutlineColor() const { return outlineColor; }
 	constexpr float getSSAORange() const { return ssaoRange; }
-	constexpr UINT getSSAOSampleCount() const { return ssaoSampleCount; }
+	constexpr uint32_t getSSAOSampleCount() const { return ssaoSampleCount; }
 	constexpr float getChromaticAberrationAmount() const { return chromaticAberrationAmount; }
 
 	constexpr bool getSSAOEnabled() const { return ssaoEnabled; }
@@ -143,7 +143,7 @@ public:
 
 	constexpr const wiGraphics::Texture* getColorGradingTexture() const { return colorGradingTex; }
 
-	constexpr UINT getMSAASampleCount() const { return msaaSampleCount; }
+	constexpr uint32_t getMSAASampleCount() const { return msaaSampleCount; }
 
 	constexpr void setExposure(float value) { exposure = value; }
 	constexpr void setBloomThreshold(float value){ bloomThreshold = value; }
@@ -155,7 +155,7 @@ public:
 	constexpr void setOutlineThickness(float value) { outlineThickness = value; }
 	constexpr void setOutlineColor(const XMFLOAT4& value) { outlineColor = value; }
 	constexpr void setSSAORange(float value) { ssaoRange = value; }
-	constexpr void setSSAOSampleCount(UINT value) { ssaoSampleCount = value; }
+	constexpr void setSSAOSampleCount(uint32_t value) { ssaoSampleCount = value; }
 	constexpr void setChromaticAberrationAmount(float value) { chromaticAberrationAmount = value; }
 
 	constexpr void setSSAOEnabled(bool value){ ssaoEnabled = value; }
@@ -179,7 +179,7 @@ public:
 
 	constexpr void setColorGradingTexture(const wiGraphics::Texture* tex) { colorGradingTex = tex; }
 
-	virtual void setMSAASampleCount(UINT value) { if (msaaSampleCount != value) { msaaSampleCount = value; ResizeBuffers(); } }
+	virtual void setMSAASampleCount(uint32_t value) { if (msaaSampleCount != value) { msaaSampleCount = value; ResizeBuffers(); } }
 
 	void Update(float dt) override;
 	void Render() const override = 0;

--- a/WickedEngine/RenderPath3D_BindLua.cpp
+++ b/WickedEngine/RenderPath3D_BindLua.cpp
@@ -299,7 +299,7 @@ int RenderPath3D_BindLua::SetMSAASampleCount(lua_State* L)
 	}
 	if (wiLua::SGetArgCount(L) > 0)
 	{
-		((RenderPath3D*)component)->setMSAASampleCount((UINT)wiLua::SGetInt(L, 1));
+		((RenderPath3D*)component)->setMSAASampleCount((uint32_t)wiLua::SGetInt(L, 1));
 	}
 	else
 		wiLua::SError(L, "SetMSAASampleCount(int value) not enough arguments!");

--- a/WickedEngine/RenderPath3D_Deferred.cpp
+++ b/WickedEngine/RenderPath3D_Deferred.cpp
@@ -162,7 +162,7 @@ void RenderPath3D_Deferred::Render() const
 
 			device->RenderPassBegin(&renderpass_gbuffer, cmd);
 
-			ViewPort vp;
+			Viewport vp;
 			vp.Width = (float)depthBuffer.GetDesc().Width;
 			vp.Height = (float)depthBuffer.GetDesc().Height;
 			device->BindViewports(1, &vp, cmd);
@@ -210,7 +210,7 @@ void RenderPath3D_Deferred::Render() const
 		{
 			device->RenderPassBegin(&renderpass_lights, cmd);
 
-			ViewPort vp;
+			Viewport vp;
 			vp.Width = (float)depthBuffer.GetDesc().Width;
 			vp.Height = (float)depthBuffer.GetDesc().Height;
 			device->BindViewports(1, &vp, cmd);
@@ -281,7 +281,7 @@ void RenderPath3D_Deferred::RenderDecals(CommandList cmd) const
 
 	device->RenderPassBegin(&renderpass_decals, cmd);
 
-	ViewPort vp;
+	Viewport vp;
 	vp.Width = (float)depthBuffer.GetDesc().Width;
 	vp.Height = (float)depthBuffer.GetDesc().Height;
 	device->BindViewports(1, &vp, cmd);
@@ -296,7 +296,7 @@ void RenderPath3D_Deferred::RenderDeferredComposition(CommandList cmd) const
 
 	device->RenderPassBegin(&renderpass_deferredcomposition, cmd);
 
-	ViewPort vp;
+	Viewport vp;
 	vp.Width = (float)depthBuffer.GetDesc().Width;
 	vp.Height = (float)depthBuffer.GetDesc().Height;
 	device->BindViewports(1, &vp, cmd);

--- a/WickedEngine/RenderPath3D_Deferred.h
+++ b/WickedEngine/RenderPath3D_Deferred.h
@@ -27,7 +27,7 @@ protected:
 	virtual void RenderDeferredComposition(wiGraphics::CommandList cmd) const;
 
 public:
-	void setMSAASampleCount(UINT value) override { /*disable MSAA for deferred*/ }
+	void setMSAASampleCount(uint32_t value) override { /*disable MSAA for deferred*/ }
 
 	void Render() const override;
 };

--- a/WickedEngine/RenderPath3D_Forward.cpp
+++ b/WickedEngine/RenderPath3D_Forward.cpp
@@ -107,7 +107,7 @@ void RenderPath3D_Forward::Render() const
 
 			device->RenderPassBegin(&renderpass_depthprepass, cmd);
 
-			ViewPort vp;
+			Viewport vp;
 			vp.Width = (float)depthBuffer.GetDesc().Width;
 			vp.Height = (float)depthBuffer.GetDesc().Height;
 			device->BindViewports(1, &vp, cmd);
@@ -162,7 +162,7 @@ void RenderPath3D_Forward::Render() const
 
 			device->RenderPassBegin(&renderpass_main, cmd);
 
-			ViewPort vp;
+			Viewport vp;
 			vp.Width = (float)depthBuffer.GetDesc().Width;
 			vp.Height = (float)depthBuffer.GetDesc().Height;
 			device->BindViewports(1, &vp, cmd);

--- a/WickedEngine/RenderPath3D_PathTracing.cpp
+++ b/WickedEngine/RenderPath3D_PathTracing.cpp
@@ -120,7 +120,7 @@ void RenderPath3D_PathTracing::Render() const
 		{
 			device->RenderPassBegin(&renderpass_debugbvh, cmd);
 
-			ViewPort vp;
+			Viewport vp;
 			vp.Width = (float)traceResult.GetDesc().Width;
 			vp.Height = (float)traceResult.GetDesc().Height;
 			device->BindViewports(1, &vp, cmd);

--- a/WickedEngine/RenderPath3D_TiledDeferred.cpp
+++ b/WickedEngine/RenderPath3D_TiledDeferred.cpp
@@ -60,7 +60,7 @@ void RenderPath3D_TiledDeferred::Render() const
 
 			device->RenderPassBegin(&renderpass_gbuffer, cmd);
 
-			ViewPort vp;
+			Viewport vp;
 			vp.Width = (float)depthBuffer.GetDesc().Width;
 			vp.Height = (float)depthBuffer.GetDesc().Height;
 			device->BindViewports(1, &vp, cmd);

--- a/WickedEngine/RenderPath3D_TiledForward.cpp
+++ b/WickedEngine/RenderPath3D_TiledForward.cpp
@@ -34,7 +34,7 @@ void RenderPath3D_TiledForward::Render() const
 
 			device->RenderPassBegin(&renderpass_depthprepass, cmd);
 
-			ViewPort vp;
+			Viewport vp;
 			vp.Width = (float)depthBuffer.GetDesc().Width;
 			vp.Height = (float)depthBuffer.GetDesc().Height;
 			device->BindViewports(1, &vp, cmd);
@@ -94,7 +94,7 @@ void RenderPath3D_TiledForward::Render() const
 
 			device->RenderPassBegin(&renderpass_main, cmd);
 
-			ViewPort vp;
+			Viewport vp;
 			vp.Width = (float)depthBuffer.GetDesc().Width;
 			vp.Height = (float)depthBuffer.GetDesc().Height;
 			device->BindViewports(1, &vp, cmd);

--- a/WickedEngine/wiDirectInput.cpp
+++ b/WickedEngine/wiDirectInput.cpp
@@ -27,7 +27,7 @@ BOOL IsXInputDevice(const GUID* pGuidProductFromDirectInput)
 	BSTR                    bstrClassName = NULL;
 	DWORD                   uReturned = 0;
 	bool                    bIsXinputDevice = false;
-	UINT                    iDevice = 0;
+	uint32_t                    iDevice = 0;
 	VARIANT                 var;
 	HRESULT                 hr;
 

--- a/WickedEngine/wiEmittedParticle.cpp
+++ b/WickedEngine/wiEmittedParticle.cpp
@@ -268,8 +268,8 @@ void wiEmittedParticle::UpdateGPU(const TransformComponent& transform, const Mat
 
 		EmittedParticleCB cb;
 		cb.xEmitterWorld = transform.world;
-		cb.xEmitCount = (UINT)emit;
-		cb.xEmitterMeshIndexCount = mesh == nullptr ? 0 : (UINT)mesh->indices.size();
+		cb.xEmitCount = (uint32_t)emit;
+		cb.xEmitterMeshIndexCount = mesh == nullptr ? 0 : (uint32_t)mesh->indices.size();
 		cb.xEmitterMeshVertexPositionStride = sizeof(MeshComponent::Vertex_POS);
 		cb.xEmitterRandomness = wiRandom::getRandom(0, 1000) * 0.001f;
 		cb.xParticleLifeSpan = life;
@@ -376,7 +376,7 @@ void wiEmittedParticle::UpdateGPU(const TransformComponent& transform, const Mat
 				sphPartitionCellOffsets.get(),
 			};
 			device->BindUAVs(CS, uav_partitionoffsets, 0, ARRAYSIZE(uav_partitionoffsets), cmd);
-			device->Dispatch((UINT)ceilf((float)SPH_PARTITION_BUCKET_COUNT / (float)THREADCOUNT_SIMULATION), 1, 1, cmd);
+			device->Dispatch((uint32_t)ceilf((float)SPH_PARTITION_BUCKET_COUNT / (float)THREADCOUNT_SIMULATION), 1, 1, cmd);
 			device->Barrier(&GPUBarrier::Memory(), 1, cmd);
 			device->EventEnd(cmd);
 

--- a/WickedEngine/wiFFTGenerator.cpp
+++ b/WickedEngine/wiFFTGenerator.cpp
@@ -27,12 +27,12 @@ namespace wiFFTGenerator
 		const CSFFT512x512_Plan& fft_plan,
 		const GPUResource& pUAV_Dst,
 		const GPUResource& pSRV_Src,
-		UINT thread_count,
-		UINT istride,
+		uint32_t thread_count,
+		uint32_t istride,
 		CommandList cmd)
 	{
 		// Setup execution configuration
-		UINT grid = thread_count / COHERENCY_GRANULARITY;
+		uint32_t grid = thread_count / COHERENCY_GRANULARITY;
 
 		GraphicsDevice* device = wiRenderer::GetDevice();
 
@@ -69,11 +69,11 @@ namespace wiFFTGenerator
 		const GPUResource& pSRV_Src,
 		CommandList cmd)
 	{
-		const UINT thread_count = fft_plan.slices * (512 * 512) / 8;
+		const uint32_t thread_count = fft_plan.slices * (512 * 512) / 8;
 		GraphicsDevice* device = wiRenderer::GetDevice();
 		const GPUBuffer* cs_cbs;
 
-		UINT istride = 512 * 512 / 8;
+		uint32_t istride = 512 * 512 / 8;
 		cs_cbs = &fft_plan.pRadix008A_CB[0];
 		device->BindConstantBuffer(CS, cs_cbs, CB_GETBINDSLOT(FFTGeneratorCB), cmd);
 		radix008A(fft_plan, fft_plan.pBuffer_Tmp, pSRV_Src, thread_count, istride, cmd);
@@ -104,7 +104,7 @@ namespace wiFFTGenerator
 		radix008A(fft_plan, pUAV_Dst, fft_plan.pBuffer_Tmp, thread_count, istride, cmd);
 	}
 
-	void create_cbuffers_512x512(CSFFT512x512_Plan& plan, GraphicsDevice* device, UINT slices)
+	void create_cbuffers_512x512(CSFFT512x512_Plan& plan, GraphicsDevice* device, uint32_t slices)
 	{
 		// Create 6 cbuffers for 512x512 transform.
 
@@ -121,9 +121,9 @@ namespace wiFFTGenerator
 		cb_data.SysMemSlicePitch = 0;
 
 		// Buffer 0
-		const UINT thread_count = slices * (512 * 512) / 8;
-		UINT ostride = 512 * 512 / 8;
-		UINT istride = ostride;
+		const uint32_t thread_count = slices * (512 * 512) / 8;
+		uint32_t ostride = 512 * 512 / 8;
+		uint32_t istride = ostride;
 		double phase_base = -TWO_PI / (512.0 * 512.0);
 
 		FFTGeneratorCB cb_data_buf0 = { thread_count, ostride, istride, 512, (float)phase_base };
@@ -178,7 +178,7 @@ namespace wiFFTGenerator
 		device->CreateBuffer(&cb_desc, &cb_data, &plan.pRadix008A_CB[5]);
 	}
 
-	void fft512x512_create_plan(CSFFT512x512_Plan& plan, UINT slices)
+	void fft512x512_create_plan(CSFFT512x512_Plan& plan, uint32_t slices)
 	{
 		GraphicsDevice* device = wiRenderer::GetDevice();
 

--- a/WickedEngine/wiFFTGenerator.h
+++ b/WickedEngine/wiFFTGenerator.h
@@ -8,7 +8,7 @@ namespace wiFFTGenerator
 	struct CSFFT512x512_Plan
 	{
 		// More than one array can be transformed at same time
-		UINT slices;
+		uint32_t slices;
 
 		// For 512x512 config, we need 6 constant buffers
 		wiGraphics::GPUBuffer pRadix008A_CB[6];
@@ -17,7 +17,7 @@ namespace wiFFTGenerator
 	};
 
 
-	void fft512x512_create_plan(CSFFT512x512_Plan& plan, UINT slices);
+	void fft512x512_create_plan(CSFFT512x512_Plan& plan, uint32_t slices);
 
 	void fft_512x512_c2c(
 		const CSFFT512x512_Plan& fft_plan,

--- a/WickedEngine/wiFont.cpp
+++ b/WickedEngine/wiFont.cpp
@@ -217,7 +217,7 @@ void wiFont::Initialize()
 
 		GPUBufferDesc bd;
 		bd.Usage = USAGE_IMMUTABLE;
-		bd.ByteWidth = UINT(sizeof(uint16_t) * indices.size());
+		bd.ByteWidth = uint32_t(sizeof(uint16_t) * indices.size());
 		bd.BindFlags = BIND_INDEX_BUFFER;
 		bd.CPUAccessFlags = 0;
 		SubresourceData InitData;
@@ -497,10 +497,10 @@ void wiFont::Draw(CommandList cmd) const
 	const GPUBuffer* vbs[] = {
 		mem.buffer,
 	};
-	const UINT strides[] = {
+	const uint32_t strides[] = {
 		sizeof(FontVertex),
 	};
-	const UINT offsets[] = {
+	const uint32_t offsets[] = {
 		mem.offset,
 	};
 	device->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, offsets, cmd);

--- a/WickedEngine/wiGPUBVH.cpp
+++ b/WickedEngine/wiGPUBVH.cpp
@@ -99,8 +99,8 @@ void wiGPUBVH::UpdateGlobalMaterialResources(const Scene& scene, CommandList cmd
 			assert(bins.size() == 1 && "The regions won't fit into the texture!");
 
 			TextureDesc desc;
-			desc.Width = (UINT)bins[0].size.w;
-			desc.Height = (UINT)bins[0].size.h;
+			desc.Width = (uint32_t)bins[0].size.w;
+			desc.Height = (uint32_t)bins[0].size.h;
 			desc.MipLevels = 1;
 			desc.ArraySize = 1;
 			desc.Format = FORMAT_R8G8B8A8_UNORM;
@@ -232,7 +232,7 @@ void wiGPUBVH::UpdateGlobalMaterialResources(const Scene& scene, CommandList cmd
 
 		desc.BindFlags = BIND_SHADER_RESOURCE;
 		desc.StructureByteStride = sizeof(ShaderMaterial);
-		desc.ByteWidth = desc.StructureByteStride * (UINT)materialArray.size();
+		desc.ByteWidth = desc.StructureByteStride * (uint32_t)materialArray.size();
 		desc.CPUAccessFlags = 0;
 		desc.Format = FORMAT_UNKNOWN;
 		desc.MiscFlags = RESOURCE_MISC_BUFFER_STRUCTURED;

--- a/WickedEngine/wiGPUSortLib.cpp
+++ b/WickedEngine/wiGPUSortLib.cpp
@@ -52,10 +52,10 @@ namespace wiGPUSortLib
 
 
 	void Sort(
-		UINT maxCount, 
+		uint32_t maxCount, 
 		const GPUBuffer& comparisonBuffer_read, 
 		const GPUBuffer& counterBuffer_read, 
-		UINT counterReadOffset, 
+		uint32_t counterReadOffset, 
 		const GPUBuffer& indexBuffer_write,
 		CommandList cmd)
 	{

--- a/WickedEngine/wiGPUSortLib.h
+++ b/WickedEngine/wiGPUSortLib.h
@@ -11,10 +11,10 @@ namespace wiGPUSortLib
 	//	counterReadOffset		-	Byte offset into the counter buffer to read the count value (Read Only)
 	//	indexBuffer_write		-	The index list which to sort. Contains index values which can index the sortBase_read buffer. This will be modified (Read + Write)
 	void Sort(
-		UINT maxCount, 
+		uint32_t maxCount, 
 		const wiGraphics::GPUBuffer& comparisonBuffer_read, 
 		const wiGraphics::GPUBuffer& counterBuffer_read, 
-		UINT counterReadOffset, 
+		uint32_t counterReadOffset, 
 		const wiGraphics::GPUBuffer& indexBuffer_write,
 		wiGraphics::CommandList cmd
 	);

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -99,10 +99,10 @@ void wiGUI::Render(CommandList cmd) const
 void wiGUI::ResetScissor(CommandList cmd) const
 {
 	wiGraphics::Rect scissor[1];
-	scissor[0].bottom = (LONG)(wiRenderer::GetDevice()->GetScreenHeight());
-	scissor[0].left = (LONG)(0);
-	scissor[0].right = (LONG)(wiRenderer::GetDevice()->GetScreenWidth());
-	scissor[0].top = (LONG)(0);
+	scissor[0].bottom = (int32_t)(wiRenderer::GetDevice()->GetScreenHeight());
+	scissor[0].left = (int32_t)(0);
+	scissor[0].right = (int32_t)(wiRenderer::GetDevice()->GetScreenWidth());
+	scissor[0].top = (int32_t)(0);
 	wiRenderer::GetDevice()->BindScissorRects(1, scissor, cmd);
 }
 

--- a/WickedEngine/wiGraphicsDescriptors.h
+++ b/WickedEngine/wiGraphicsDescriptors.h
@@ -324,7 +324,7 @@ namespace wiGraphics
 
 	// Structs /////////////////////////////////////////////
 
-	struct ViewPort
+	struct Viewport
 	{
 		float TopLeftX = 0.0f;
 		float TopLeftY = 0.0f;
@@ -335,15 +335,15 @@ namespace wiGraphics
 	};
 	struct VertexLayoutDesc
 	{
-		static const UINT APPEND_ALIGNED_ELEMENT = 0xffffffff; // automatically figure out AlignedByteOffset depending on Format
+		static const uint32_t APPEND_ALIGNED_ELEMENT = 0xffffffff; // automatically figure out AlignedByteOffset depending on Format
 
 		char* SemanticName = nullptr;
-		UINT SemanticIndex = 0;
+		uint32_t SemanticIndex = 0;
 		FORMAT Format = FORMAT_UNKNOWN;
-		UINT InputSlot = 0;
-		UINT AlignedByteOffset = APPEND_ALIGNED_ELEMENT;
+		uint32_t InputSlot = 0;
+		uint32_t AlignedByteOffset = APPEND_ALIGNED_ELEMENT;
 		INPUT_CLASSIFICATION InputSlotClass = INPUT_CLASSIFICATION::INPUT_PER_VERTEX_DATA;
-		UINT InstanceDataStepRate = 0;
+		uint32_t InstanceDataStepRate = 0;
 	};
 	union ClearValue
 	{
@@ -351,7 +351,7 @@ namespace wiGraphics
 		struct ClearDepthStencil
 		{
 			float depth;
-			UINT stencil;
+			uint32_t stencil;
 		} depthstencil;
 	};
 	struct TextureDesc
@@ -362,17 +362,17 @@ namespace wiGraphics
 			TEXTURE_2D,
 			TEXTURE_3D,
 		} type = TEXTURE_2D;
-		UINT Width = 0;
-		UINT Height = 0;
-		UINT Depth = 0;
-		UINT ArraySize = 1;
-		UINT MipLevels = 1;
+		uint32_t Width = 0;
+		uint32_t Height = 0;
+		uint32_t Depth = 0;
+		uint32_t ArraySize = 1;
+		uint32_t MipLevels = 1;
 		FORMAT Format = FORMAT_UNKNOWN;
-		UINT SampleCount = 1;
+		uint32_t SampleCount = 1;
 		USAGE Usage = USAGE_DEFAULT;
-		UINT BindFlags = 0;
-		UINT CPUAccessFlags = 0;
-		UINT MiscFlags = 0;
+		uint32_t BindFlags = 0;
+		uint32_t CPUAccessFlags = 0;
+		uint32_t MiscFlags = 0;
 		ClearValue clear = {};
 		IMAGE_LAYOUT layout = IMAGE_LAYOUT_GENERAL;
 	};
@@ -383,7 +383,7 @@ namespace wiGraphics
 		TEXTURE_ADDRESS_MODE AddressV = TEXTURE_ADDRESS_CLAMP;
 		TEXTURE_ADDRESS_MODE AddressW = TEXTURE_ADDRESS_CLAMP;
 		float MipLODBias = 0.0f;
-		UINT MaxAnisotropy = 0;
+		uint32_t MaxAnisotropy = 0;
 		COMPARISON_FUNC ComparisonFunc = COMPARISON_NEVER;
 		float BorderColor[4] = { 0.0f,0.0f,0.0f,0.0f };
 		float MinLOD = 0.0f;
@@ -401,7 +401,7 @@ namespace wiGraphics
 		bool MultisampleEnable = false;
 		bool AntialiasedLineEnable = false;
 		bool ConservativeRasterizationEnable = false;
-		UINT ForcedSampleCount = 0;
+		uint32_t ForcedSampleCount = 0;
 	};
 	struct DepthStencilOpDesc
 	{
@@ -440,12 +440,12 @@ namespace wiGraphics
 	};
 	struct GPUBufferDesc
 	{
-		UINT ByteWidth = 0;
+		uint32_t ByteWidth = 0;
 		USAGE Usage = USAGE_DEFAULT;
-		UINT BindFlags = 0;
-		UINT CPUAccessFlags = 0;
-		UINT MiscFlags = 0;
-		UINT StructureByteStride = 0; // needed for typed and structured buffer types!
+		uint32_t BindFlags = 0;
+		uint32_t CPUAccessFlags = 0;
+		uint32_t MiscFlags = 0;
+		uint32_t StructureByteStride = 0; // needed for typed and structured buffer types!
 		FORMAT Format = FORMAT_UNKNOWN; // only needed for typed buffer!
 	};
 	struct GPUQueryDesc
@@ -454,11 +454,11 @@ namespace wiGraphics
 	};
 	struct GPUQueryResult
 	{
-		BOOL	result_passed = FALSE;
-		UINT64	result_passed_sample_count = 0;
-		UINT64	result_timestamp = 0;
-		UINT64	result_timestamp_frequency = 0;
-		BOOL	result_disjoint = FALSE;
+		bool		result_passed = FALSE;
+		uint64_t	result_passed_sample_count = 0;
+		uint64_t	result_timestamp = 0;
+		uint64_t	result_timestamp_frequency = 0;
+		bool		result_disjoint = FALSE;
 	};
 	struct PipelineStateDesc
 	{
@@ -472,7 +472,7 @@ namespace wiGraphics
 		const DepthStencilState*	dss = nullptr;
 		const VertexLayout*			il = nullptr;
 		PRIMITIVETOPOLOGY			pt = TRIANGLELIST;
-		UINT						sampleMask = 0xFFFFFFFF;
+		uint32_t						sampleMask = 0xFFFFFFFF;
 	};
 	struct GPUBarrier
 	{
@@ -553,42 +553,42 @@ namespace wiGraphics
 	};
 	struct RenderPassDesc
 	{
-		UINT numAttachments = 0;
+		uint32_t numAttachments = 0;
 		RenderPassAttachment attachments[9] = {};
 	};
 	struct IndirectDrawArgsInstanced
 	{
-		UINT VertexCountPerInstance = 0;
-		UINT InstanceCount = 0;
-		UINT StartVertexLocation = 0;
-		UINT StartInstanceLocation = 0;
+		uint32_t VertexCountPerInstance = 0;
+		uint32_t InstanceCount = 0;
+		uint32_t StartVertexLocation = 0;
+		uint32_t StartInstanceLocation = 0;
 	};
 	struct IndirectDrawArgsIndexedInstanced
 	{
-		UINT IndexCountPerInstance = 0;
-		UINT InstanceCount = 0;
-		UINT StartIndexLocation = 0;
+		uint32_t IndexCountPerInstance = 0;
+		uint32_t InstanceCount = 0;
+		uint32_t StartIndexLocation = 0;
 		INT BaseVertexLocation = 0;
-		UINT StartInstanceLocation = 0;
+		uint32_t StartInstanceLocation = 0;
 	};
 	struct IndirectDispatchArgs
 	{
-		UINT ThreadGroupCountX = 0;
-		UINT ThreadGroupCountY = 0;
-		UINT ThreadGroupCountZ = 0;
+		uint32_t ThreadGroupCountX = 0;
+		uint32_t ThreadGroupCountY = 0;
+		uint32_t ThreadGroupCountZ = 0;
 	};
 	struct SubresourceData
 	{
 		const void *pSysMem = nullptr;
-		UINT SysMemPitch = 0;
-		UINT SysMemSlicePitch = 0;
+		uint32_t SysMemPitch = 0;
+		uint32_t SysMemSlicePitch = 0;
 	};
 	struct Rect
 	{
-		LONG left = 0;
-		LONG top = 0;
-		LONG right = 0;
-		LONG bottom = 0;
+		int32_t left = 0;
+		int32_t top = 0;
+		int32_t right = 0;
+		int32_t bottom = 0;
 	};
 
 }

--- a/WickedEngine/wiGraphicsDevice.h
+++ b/WickedEngine/wiGraphicsDevice.h
@@ -21,7 +21,7 @@ namespace wiGraphics
 		bool FULLSCREEN = false;
 		bool RESOLUTIONCHANGED = false;
 		FORMAT BACKBUFFER_FORMAT = FORMAT_R10G10B10A2_UNORM;
-		static const UINT BACKBUFFER_COUNT = 2;
+		static const uint32_t BACKBUFFER_COUNT = 2;
 		bool TESSELLATION = false;
 		bool CONSERVATIVE_RASTERIZATION = false;
 		bool RASTERIZER_ORDERED_VIEWS = false;
@@ -32,7 +32,7 @@ namespace wiGraphics
 
 		virtual HRESULT CreateBuffer(const GPUBufferDesc *pDesc, const SubresourceData* pInitialData, GPUBuffer *pBuffer) = 0;
 		virtual HRESULT CreateTexture(const TextureDesc* pDesc, const SubresourceData *pInitialData, Texture *pTexture) = 0;
-		virtual HRESULT CreateInputLayout(const VertexLayoutDesc *pInputElementDescs, UINT NumElements, const ShaderByteCode* shaderCode, VertexLayout *pInputLayout) = 0;
+		virtual HRESULT CreateInputLayout(const VertexLayoutDesc *pInputElementDescs, uint32_t NumElements, const ShaderByteCode* shaderCode, VertexLayout *pInputLayout) = 0;
 		virtual HRESULT CreateVertexShader(const void *pShaderBytecode, SIZE_T BytecodeLength, VertexShader *pVertexShader) = 0;
 		virtual HRESULT CreatePixelShader(const void *pShaderBytecode, SIZE_T BytecodeLength, PixelShader *pPixelShader) = 0;
 		virtual HRESULT CreateGeometryShader(const void *pShaderBytecode, SIZE_T BytecodeLength, GeometryShader *pGeometryShader) = 0;
@@ -47,7 +47,7 @@ namespace wiGraphics
 		virtual HRESULT CreatePipelineState(const PipelineStateDesc* pDesc, PipelineState* pso) = 0;
 		virtual HRESULT CreateRenderPass(const RenderPassDesc* pDesc, RenderPass* renderpass) = 0;
 
-		virtual int CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, UINT firstSlice, UINT sliceCount, UINT firstMip, UINT mipCount) = 0;
+		virtual int CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, uint32_t firstSlice, uint32_t sliceCount, uint32_t firstMip, uint32_t mipCount) = 0;
 
 		virtual void DestroyResource(GPUResource* pResource) = 0;
 		virtual void DestroyBuffer(GPUBuffer *pBuffer) = 0;
@@ -113,7 +113,7 @@ namespace wiGraphics
 			return XMMatrixOrthographicOffCenterLH(0, (float)GetScreenWidth(), (float)GetScreenHeight(), 0, -1, 1);
 		}
 		inline FORMAT GetBackBufferFormat() const { return BACKBUFFER_FORMAT; }
-		inline static UINT GetBackBufferCount() { return BACKBUFFER_COUNT; }
+		inline static uint32_t GetBackBufferCount() { return BACKBUFFER_COUNT; }
 
 		inline bool IsDebugDevice() const { return DEBUGDEVICE; }
 
@@ -122,44 +122,44 @@ namespace wiGraphics
 
 		virtual void RenderPassBegin(const RenderPass* renderpass, CommandList cmd) = 0;
 		virtual void RenderPassEnd(CommandList cmd) = 0;
-		virtual void BindScissorRects(UINT numRects, const Rect* rects, CommandList cmd) = 0;
-		virtual void BindViewports(UINT NumViewports, const ViewPort *pViewports, CommandList cmd) = 0;
-		virtual void BindResource(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource = -1) = 0;
-		virtual void BindResources(SHADERSTAGE stage, const GPUResource *const* resources, UINT slot, UINT count, CommandList cmd) = 0;
-		virtual void BindUAV(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource = -1) = 0;
-		virtual void BindUAVs(SHADERSTAGE stage, const GPUResource *const* resources, UINT slot, UINT count, CommandList cmd) = 0;
-		virtual void UnbindResources(UINT slot, UINT num, CommandList cmd) = 0;
-		virtual void UnbindUAVs(UINT slot, UINT num, CommandList cmd) = 0;
-		virtual void BindSampler(SHADERSTAGE stage, const Sampler* sampler, UINT slot, CommandList cmd) = 0;
-		virtual void BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, UINT slot, CommandList cmd) = 0;
-		virtual void BindVertexBuffers(const GPUBuffer *const* vertexBuffers, UINT slot, UINT count, const UINT* strides, const UINT* offsets, CommandList cmd) = 0;
-		virtual void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, UINT offset, CommandList cmd) = 0;
-		virtual void BindStencilRef(UINT value, CommandList cmd) = 0;
+		virtual void BindScissorRects(uint32_t numRects, const Rect* rects, CommandList cmd) = 0;
+		virtual void BindViewports(uint32_t NumViewports, const Viewport* pViewports, CommandList cmd) = 0;
+		virtual void BindResource(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource = -1) = 0;
+		virtual void BindResources(SHADERSTAGE stage, const GPUResource *const* resources, uint32_t slot, uint32_t count, CommandList cmd) = 0;
+		virtual void BindUAV(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource = -1) = 0;
+		virtual void BindUAVs(SHADERSTAGE stage, const GPUResource *const* resources, uint32_t slot, uint32_t count, CommandList cmd) = 0;
+		virtual void UnbindResources(uint32_t slot, uint32_t num, CommandList cmd) = 0;
+		virtual void UnbindUAVs(uint32_t slot, uint32_t num, CommandList cmd) = 0;
+		virtual void BindSampler(SHADERSTAGE stage, const Sampler* sampler, uint32_t slot, CommandList cmd) = 0;
+		virtual void BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, uint32_t slot, CommandList cmd) = 0;
+		virtual void BindVertexBuffers(const GPUBuffer *const* vertexBuffers, uint32_t slot, uint32_t count, const uint32_t* strides, const uint32_t* offsets, CommandList cmd) = 0;
+		virtual void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint32_t offset, CommandList cmd) = 0;
+		virtual void BindStencilRef(uint32_t value, CommandList cmd) = 0;
 		virtual void BindBlendFactor(float r, float g, float b, float a, CommandList cmd) = 0;
 		virtual void BindPipelineState(const PipelineState* pso, CommandList cmd) = 0;
 		virtual void BindComputeShader(const ComputeShader* cs, CommandList cmd) = 0;
-		virtual void Draw(UINT vertexCount, UINT startVertexLocation, CommandList cmd) = 0;
-		virtual void DrawIndexed(UINT indexCount, UINT startIndexLocation, UINT baseVertexLocation, CommandList cmd) = 0;
-		virtual void DrawInstanced(UINT vertexCount, UINT instanceCount, UINT startVertexLocation, UINT startInstanceLocation, CommandList cmd) = 0;
-		virtual void DrawIndexedInstanced(UINT indexCount, UINT instanceCount, UINT startIndexLocation, UINT baseVertexLocation, UINT startInstanceLocation, CommandList cmd) = 0;
-		virtual void DrawInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd) = 0;
-		virtual void DrawIndexedInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd) = 0;
-		virtual void Dispatch(UINT threadGroupCountX, UINT threadGroupCountY, UINT threadGroupCountZ, CommandList cmd) = 0;
-		virtual void DispatchIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd) = 0;
+		virtual void Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd) = 0;
+		virtual void DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, CommandList cmd) = 0;
+		virtual void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd) = 0;
+		virtual void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, uint32_t startInstanceLocation, CommandList cmd) = 0;
+		virtual void DrawInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd) = 0;
+		virtual void DrawIndexedInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd) = 0;
+		virtual void Dispatch(uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ, CommandList cmd) = 0;
+		virtual void DispatchIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd) = 0;
 		virtual void CopyResource(const GPUResource* pDst, const GPUResource* pSrc, CommandList cmd) = 0;
-		virtual void CopyTexture2D_Region(const Texture* pDst, UINT dstMip, UINT dstX, UINT dstY, const Texture* pSrc, UINT srcMip, CommandList cmd) = 0;
+		virtual void CopyTexture2D_Region(const Texture* pDst, uint32_t dstMip, uint32_t dstX, uint32_t dstY, const Texture* pSrc, uint32_t srcMip, CommandList cmd) = 0;
 		virtual void MSAAResolve(const Texture* pDst, const Texture* pSrc, CommandList cmd) = 0;
 		virtual void UpdateBuffer(const GPUBuffer* buffer, const void* data, CommandList cmd, int dataSize = -1) = 0;
 		virtual void QueryBegin(const GPUQuery *query, CommandList cmd) = 0;
 		virtual void QueryEnd(const GPUQuery *query, CommandList cmd) = 0;
 		virtual bool QueryRead(const GPUQuery *query, GPUQueryResult* result) = 0;
-		virtual void Barrier(const GPUBarrier* barriers, UINT numBarriers, CommandList cmd) = 0;
+		virtual void Barrier(const GPUBarrier* barriers, uint32_t numBarriers, CommandList cmd) = 0;
 
 		struct GPUAllocation
 		{
 			void* data = nullptr;				// application can write to this. Reads might be not supported or slow. The offset is already applied
 			const GPUBuffer* buffer = nullptr;	// application can bind it to the GPU
-			UINT offset = 0;					// allocation's offset from the GPUbuffer's beginning
+			uint32_t offset = 0;					// allocation's offset from the GPUbuffer's beginning
 
 			// Returns true if the allocation was successful
 			inline bool IsValid() const { return data != nullptr && buffer != nullptr; }

--- a/WickedEngine/wiGraphicsDevice_DX11.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX11.cpp
@@ -16,9 +16,9 @@ namespace wiGraphics
 {
 // Engine -> Native converters
 
-constexpr UINT _ParseBindFlags(UINT value)
+constexpr uint32_t _ParseBindFlags(uint32_t value)
 {
-	UINT _flag = 0;
+	uint32_t _flag = 0;
 
 	if (value & BIND_VERTEX_BUFFER)
 		_flag |= D3D11_BIND_VERTEX_BUFFER;
@@ -39,9 +39,9 @@ constexpr UINT _ParseBindFlags(UINT value)
 
 	return _flag;
 }
-constexpr UINT _ParseCPUAccessFlags(UINT value)
+constexpr uint32_t _ParseCPUAccessFlags(uint32_t value)
 {
-	UINT _flag = 0;
+	uint32_t _flag = 0;
 
 	if (value & CPU_ACCESS_WRITE)
 		_flag |= D3D11_CPU_ACCESS_WRITE;
@@ -50,9 +50,9 @@ constexpr UINT _ParseCPUAccessFlags(UINT value)
 
 	return _flag;
 }
-constexpr UINT _ParseResourceMiscFlags(UINT value)
+constexpr uint32_t _ParseResourceMiscFlags(uint32_t value)
 {
-	UINT _flag = 0;
+	uint32_t _flag = 0;
 
 	if (value & RESOURCE_MISC_SHARED)
 		_flag |= D3D11_RESOURCE_MISC_SHARED;
@@ -69,9 +69,9 @@ constexpr UINT _ParseResourceMiscFlags(UINT value)
 
 	return _flag;
 }
-constexpr UINT _ParseColorWriteMask(UINT value)
+constexpr uint32_t _ParseColorWriteMask(uint32_t value)
 {
-	UINT _flag = 0;
+	uint32_t _flag = 0;
 
 	if (value == D3D11_COLOR_WRITE_ENABLE_ALL)
 	{
@@ -738,9 +738,9 @@ inline D3D11_SUBRESOURCE_DATA _ConvertSubresourceData(const SubresourceData& pIn
 
 // Native -> Engine converters
 
-constexpr UINT _ParseBindFlags_Inv(UINT value)
+constexpr uint32_t _ParseBindFlags_Inv(uint32_t value)
 {
-	UINT _flag = 0;
+	uint32_t _flag = 0;
 
 	if (value & D3D11_BIND_VERTEX_BUFFER)
 		_flag |= BIND_VERTEX_BUFFER;
@@ -761,9 +761,9 @@ constexpr UINT _ParseBindFlags_Inv(UINT value)
 
 	return _flag;
 }
-constexpr UINT _ParseCPUAccessFlags_Inv(UINT value)
+constexpr uint32_t _ParseCPUAccessFlags_Inv(uint32_t value)
 {
-	UINT _flag = 0;
+	uint32_t _flag = 0;
 
 	if (value & D3D11_CPU_ACCESS_WRITE)
 		_flag |= CPU_ACCESS_WRITE;
@@ -772,9 +772,9 @@ constexpr UINT _ParseCPUAccessFlags_Inv(UINT value)
 
 	return _flag;
 }
-constexpr UINT _ParseResourceMiscFlags_Inv(UINT value)
+constexpr uint32_t _ParseResourceMiscFlags_Inv(uint32_t value)
 {
-	UINT _flag = 0;
+	uint32_t _flag = 0;
 
 	if (value & D3D11_RESOURCE_MISC_SHARED)
 		_flag |= RESOURCE_MISC_SHARED;
@@ -1102,7 +1102,7 @@ GraphicsDevice_DX11::GraphicsDevice_DX11(wiWindowRegistration::window_type windo
 		blendFactor[i] = XMFLOAT4(1, 1, 1, 1);
 	}
 
-	UINT createDeviceFlags = 0;
+	uint32_t createDeviceFlags = 0;
 
 	if (debuglayer)
 	{
@@ -1115,16 +1115,16 @@ GraphicsDevice_DX11::GraphicsDevice_DX11(wiWindowRegistration::window_type windo
 		D3D_DRIVER_TYPE_WARP,
 		D3D_DRIVER_TYPE_REFERENCE,
 	};
-	UINT numDriverTypes = ARRAYSIZE(driverTypes);
+	uint32_t numDriverTypes = ARRAYSIZE(driverTypes);
 
 	D3D_FEATURE_LEVEL featureLevels[] =
 	{
 		D3D_FEATURE_LEVEL_11_1,
 		D3D_FEATURE_LEVEL_11_0,
 	};
-	UINT numFeatureLevels = ARRAYSIZE(featureLevels);
+	uint32_t numFeatureLevels = ARRAYSIZE(featureLevels);
 
-	for (UINT driverTypeIndex = 0; driverTypeIndex < numDriverTypes; driverTypeIndex++)
+	for (uint32_t driverTypeIndex = 0; driverTypeIndex < numDriverTypes; driverTypeIndex++)
 	{
 		driverType = driverTypes[driverTypeIndex];
 		hr = D3D11CreateDevice(nullptr, driverType, nullptr, createDeviceFlags, featureLevels, numFeatureLevels, D3D11_SDK_VERSION, &device
@@ -1310,7 +1310,7 @@ HRESULT GraphicsDevice_DX11::CreateBuffer(const GPUBufferDesc *pDesc, const Subr
 	if (pInitialData != nullptr)
 	{
 		data = new D3D11_SUBRESOURCE_DATA[1];
-		for (UINT slice = 0; slice < 1; ++slice)
+		for (uint32_t slice = 0; slice < 1; ++slice)
 		{
 			data[slice] = _ConvertSubresourceData(pInitialData[slice]);
 		}
@@ -1413,9 +1413,9 @@ HRESULT GraphicsDevice_DX11::CreateTexture(const TextureDesc* pDesc, const Subre
 	std::vector<D3D11_SUBRESOURCE_DATA> data;
 	if (pInitialData != nullptr)
 	{
-		UINT dataCount = pDesc->ArraySize * std::max(1u, pDesc->MipLevels);
+		uint32_t dataCount = pDesc->ArraySize * std::max(1u, pDesc->MipLevels);
 		data.resize(dataCount);
-		for (UINT slice = 0; slice < dataCount; ++slice)
+		for (uint32_t slice = 0; slice < dataCount; ++slice)
 		{
 			data[slice] = _ConvertSubresourceData(pInitialData[slice]);
 		}
@@ -1454,7 +1454,7 @@ HRESULT GraphicsDevice_DX11::CreateTexture(const TextureDesc* pDesc, const Subre
 
 	if (pTexture->desc.MipLevels == 0)
 	{
-		pTexture->desc.MipLevels = (UINT)log2(std::max(pTexture->desc.Width, pTexture->desc.Height));
+		pTexture->desc.MipLevels = (uint32_t)log2(std::max(pTexture->desc.Width, pTexture->desc.Height));
 	}
 
 	if (pTexture->desc.BindFlags & BIND_RENDER_TARGET)
@@ -1476,7 +1476,7 @@ HRESULT GraphicsDevice_DX11::CreateTexture(const TextureDesc* pDesc, const Subre
 
 	return hr;
 }
-HRESULT GraphicsDevice_DX11::CreateInputLayout(const VertexLayoutDesc *pInputElementDescs, UINT NumElements, const ShaderByteCode* shaderCode, VertexLayout *pInputLayout)
+HRESULT GraphicsDevice_DX11::CreateInputLayout(const VertexLayoutDesc *pInputElementDescs, uint32_t NumElements, const ShaderByteCode* shaderCode, VertexLayout *pInputLayout)
 {
 	DestroyInputLayout(pInputLayout);
 	pInputLayout->Register(this);
@@ -1484,7 +1484,7 @@ HRESULT GraphicsDevice_DX11::CreateInputLayout(const VertexLayoutDesc *pInputEle
 	pInputLayout->desc.reserve((size_t)NumElements);
 
 	D3D11_INPUT_ELEMENT_DESC* desc = new D3D11_INPUT_ELEMENT_DESC[NumElements];
-	for (UINT i = 0; i < NumElements; ++i)
+	for (uint32_t i = 0; i < NumElements; ++i)
 	{
 		desc[i].SemanticName = pInputElementDescs[i].SemanticName;
 		desc[i].SemanticIndex = pInputElementDescs[i].SemanticIndex;
@@ -1770,7 +1770,7 @@ HRESULT GraphicsDevice_DX11::CreateRenderPass(const RenderPassDesc* pDesc, Rende
 	return S_OK;
 }
 
-int GraphicsDevice_DX11::CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, UINT firstSlice, UINT sliceCount, UINT firstMip, UINT mipCount)
+int GraphicsDevice_DX11::CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, uint32_t firstSlice, uint32_t sliceCount, uint32_t firstMip, uint32_t mipCount)
 {
 	switch (type)
 	{
@@ -2382,9 +2382,9 @@ bool GraphicsDevice_DX11::DownloadResource(const GPUResource* resourceToDownload
 			bool result = SUCCEEDED(hr);
 			if (result)
 			{
-				UINT cpycount = std::max(1u, textureToDownload->desc.Width) * std::max(1u, textureToDownload->desc.Height) * std::max(1u, textureToDownload->desc.Depth);
-				UINT cpystride = GetFormatStride(textureToDownload->desc.Format);
-				UINT cpysize = cpycount * cpystride;
+				uint32_t cpycount = std::max(1u, textureToDownload->desc.Width) * std::max(1u, textureToDownload->desc.Height) * std::max(1u, textureToDownload->desc.Depth);
+				uint32_t cpystride = GetFormatStride(textureToDownload->desc.Format);
+				uint32_t cpysize = cpycount * cpystride;
 				memcpy(dataDest, mappedResource.pData, cpysize);
 				immediateContext->Unmap((ID3D11Resource*)textureDest->resource, 0);
 			}
@@ -2398,7 +2398,7 @@ bool GraphicsDevice_DX11::DownloadResource(const GPUResource* resourceToDownload
 
 void GraphicsDevice_DX11::SetName(GPUResource* pResource, const std::string& name)
 {
-	((ID3D11Resource*)pResource->resource)->SetPrivateData(WKPDID_D3DDebugObjectName, (UINT)name.length(), name.c_str());
+	((ID3D11Resource*)pResource->resource)->SetPrivateData(WKPDID_D3DDebugObjectName, (uint32_t)name.length(), name.c_str());
 }
 
 void GraphicsDevice_DX11::PresentBegin(CommandList cmd)
@@ -2485,8 +2485,8 @@ CommandList GraphicsDevice_DX11::BeginCommandList()
 	BindComputeShader(nullptr, cmd);
 
 	D3D11_VIEWPORT vp = {};
-	vp.Width = (FLOAT)SCREENWIDTH;
-	vp.Height = (FLOAT)SCREENHEIGHT;
+	vp.Width = (float)SCREENWIDTH;
+	vp.Height = (float)SCREENHEIGHT;
 	vp.MinDepth = 0.0f;
 	vp.MaxDepth = 1.0f;
 	vp.TopLeftX = 0;
@@ -2494,7 +2494,7 @@ CommandList GraphicsDevice_DX11::BeginCommandList()
 	deviceContexts[cmd]->RSSetViewports(1, &vp);
 
 	D3D11_RECT pRects[8];
-	for (UINT i = 0; i < 8; ++i)
+	for (uint32_t i = 0; i < 8; ++i)
 	{
 		pRects[i].bottom = INT32_MAX;
 		pRects[i].left = INT32_MIN;
@@ -2528,10 +2528,10 @@ void GraphicsDevice_DX11::RenderPassBegin(const RenderPass* renderpass, CommandL
 {
 	const RenderPassDesc& desc = renderpass->GetDesc();
 
-	UINT rt_count = 0;
+	uint32_t rt_count = 0;
 	ID3D11RenderTargetView* RTVs[8] = {};
 	ID3D11DepthStencilView* DSV = nullptr;
-	for (UINT i = 0; i < desc.numAttachments; ++i)
+	for (uint32_t i = 0; i < desc.numAttachments; ++i)
 	{
 		const RenderPassAttachment& attachment = desc.attachments[i];
 		const Texture* texture = attachment.texture;
@@ -2570,7 +2570,7 @@ void GraphicsDevice_DX11::RenderPassBegin(const RenderPass* renderpass, CommandL
 
 			if (attachment.loadop == RenderPassAttachment::LOADOP_CLEAR)
 			{
-				UINT _flags = D3D11_CLEAR_DEPTH;
+				uint32_t _flags = D3D11_CLEAR_DEPTH;
 				if (IsFormatStencilSupport(texture->desc.Format))
 					_flags |= D3D11_CLEAR_STENCIL;
 				deviceContexts[cmd]->ClearDepthStencilView(DSV, _flags, texture->desc.clear.depthstencil.depth, texture->desc.clear.depthstencil.stencil);
@@ -2581,8 +2581,8 @@ void GraphicsDevice_DX11::RenderPassBegin(const RenderPass* renderpass, CommandL
 	if (raster_uavs_count[cmd] > 0)
 	{
 		// UAVs:
-		const UINT count = raster_uavs_count[cmd];
-		const UINT slot = raster_uavs_slot[cmd];
+		const uint32_t count = raster_uavs_count[cmd];
+		const uint32_t slot = raster_uavs_slot[cmd];
 
 		deviceContexts[cmd]->OMSetRenderTargetsAndUnorderedAccessViews(rt_count, RTVs, DSV, slot, count, &raster_uavs[cmd][slot], nullptr);
 
@@ -2598,23 +2598,23 @@ void GraphicsDevice_DX11::RenderPassEnd(CommandList cmd)
 {
 	deviceContexts[cmd]->OMSetRenderTargets(0, nullptr, nullptr);
 }
-void GraphicsDevice_DX11::BindScissorRects(UINT numRects, const Rect* rects, CommandList cmd) {
+void GraphicsDevice_DX11::BindScissorRects(uint32_t numRects, const Rect* rects, CommandList cmd) {
 	assert(rects != nullptr);
 	assert(numRects <= 8);
 	D3D11_RECT pRects[8];
-	for(UINT i = 0; i < numRects; ++i) {
-		pRects[i].bottom = rects[i].bottom;
-		pRects[i].left = rects[i].left;
-		pRects[i].right = rects[i].right;
-		pRects[i].top = rects[i].top;
+	for(uint32_t i = 0; i < numRects; ++i) {
+		pRects[i].bottom = (LONG)rects[i].bottom;
+		pRects[i].left = (LONG)rects[i].left;
+		pRects[i].right = (LONG)rects[i].right;
+		pRects[i].top = (LONG)rects[i].top;
 	}
 	deviceContexts[cmd]->RSSetScissorRects(numRects, pRects);
 }
-void GraphicsDevice_DX11::BindViewports(UINT NumViewports, const ViewPort *pViewports, CommandList cmd) 
+void GraphicsDevice_DX11::BindViewports(uint32_t NumViewports, const Viewport* pViewports, CommandList cmd)
 {
 	assert(NumViewports <= 6);
 	D3D11_VIEWPORT d3dViewPorts[6];
-	for (UINT i = 0; i < NumViewports; ++i)
+	for (uint32_t i = 0; i < NumViewports; ++i)
 	{
 		d3dViewPorts[i].TopLeftX = pViewports[i].TopLeftX;
 		d3dViewPorts[i].TopLeftY = pViewports[i].TopLeftY;
@@ -2625,7 +2625,7 @@ void GraphicsDevice_DX11::BindViewports(UINT NumViewports, const ViewPort *pView
 	}
 	deviceContexts[cmd]->RSSetViewports(NumViewports, d3dViewPorts);
 }
-void GraphicsDevice_DX11::BindResource(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource)
+void GraphicsDevice_DX11::BindResource(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource)
 {
 	if (resource != nullptr)
 	{
@@ -2667,11 +2667,11 @@ void GraphicsDevice_DX11::BindResource(SHADERSTAGE stage, const GPUResource* res
 		}
 	}
 }
-void GraphicsDevice_DX11::BindResources(SHADERSTAGE stage, const GPUResource *const* resources, UINT slot, UINT count, CommandList cmd)
+void GraphicsDevice_DX11::BindResources(SHADERSTAGE stage, const GPUResource *const* resources, uint32_t slot, uint32_t count, CommandList cmd)
 {
 	assert(count <= 16);
 	ID3D11ShaderResourceView* srvs[16];
-	for (UINT i = 0; i < count; ++i)
+	for (uint32_t i = 0; i < count; ++i)
 	{
 		srvs[i] = resources[i] != nullptr ? (ID3D11ShaderResourceView*)resources[i]->SRV : nullptr;
 	}
@@ -2701,7 +2701,7 @@ void GraphicsDevice_DX11::BindResources(SHADERSTAGE stage, const GPUResource *co
 		break;
 	}
 }
-void GraphicsDevice_DX11::BindUAV(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource)
+void GraphicsDevice_DX11::BindUAV(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource)
 {
 	if (resource != nullptr)
 	{
@@ -2729,11 +2729,11 @@ void GraphicsDevice_DX11::BindUAV(SHADERSTAGE stage, const GPUResource* resource
 		}
 	}
 }
-void GraphicsDevice_DX11::BindUAVs(SHADERSTAGE stage, const GPUResource *const* resources, UINT slot, UINT count, CommandList cmd)
+void GraphicsDevice_DX11::BindUAVs(SHADERSTAGE stage, const GPUResource *const* resources, uint32_t slot, uint32_t count, CommandList cmd)
 {
 	assert(slot + count <= 8);
 	ID3D11UnorderedAccessView* uavs[8];
-	for (UINT i = 0; i < count; ++i)
+	for (uint32_t i = 0; i < count; ++i)
 	{
 		uavs[i] = resources[i] != nullptr ? (ID3D11UnorderedAccessView*)resources[i]->UAV : nullptr;
 
@@ -2745,7 +2745,7 @@ void GraphicsDevice_DX11::BindUAVs(SHADERSTAGE stage, const GPUResource *const* 
 
 	if(stage == CS)
 	{
-		deviceContexts[cmd]->CSSetUnorderedAccessViews(static_cast<UINT>(slot), static_cast<UINT>(count), uavs, nullptr);
+		deviceContexts[cmd]->CSSetUnorderedAccessViews(static_cast<uint32_t>(slot), static_cast<uint32_t>(count), uavs, nullptr);
 	}
 	else
 	{
@@ -2753,7 +2753,7 @@ void GraphicsDevice_DX11::BindUAVs(SHADERSTAGE stage, const GPUResource *const* 
 		raster_uavs_count[cmd] = std::max(raster_uavs_count[cmd], uint8_t(count));
 	}
 }
-void GraphicsDevice_DX11::UnbindResources(UINT slot, UINT num, CommandList cmd)
+void GraphicsDevice_DX11::UnbindResources(uint32_t slot, uint32_t num, CommandList cmd)
 {
 	assert(num <= ARRAYSIZE(__nullBlob) && "Extend nullBlob to support more resource unbinding!");
 	deviceContexts[cmd]->PSSetShaderResources(slot, num, (ID3D11ShaderResourceView**)__nullBlob);
@@ -2763,7 +2763,7 @@ void GraphicsDevice_DX11::UnbindResources(UINT slot, UINT num, CommandList cmd)
 	deviceContexts[cmd]->DSSetShaderResources(slot, num, (ID3D11ShaderResourceView**)__nullBlob);
 	deviceContexts[cmd]->CSSetShaderResources(slot, num, (ID3D11ShaderResourceView**)__nullBlob);
 }
-void GraphicsDevice_DX11::UnbindUAVs(UINT slot, UINT num, CommandList cmd)
+void GraphicsDevice_DX11::UnbindUAVs(uint32_t slot, uint32_t num, CommandList cmd)
 {
 	assert(num <= ARRAYSIZE(__nullBlob) && "Extend nullBlob to support more resource unbinding!");
 	deviceContexts[cmd]->CSSetUnorderedAccessViews(slot, num, (ID3D11UnorderedAccessView**)__nullBlob, 0);
@@ -2771,7 +2771,7 @@ void GraphicsDevice_DX11::UnbindUAVs(UINT slot, UINT num, CommandList cmd)
 	raster_uavs_count[cmd] = 0;
 	raster_uavs_slot[cmd] = 8;
 }
-void GraphicsDevice_DX11::BindSampler(SHADERSTAGE stage, const Sampler* sampler, UINT slot, CommandList cmd)
+void GraphicsDevice_DX11::BindSampler(SHADERSTAGE stage, const Sampler* sampler, uint32_t slot, CommandList cmd)
 {
 	ID3D11SamplerState* SAM = (ID3D11SamplerState*)sampler->resource;
 
@@ -2800,7 +2800,7 @@ void GraphicsDevice_DX11::BindSampler(SHADERSTAGE stage, const Sampler* sampler,
 		break;
 	}
 }
-void GraphicsDevice_DX11::BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, UINT slot, CommandList cmd)
+void GraphicsDevice_DX11::BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, uint32_t slot, CommandList cmd)
 {
 	ID3D11Buffer* res = buffer ? (ID3D11Buffer*)buffer->resource : nullptr;
 	switch (stage)
@@ -2828,22 +2828,22 @@ void GraphicsDevice_DX11::BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer*
 		break;
 	}
 }
-void GraphicsDevice_DX11::BindVertexBuffers(const GPUBuffer *const* vertexBuffers, UINT slot, UINT count, const UINT* strides, const UINT* offsets, CommandList cmd)
+void GraphicsDevice_DX11::BindVertexBuffers(const GPUBuffer *const* vertexBuffers, uint32_t slot, uint32_t count, const uint32_t* strides, const uint32_t* offsets, CommandList cmd)
 {
 	assert(count <= 8);
 	ID3D11Buffer* res[8] = { 0 };
-	for (UINT i = 0; i < count; ++i)
+	for (uint32_t i = 0; i < count; ++i)
 	{
 		res[i] = vertexBuffers[i] != nullptr ? (ID3D11Buffer*)vertexBuffers[i]->resource : nullptr;
 	}
-	deviceContexts[cmd]->IASetVertexBuffers(slot, count, res, strides, (offsets != nullptr ? offsets : reinterpret_cast<const UINT*>(__nullBlob)));
+	deviceContexts[cmd]->IASetVertexBuffers(slot, count, res, strides, (offsets != nullptr ? offsets : reinterpret_cast<const uint32_t*>(__nullBlob)));
 }
-void GraphicsDevice_DX11::BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, UINT offset, CommandList cmd)
+void GraphicsDevice_DX11::BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint32_t offset, CommandList cmd)
 {
 	ID3D11Buffer* res = indexBuffer != nullptr ? (ID3D11Buffer*)indexBuffer->resource : nullptr;
 	deviceContexts[cmd]->IASetIndexBuffer(res, (format == INDEXBUFFER_FORMAT::INDEXFORMAT_16BIT ? DXGI_FORMAT_R16_UINT : DXGI_FORMAT_R32_UINT), offset);
 }
-void GraphicsDevice_DX11::BindStencilRef(UINT value, CommandList cmd)
+void GraphicsDevice_DX11::BindStencilRef(uint32_t value, CommandList cmd)
 {
 	stencilRef[cmd] = value;
 }
@@ -2964,49 +2964,49 @@ void GraphicsDevice_DX11::BindComputeShader(const ComputeShader* cs, CommandList
 		prev_cs[cmd] = _cs;
 	}
 }
-void GraphicsDevice_DX11::Draw(UINT vertexCount, UINT startVertexLocation, CommandList cmd) 
+void GraphicsDevice_DX11::Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd) 
 {
 	commit_allocations(cmd);
 
 	deviceContexts[cmd]->Draw(vertexCount, startVertexLocation);
 }
-void GraphicsDevice_DX11::DrawIndexed(UINT indexCount, UINT startIndexLocation, UINT baseVertexLocation, CommandList cmd)
+void GraphicsDevice_DX11::DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, CommandList cmd)
 {
 	commit_allocations(cmd);
 
 	deviceContexts[cmd]->DrawIndexed(indexCount, startIndexLocation, baseVertexLocation);
 }
-void GraphicsDevice_DX11::DrawInstanced(UINT vertexCount, UINT instanceCount, UINT startVertexLocation, UINT startInstanceLocation, CommandList cmd) 
+void GraphicsDevice_DX11::DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd) 
 {
 	commit_allocations(cmd);
 
 	deviceContexts[cmd]->DrawInstanced(vertexCount, instanceCount, startVertexLocation, startInstanceLocation);
 }
-void GraphicsDevice_DX11::DrawIndexedInstanced(UINT indexCount, UINT instanceCount, UINT startIndexLocation, UINT baseVertexLocation, UINT startInstanceLocation, CommandList cmd)
+void GraphicsDevice_DX11::DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, uint32_t startInstanceLocation, CommandList cmd)
 {
 	commit_allocations(cmd);
 
 	deviceContexts[cmd]->DrawIndexedInstanced(indexCount, instanceCount, startIndexLocation, baseVertexLocation, startInstanceLocation);
 }
-void GraphicsDevice_DX11::DrawInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd)
+void GraphicsDevice_DX11::DrawInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd)
 {
 	commit_allocations(cmd);
 
 	deviceContexts[cmd]->DrawInstancedIndirect((ID3D11Buffer*)args->resource, args_offset);
 }
-void GraphicsDevice_DX11::DrawIndexedInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd)
+void GraphicsDevice_DX11::DrawIndexedInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd)
 {
 	commit_allocations(cmd);
 
 	deviceContexts[cmd]->DrawIndexedInstancedIndirect((ID3D11Buffer*)args->resource, args_offset);
 }
-void GraphicsDevice_DX11::Dispatch(UINT threadGroupCountX, UINT threadGroupCountY, UINT threadGroupCountZ, CommandList cmd)
+void GraphicsDevice_DX11::Dispatch(uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ, CommandList cmd)
 {
 	commit_allocations(cmd);
 
 	deviceContexts[cmd]->Dispatch(threadGroupCountX, threadGroupCountY, threadGroupCountZ);
 }
-void GraphicsDevice_DX11::DispatchIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd)
+void GraphicsDevice_DX11::DispatchIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd)
 {
 	commit_allocations(cmd);
 
@@ -3016,7 +3016,7 @@ void GraphicsDevice_DX11::CopyResource(const GPUResource* pDst, const GPUResourc
 {
 	deviceContexts[cmd]->CopyResource((ID3D11Resource*)pDst->resource, (ID3D11Resource*)pSrc->resource);
 }
-void GraphicsDevice_DX11::CopyTexture2D_Region(const Texture* pDst, UINT dstMip, UINT dstX, UINT dstY, const Texture* pSrc, UINT srcMip, CommandList cmd)
+void GraphicsDevice_DX11::CopyTexture2D_Region(const Texture* pDst, uint32_t dstMip, uint32_t dstX, uint32_t dstY, const Texture* pSrc, uint32_t srcMip, CommandList cmd)
 {
 	deviceContexts[cmd]->CopySubresourceRegion((ID3D11Resource*)pDst->resource, D3D11CalcSubresource(dstMip, 0, pDst->GetDesc().MipLevels), dstX, dstY, 0,
 		(ID3D11Resource*)pSrc->resource, D3D11CalcSubresource(srcMip, 0, pSrc->GetDesc().MipLevels), nullptr);
@@ -3054,7 +3054,7 @@ void GraphicsDevice_DX11::UpdateBuffer(const GPUBuffer* buffer, const void* data
 	{
 		D3D11_BOX box = {};
 		box.left = 0;
-		box.right = static_cast<UINT>(dataSize);
+		box.right = static_cast<uint32_t>(dataSize);
 		box.top = 0;
 		box.bottom = 1;
 		box.front = 0;
@@ -3073,7 +3073,7 @@ void GraphicsDevice_DX11::QueryEnd(const GPUQuery* query, CommandList cmd)
 }
 bool GraphicsDevice_DX11::QueryRead(const GPUQuery* query, GPUQueryResult* result)
 {
-	const UINT _flags = D3D11_ASYNC_GETDATA_DONOTFLUSH;
+	const uint32_t _flags = D3D11_ASYNC_GETDATA_DONOTFLUSH;
 
 	ID3D11Query* QUERY = (ID3D11Query*)query->resource;
 
@@ -3136,7 +3136,7 @@ GraphicsDevice::GPUAllocation GraphicsDevice_DX11::AllocateGPU(size_t dataSize, 
 	allocator.residentFrame = FRAMECOUNT;
 
 	result.buffer = &allocator.buffer;
-	result.offset = (UINT)position;
+	result.offset = (uint32_t)position;
 	result.data = (void*)((size_t)mappedResource.pData + position);
 	return result;
 }

--- a/WickedEngine/wiGraphicsDevice_DX11.h
+++ b/WickedEngine/wiGraphicsDevice_DX11.h
@@ -26,7 +26,7 @@ namespace wiGraphics
 		ID3D11CommandList*			commandLists[COMMANDLIST_COUNT] = {};
 		ID3DUserDefinedAnnotation*	userDefinedAnnotations[COMMANDLIST_COUNT] = {};
 
-		UINT		stencilRef[COMMANDLIST_COUNT];
+		uint32_t		stencilRef[COMMANDLIST_COUNT];
 		XMFLOAT4	blendFactor[COMMANDLIST_COUNT];
 
 		ID3D11VertexShader* prev_vs[COMMANDLIST_COUNT] = {};
@@ -36,10 +36,10 @@ namespace wiGraphics
 		ID3D11GeometryShader* prev_gs[COMMANDLIST_COUNT] = {};
 		ID3D11ComputeShader* prev_cs[COMMANDLIST_COUNT] = {};
 		XMFLOAT4 prev_blendfactor[COMMANDLIST_COUNT] = {};
-		UINT prev_samplemask[COMMANDLIST_COUNT] = {};
+		uint32_t prev_samplemask[COMMANDLIST_COUNT] = {};
 		ID3D11BlendState* prev_bs[COMMANDLIST_COUNT] = {};
 		ID3D11RasterizerState* prev_rs[COMMANDLIST_COUNT] = {};
-		UINT prev_stencilRef[COMMANDLIST_COUNT] = {};
+		uint32_t prev_stencilRef[COMMANDLIST_COUNT] = {};
 		ID3D11DepthStencilState* prev_dss[COMMANDLIST_COUNT] = {};
 		ID3D11InputLayout* prev_il[COMMANDLIST_COUNT] = {};
 		PRIMITIVETOPOLOGY prev_pt[COMMANDLIST_COUNT] = {};
@@ -70,7 +70,7 @@ namespace wiGraphics
 
 		HRESULT CreateBuffer(const GPUBufferDesc *pDesc, const SubresourceData* pInitialData, GPUBuffer *pBuffer) override;
 		HRESULT CreateTexture(const TextureDesc* pDesc, const SubresourceData *pInitialData, Texture *pTexture) override;
-		HRESULT CreateInputLayout(const VertexLayoutDesc *pInputElementDescs, UINT NumElements, const ShaderByteCode* shaderCode, VertexLayout *pInputLayout) override;
+		HRESULT CreateInputLayout(const VertexLayoutDesc *pInputElementDescs, uint32_t NumElements, const ShaderByteCode* shaderCode, VertexLayout *pInputLayout) override;
 		HRESULT CreateVertexShader(const void *pShaderBytecode, SIZE_T BytecodeLength, VertexShader *pVertexShader) override;
 		HRESULT CreatePixelShader(const void *pShaderBytecode, SIZE_T BytecodeLength, PixelShader *pPixelShader) override;
 		HRESULT CreateGeometryShader(const void *pShaderBytecode, SIZE_T BytecodeLength, GeometryShader *pGeometryShader) override;
@@ -85,7 +85,7 @@ namespace wiGraphics
 		HRESULT CreatePipelineState(const PipelineStateDesc* pDesc, PipelineState* pso) override;
 		HRESULT CreateRenderPass(const RenderPassDesc* pDesc, RenderPass* renderpass) override;
 
-		int CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, UINT firstSlice, UINT sliceCount, UINT firstMip, UINT mipCount) override;
+		int CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, uint32_t firstSlice, uint32_t sliceCount, uint32_t firstMip, uint32_t mipCount) override;
 
 		void DestroyResource(GPUResource* pResource) override;
 		void DestroyBuffer(GPUBuffer *pBuffer) override;
@@ -124,38 +124,38 @@ namespace wiGraphics
 
 		void RenderPassBegin(const RenderPass* renderpass, CommandList cmd) override;
 		void RenderPassEnd(CommandList cmd) override;
-		void BindScissorRects(UINT numRects, const Rect* rects, CommandList cmd) override;
-		void BindViewports(UINT NumViewports, const ViewPort *pViewports, CommandList cmd) override;
-		void BindResource(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource = -1) override;
-		void BindResources(SHADERSTAGE stage, const GPUResource *const* resources, UINT slot, UINT count, CommandList cmd) override;
-		void BindUAV(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource = -1) override;
-		void BindUAVs(SHADERSTAGE stage, const GPUResource *const* resources, UINT slot, UINT count, CommandList cmd) override;
-		void UnbindResources(UINT slot, UINT num, CommandList cmd) override;
-		void UnbindUAVs(UINT slot, UINT num, CommandList cmd) override;
-		void BindSampler(SHADERSTAGE stage, const Sampler* sampler, UINT slot, CommandList cmd) override;
-		void BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, UINT slot, CommandList cmd) override;
-		void BindVertexBuffers(const GPUBuffer *const* vertexBuffers, UINT slot, UINT count, const UINT* strides, const UINT* offsets, CommandList cmd) override;
-		void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, UINT offset, CommandList cmd) override;
-		void BindStencilRef(UINT value, CommandList cmd) override;
+		void BindScissorRects(uint32_t numRects, const Rect* rects, CommandList cmd) override;
+		void BindViewports(uint32_t NumViewports, const Viewport* pViewports, CommandList cmd) override;
+		void BindResource(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource = -1) override;
+		void BindResources(SHADERSTAGE stage, const GPUResource *const* resources, uint32_t slot, uint32_t count, CommandList cmd) override;
+		void BindUAV(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource = -1) override;
+		void BindUAVs(SHADERSTAGE stage, const GPUResource *const* resources, uint32_t slot, uint32_t count, CommandList cmd) override;
+		void UnbindResources(uint32_t slot, uint32_t num, CommandList cmd) override;
+		void UnbindUAVs(uint32_t slot, uint32_t num, CommandList cmd) override;
+		void BindSampler(SHADERSTAGE stage, const Sampler* sampler, uint32_t slot, CommandList cmd) override;
+		void BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, uint32_t slot, CommandList cmd) override;
+		void BindVertexBuffers(const GPUBuffer *const* vertexBuffers, uint32_t slot, uint32_t count, const uint32_t* strides, const uint32_t* offsets, CommandList cmd) override;
+		void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint32_t offset, CommandList cmd) override;
+		void BindStencilRef(uint32_t value, CommandList cmd) override;
 		void BindBlendFactor(float r, float g, float b, float a, CommandList cmd) override;
 		void BindPipelineState(const PipelineState* pso, CommandList cmd) override;
 		void BindComputeShader(const ComputeShader* cs, CommandList cmd) override;
-		void Draw(UINT vertexCount, UINT startVertexLocation, CommandList cmd) override;
-		void DrawIndexed(UINT indexCount, UINT startIndexLocation, UINT baseVertexLocation, CommandList cmd) override;
-		void DrawInstanced(UINT vertexCount, UINT instanceCount, UINT startVertexLocation, UINT startInstanceLocation, CommandList cmd) override;
-		void DrawIndexedInstanced(UINT indexCount, UINT instanceCount, UINT startIndexLocation, UINT baseVertexLocation, UINT startInstanceLocation, CommandList cmd) override;
-		void DrawInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd) override;
-		void DrawIndexedInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd) override;
-		void Dispatch(UINT threadGroupCountX, UINT threadGroupCountY, UINT threadGroupCountZ, CommandList cmd) override;
-		void DispatchIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd) override;
+		void Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd) override;
+		void DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, CommandList cmd) override;
+		void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd) override;
+		void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, uint32_t startInstanceLocation, CommandList cmd) override;
+		void DrawInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd) override;
+		void DrawIndexedInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd) override;
+		void Dispatch(uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ, CommandList cmd) override;
+		void DispatchIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd) override;
 		void CopyResource(const GPUResource* pDst, const GPUResource* pSrc, CommandList cmd) override;
-		void CopyTexture2D_Region(const Texture* pDst, UINT dstMip, UINT dstX, UINT dstY, const Texture* pSrc, UINT srcMip, CommandList cmd) override;
+		void CopyTexture2D_Region(const Texture* pDst, uint32_t dstMip, uint32_t dstX, uint32_t dstY, const Texture* pSrc, uint32_t srcMip, CommandList cmd) override;
 		void MSAAResolve(const Texture* pDst, const Texture* pSrc, CommandList cmd) override;
 		void UpdateBuffer(const GPUBuffer* buffer, const void* data, CommandList cmd, int dataSize = -1) override;
 		void QueryBegin(const GPUQuery *query, CommandList cmd) override;
 		void QueryEnd(const GPUQuery *query, CommandList cmd) override;
 		bool QueryRead(const GPUQuery* query, GPUQueryResult* result) override;
-		void Barrier(const GPUBarrier* barriers, UINT numBarriers, CommandList cmd) override {}
+		void Barrier(const GPUBarrier* barriers, uint32_t numBarriers, CommandList cmd) override {}
 
 		GPUAllocation AllocateGPU(size_t dataSize, CommandList cmd) override;
 

--- a/WickedEngine/wiGraphicsDevice_DX12.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX12.cpp
@@ -37,9 +37,9 @@ namespace wiGraphics
 		return native;
 	}
 
-	inline UINT _ParseColorWriteMask(UINT value)
+	inline uint32_t _ParseColorWriteMask(uint32_t value)
 	{
-		UINT _flag = 0;
+		uint32_t _flag = 0;
 
 		if (value == D3D12_COLOR_WRITE_ENABLE_ALL)
 		{
@@ -893,7 +893,7 @@ namespace wiGraphics
 		TextureDesc retVal;
 
 		retVal.Format = _ConvertFormat_Inv(desc.Format);
-		retVal.Width = (UINT)desc.Width;
+		retVal.Width = (uint32_t)desc.Width;
 		retVal.Height = desc.Height;
 		retVal.MipLevels = desc.MipLevels;
 
@@ -915,7 +915,7 @@ namespace wiGraphics
 
 	// Allocator heaps:
 
-	GraphicsDevice_DX12::DescriptorAllocator::DescriptorAllocator(ID3D12Device* device, D3D12_DESCRIPTOR_HEAP_TYPE type, UINT maxCount)
+	GraphicsDevice_DX12::DescriptorAllocator::DescriptorAllocator(ID3D12Device* device, D3D12_DESCRIPTOR_HEAP_TYPE type, uint32_t maxCount)
 	{
 		D3D12_DESCRIPTOR_HEAP_DESC heapDesc = {};
 		heapDesc.NodeMask = 0;
@@ -998,7 +998,7 @@ namespace wiGraphics
 
 
 
-	GraphicsDevice_DX12::FrameResources::DescriptorTableFrameAllocator::DescriptorTableFrameAllocator(GraphicsDevice_DX12* device, UINT maxRenameCount_resources, UINT maxRenameCount_samplers) : device(device)
+	GraphicsDevice_DX12::FrameResources::DescriptorTableFrameAllocator::DescriptorTableFrameAllocator(GraphicsDevice_DX12* device, uint32_t maxRenameCount_resources, uint32_t maxRenameCount_samplers) : device(device)
 	{
 		HRESULT hr;
 
@@ -1067,7 +1067,7 @@ namespace wiGraphics
 						D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 				}
 
-				for (UINT slot = 0; slot < GPU_RESOURCE_HEAP_CBV_COUNT; ++slot)
+				for (uint32_t slot = 0; slot < GPU_RESOURCE_HEAP_CBV_COUNT; ++slot)
 				{
 					const GPUBuffer* buffer = table.CBV[slot];
 					if (buffer == nullptr)
@@ -1088,7 +1088,7 @@ namespace wiGraphics
 							D3D12_CONSTANT_BUFFER_VIEW_DESC cbv;
 							cbv.BufferLocation = ((ID3D12Resource*)state.allocation.buffer->resource)->GetGPUVirtualAddress();
 							cbv.BufferLocation += (D3D12_GPU_VIRTUAL_ADDRESS)state.allocation.offset;
-							cbv.SizeInBytes = (UINT)Align((size_t)buffer->desc.ByteWidth, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
+							cbv.SizeInBytes = (uint32_t)Align((size_t)buffer->desc.ByteWidth, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT);
 
 							// Instead of copying like usually, here we create a CBV in place into the GPU-visible table:
 							device->device->CreateConstantBufferView(&cbv, dst);
@@ -1101,7 +1101,7 @@ namespace wiGraphics
 						device->device->CopyDescriptorsSimple(1, dst, src, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 					}
 				}
-				for (UINT slot = 0; slot < GPU_RESOURCE_HEAP_SRV_COUNT; ++slot)
+				for (uint32_t slot = 0; slot < GPU_RESOURCE_HEAP_SRV_COUNT; ++slot)
 				{
 					const GPUResource* resource = table.SRV[slot];
 					const int subresource = table.SRV_index[slot];
@@ -1130,7 +1130,7 @@ namespace wiGraphics
 
 					device->device->CopyDescriptorsSimple(1, dst, src, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 				}
-				for (UINT slot = 0; slot < GPU_RESOURCE_HEAP_UAV_COUNT; ++slot)
+				for (uint32_t slot = 0; slot < GPU_RESOURCE_HEAP_UAV_COUNT; ++slot)
 				{
 					const GPUResource* resource = table.UAV[slot];
 					const int subresource = table.UAV_index[slot];
@@ -1193,7 +1193,7 @@ namespace wiGraphics
 						D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 				}
 
-				for (UINT slot = 0; slot < GPU_SAMPLER_HEAP_COUNT; ++slot)
+				for (uint32_t slot = 0; slot < GPU_SAMPLER_HEAP_COUNT; ++slot)
 				{
 					const Sampler* sampler = table.SAM[slot];
 					if (sampler == nullptr || sampler->resource == WI_NULL_HANDLE)
@@ -1259,7 +1259,7 @@ namespace wiGraphics
 		dataEnd = dataBegin + size;
 
 		// Because the "buffer" is created by hand in this, fill the desc to indicate how it can be used:
-		buffer.desc.ByteWidth = (UINT)((size_t)dataEnd - (size_t)dataBegin);
+		buffer.desc.ByteWidth = (uint32_t)((size_t)dataEnd - (size_t)dataBegin);
 		buffer.desc.Usage = USAGE_DYNAMIC;
 		buffer.desc.BindFlags = BIND_VERTEX_BUFFER | BIND_INDEX_BUFFER | BIND_SHADER_RESOURCE;
 		buffer.desc.MiscFlags = RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
@@ -1509,7 +1509,7 @@ namespace wiGraphics
 		D3D12_CPU_DESCRIPTOR_HANDLE null_resource_heap_dest = null_resource_heap_cpu_start;
 
 		D3D12_CONSTANT_BUFFER_VIEW_DESC cbv_desc = {};
-		for (UINT slot = 0; slot < GPU_RESOURCE_HEAP_CBV_COUNT; ++slot)
+		for (uint32_t slot = 0; slot < GPU_RESOURCE_HEAP_CBV_COUNT; ++slot)
 		{
 			device->CreateConstantBufferView(&cbv_desc, null_resource_heap_dest);
 			null_resource_heap_dest.ptr += resource_descriptor_size;
@@ -1519,7 +1519,7 @@ namespace wiGraphics
 		srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
 		srv_desc.Format = DXGI_FORMAT_R32_UINT;
 		srv_desc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
-		for (UINT slot = 0; slot < GPU_RESOURCE_HEAP_SRV_COUNT; ++slot)
+		for (uint32_t slot = 0; slot < GPU_RESOURCE_HEAP_SRV_COUNT; ++slot)
 		{
 			device->CreateShaderResourceView(nullptr, &srv_desc, null_resource_heap_dest);
 			null_resource_heap_dest.ptr += resource_descriptor_size;
@@ -1528,7 +1528,7 @@ namespace wiGraphics
 		D3D12_UNORDERED_ACCESS_VIEW_DESC uav_desc = {};
 		uav_desc.Format = DXGI_FORMAT_R32_UINT;
 		uav_desc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-		for (UINT slot = 0; slot < GPU_RESOURCE_HEAP_UAV_COUNT; ++slot)
+		for (uint32_t slot = 0; slot < GPU_RESOURCE_HEAP_UAV_COUNT; ++slot)
 		{
 			device->CreateUnorderedAccessView(nullptr, nullptr, &uav_desc, null_resource_heap_dest);
 			null_resource_heap_dest.ptr += resource_descriptor_size;
@@ -1540,7 +1540,7 @@ namespace wiGraphics
 		sampler_desc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
 		sampler_desc.ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
 		sampler_desc.Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
-		for (UINT slot = 0; slot < GPU_SAMPLER_HEAP_COUNT; ++slot)
+		for (uint32_t slot = 0; slot < GPU_SAMPLER_HEAP_COUNT; ++slot)
 		{
 			device->CreateSampler(&sampler_desc, null_sampler_heap_dest);
 			null_sampler_heap_dest.ptr += sampler_descriptor_size;
@@ -1552,7 +1552,7 @@ namespace wiGraphics
 
 
 		// Create frame-resident resources:
-		for (UINT fr = 0; fr < BACKBUFFER_COUNT; ++fr)
+		for (uint32_t fr = 0; fr < BACKBUFFER_COUNT; ++fr)
 		{
 			hr = swapChain->GetBuffer(fr, __uuidof(ID3D12Resource), (void**)&frames[fr].backBuffer);
 			assert(SUCCEEDED(hr));
@@ -1614,7 +1614,7 @@ namespace wiGraphics
 		samplerRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
 
 		{
-			UINT descriptorRangeCount = 3;
+			uint32_t descriptorRangeCount = 3;
 			D3D12_DESCRIPTOR_RANGE* descriptorRanges = new D3D12_DESCRIPTOR_RANGE[descriptorRangeCount];
 
 			descriptorRanges[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_CBV;
@@ -1638,7 +1638,7 @@ namespace wiGraphics
 
 
 
-			UINT paramCount = 2 * (SHADERSTAGE_COUNT - 1); // 2: resource,sampler;   5: vs,hs,ds,gs,ps;
+			uint32_t paramCount = 2 * (SHADERSTAGE_COUNT - 1); // 2: resource,sampler;   5: vs,hs,ds,gs,ps;
 			D3D12_ROOT_PARAMETER* params = new D3D12_ROOT_PARAMETER[paramCount];
 			params[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
 			params[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_VERTEX;
@@ -1713,7 +1713,7 @@ namespace wiGraphics
 			SAFE_DELETE_ARRAY(params);
 		}
 		{
-			UINT descriptorRangeCount = 3;
+			uint32_t descriptorRangeCount = 3;
 			D3D12_DESCRIPTOR_RANGE* descriptorRanges = new D3D12_DESCRIPTOR_RANGE[descriptorRangeCount];
 
 			descriptorRanges[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_CBV;
@@ -1736,7 +1736,7 @@ namespace wiGraphics
 
 
 
-			UINT paramCount = 2;
+			uint32_t paramCount = 2;
 			D3D12_ROOT_PARAMETER* params = new D3D12_ROOT_PARAMETER[paramCount];
 			params[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
 			params[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
@@ -1808,7 +1808,7 @@ namespace wiGraphics
 			D3D12_QUERY_HEAP_DESC queryheapdesc = {};
 			queryheapdesc.NodeMask = 0;
 
-			for (UINT i = 0; i < timestamp_query_count; ++i)
+			for (uint32_t i = 0; i < timestamp_query_count; ++i)
 			{
 				free_timestampqueries.push_back(i);
 			}
@@ -1817,7 +1817,7 @@ namespace wiGraphics
 			hr = device->CreateQueryHeap(&queryheapdesc, __uuidof(ID3D12QueryHeap), (void**)&querypool_timestamp);
 			assert(SUCCEEDED(hr));
 
-			for (UINT i = 0; i < occlusion_query_count; ++i)
+			for (uint32_t i = 0; i < occlusion_query_count; ++i)
 			{
 				free_occlusionqueries.push_back(i);
 			}
@@ -1832,7 +1832,7 @@ namespace wiGraphics
 
 			hr = allocator->CreateResource(
 				&allocationDesc,
-				&CD3DX12_RESOURCE_DESC::Buffer(timestamp_query_count * sizeof(UINT64)),
+				&CD3DX12_RESOURCE_DESC::Buffer(timestamp_query_count * sizeof(uint64_t)),
 				D3D12_RESOURCE_STATE_COPY_DEST,
 				nullptr,
 				&allocation_querypool_timestamp_readback,
@@ -1842,7 +1842,7 @@ namespace wiGraphics
 
 			hr = allocator->CreateResource(
 				&allocationDesc,
-				&CD3DX12_RESOURCE_DESC::Buffer(occlusion_query_count * sizeof(UINT64)),
+				&CD3DX12_RESOURCE_DESC::Buffer(occlusion_query_count * sizeof(uint64_t)),
 				D3D12_RESOURCE_STATE_COPY_DEST,
 				nullptr,
 				&allocation_querypool_occlusion_readback,
@@ -1859,7 +1859,7 @@ namespace wiGraphics
 
 		SAFE_RELEASE(swapChain);
 
-		for (UINT fr = 0; fr < BACKBUFFER_COUNT; ++fr)
+		for (uint32_t fr = 0; fr < BACKBUFFER_COUNT; ++fr)
 		{
 			SAFE_RELEASE(frames[fr].backBuffer);
 
@@ -1920,7 +1920,7 @@ namespace wiGraphics
 
 			WaitForGPU();
 
-			for (UINT fr = 0; fr < BACKBUFFER_COUNT; ++fr)
+			for (uint32_t fr = 0; fr < BACKBUFFER_COUNT; ++fr)
 			{
 				SAFE_RELEASE(frames[fr].backBuffer);
 			}
@@ -1928,7 +1928,7 @@ namespace wiGraphics
 			HRESULT hr = swapChain->ResizeBuffers(GetBackBufferCount(), width, height, _ConvertFormat(GetBackBufferFormat()), 0);
 			assert(SUCCEEDED(hr));
 
-			for (UINT fr = 0; fr < BACKBUFFER_COUNT; ++fr)
+			for (uint32_t fr = 0; fr < BACKBUFFER_COUNT; ++fr)
 			{
 				hr = swapChain->GetBuffer(fr, __uuidof(ID3D12Resource), (void**)&frames[fr].backBuffer);
 				assert(SUCCEEDED(hr));
@@ -1963,12 +1963,12 @@ namespace wiGraphics
 		{
 			alignment = D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT;
 		}
-		UINT64 alignedSize = Align(pDesc->ByteWidth, alignment);
+		size_t alignedSize = Align(pDesc->ByteWidth, alignment);
 
 		D3D12_RESOURCE_DESC desc;
 		desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
 		desc.Format = DXGI_FORMAT_UNKNOWN;
-		desc.Width = alignedSize;
+		desc.Width = (UINT64)alignedSize;
 		desc.Height = 1;
 		desc.MipLevels = 1;
 		desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
@@ -2022,7 +2022,7 @@ namespace wiGraphics
 		if (pDesc->BindFlags & BIND_CONSTANT_BUFFER)
 		{
 			D3D12_CONSTANT_BUFFER_VIEW_DESC cbv_desc = {};
-			cbv_desc.SizeInBytes = (UINT)alignedSize;
+			cbv_desc.SizeInBytes = (uint32_t)alignedSize;
 			cbv_desc.BufferLocation = ((ID3D12Resource*)pBuffer->resource)->GetGPUVirtualAddress();
 
 			pBuffer->CBV = ResourceAllocator->allocate();
@@ -2225,21 +2225,21 @@ namespace wiGraphics
 
 		if (pTexture->desc.MipLevels == 0)
 		{
-			pTexture->desc.MipLevels = (UINT)log2(std::max(pTexture->desc.Width, pTexture->desc.Height));
+			pTexture->desc.MipLevels = (uint32_t)log2(std::max(pTexture->desc.Width, pTexture->desc.Height));
 		}
 
 
 		// Issue data copy on request:
 		if (pInitialData != nullptr)
 		{
-			UINT dataCount = pDesc->ArraySize * std::max(1u, pDesc->MipLevels);
+			uint32_t dataCount = pDesc->ArraySize * std::max(1u, pDesc->MipLevels);
 			D3D12_SUBRESOURCE_DATA* data = new D3D12_SUBRESOURCE_DATA[dataCount];
-			for (UINT slice = 0; slice < dataCount; ++slice)
+			for (uint32_t slice = 0; slice < dataCount; ++slice)
 			{
 				data[slice] = _ConvertSubresourceData(pInitialData[slice]);
 			}
 
-			UINT FirstSubresource = 0;
+			uint32_t FirstSubresource = 0;
 
 			UINT64 RequiredSize = 0;
 			device->GetCopyableFootprints(&desc, 0, dataCount, 0, nullptr, nullptr, nullptr, &RequiredSize);
@@ -2276,14 +2276,14 @@ namespace wiGraphics
 
 		return hr;
 	}
-	HRESULT GraphicsDevice_DX12::CreateInputLayout(const VertexLayoutDesc* pInputElementDescs, UINT NumElements, const ShaderByteCode* shaderCode, VertexLayout* pInputLayout)
+	HRESULT GraphicsDevice_DX12::CreateInputLayout(const VertexLayoutDesc* pInputElementDescs, uint32_t NumElements, const ShaderByteCode* shaderCode, VertexLayout* pInputLayout)
 	{
 		DestroyInputLayout(pInputLayout);
 		pInputLayout->Register(this);
 
 		pInputLayout->desc.clear();
 		pInputLayout->desc.reserve((size_t)NumElements);
-		for (UINT i = 0; i < NumElements; ++i)
+		for (uint32_t i = 0; i < NumElements; ++i)
 		{
 			pInputLayout->desc.push_back(pInputElementDescs[i]);
 		}
@@ -2424,7 +2424,7 @@ namespace wiGraphics
 
 		pQuery->desc = *pDesc;
 
-		UINT query_index;
+		uint32_t query_index;
 
 		switch (pDesc->Type)
 		{
@@ -2491,7 +2491,7 @@ namespace wiGraphics
 
 		renderpass->hash = 0;
 		wiHelper::hash_combine(renderpass->hash, pDesc->numAttachments);
-		for (UINT i = 0; i < pDesc->numAttachments; ++i)
+		for (uint32_t i = 0; i < pDesc->numAttachments; ++i)
 		{
 			wiHelper::hash_combine(renderpass->hash, pDesc->attachments[i].texture->desc.Format);
 			wiHelper::hash_combine(renderpass->hash, pDesc->attachments[i].texture->desc.SampleCount);
@@ -2500,7 +2500,7 @@ namespace wiGraphics
 		return S_OK;
 	}
 
-	int GraphicsDevice_DX12::CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, UINT firstSlice, UINT sliceCount, UINT firstMip, UINT mipCount)
+	int GraphicsDevice_DX12::CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, uint32_t firstSlice, uint32_t sliceCount, uint32_t firstMip, uint32_t mipCount)
 	{
 		switch (type)
 		{
@@ -3171,10 +3171,10 @@ namespace wiGraphics
 					((ID3D12PipelineState*)item.handle)->Release();
 					break;
 				case DestroyItem::QUERY_TIMESTAMP:
-					free_timestampqueries.push_back((UINT)item.handle);
+					free_timestampqueries.push_back((uint32_t)item.handle);
 					break;
 				case DestroyItem::QUERY_OCCLUSION:
-					free_timestampqueries.push_back((UINT)item.handle);
+					free_timestampqueries.push_back((uint32_t)item.handle);
 					break;
 				default:
 					break;
@@ -3200,7 +3200,7 @@ namespace wiGraphics
 			assert(cmd < COMMANDLIST_COUNT);
 
 			HRESULT hr;
-			for (UINT fr = 0; fr < BACKBUFFER_COUNT; ++fr)
+			for (uint32_t fr = 0; fr < BACKBUFFER_COUNT; ++fr)
 			{
 				hr = device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_DIRECT, __uuidof(ID3D12CommandAllocator), (void**)&frames[fr].commandAllocators[cmd]);
 				hr = device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, frames[fr].commandAllocators[cmd], nullptr, __uuidof(ID3D12GraphicsCommandList4), (void**)&frames[fr].commandLists[cmd]);
@@ -3231,8 +3231,8 @@ namespace wiGraphics
 		GetFrameResources().resourceBuffer[cmd]->clear();
 
 		D3D12_VIEWPORT vp = {};
-		vp.Width = (FLOAT)SCREENWIDTH;
-		vp.Height = (FLOAT)SCREENHEIGHT;
+		vp.Width = (float)SCREENWIDTH;
+		vp.Height = (float)SCREENHEIGHT;
 		vp.MinDepth = 0.0f;
 		vp.MaxDepth = 1.0f;
 		vp.TopLeftX = 0;
@@ -3240,7 +3240,7 @@ namespace wiGraphics
 		GetDirectCommandList(cmd)->RSSetViewports(1, &vp);
 
 		D3D12_RECT pRects[8];
-		for (UINT i = 0; i < 8; ++i)
+		for (uint32_t i = 0; i < 8; ++i)
 		{
 			pRects[i].bottom = INT32_MAX;
 			pRects[i].left = INT32_MIN;
@@ -3290,11 +3290,11 @@ namespace wiGraphics
 
 #ifdef DX12_REAL_RENDERPASS
 
-		UINT rt_count = 0;
+		uint32_t rt_count = 0;
 		D3D12_RENDER_PASS_RENDER_TARGET_DESC RTVs[8] = {};
 		bool dsv = false;
 		D3D12_RENDER_PASS_DEPTH_STENCIL_DESC DSV = {};
-		for (UINT i = 0; i < desc.numAttachments; ++i)
+		for (uint32_t i = 0; i < desc.numAttachments; ++i)
 		{
 			const RenderPassAttachment& attachment = desc.attachments[i];
 			const Texture2D* texture = attachment.texture;
@@ -3400,10 +3400,10 @@ namespace wiGraphics
 
 #else
 
-		UINT rt_count = 0;
+		uint32_t rt_count = 0;
 		D3D12_CPU_DESCRIPTOR_HANDLE RTVs[8] = {};
 		D3D12_CPU_DESCRIPTOR_HANDLE* DSV = nullptr;
-		for (UINT i = 0; i < desc.numAttachments; ++i)
+		for (uint32_t i = 0; i < desc.numAttachments; ++i)
 		{
 			const RenderPassAttachment& attachment = desc.attachments[i];
 			const Texture* texture = attachment.texture;
@@ -3442,7 +3442,7 @@ namespace wiGraphics
 
 				if (attachment.loadop == RenderPassAttachment::LOADOP_CLEAR)
 				{
-					UINT _flags = D3D12_CLEAR_FLAG_DEPTH;
+					uint32_t _flags = D3D12_CLEAR_FLAG_DEPTH;
 					if (IsFormatStencilSupport(texture->desc.Format))
 						_flags |= D3D12_CLEAR_FLAG_STENCIL;
 					GetDirectCommandList(cmd)->ClearDepthStencilView(*DSV, (D3D12_CLEAR_FLAGS)_flags, texture->desc.clear.depthstencil.depth, texture->desc.clear.depthstencil.stencil, 0, nullptr);
@@ -3466,8 +3466,8 @@ namespace wiGraphics
 
 		// Perform render pass transitions:
 		D3D12_RESOURCE_BARRIER barrierdescs[9];
-		UINT numBarriers = 0;
-		for (UINT i = 0; i < active_renderpass[cmd]->desc.numAttachments; ++i)
+		uint32_t numBarriers = 0;
+		for (uint32_t i = 0; i < active_renderpass[cmd]->desc.numAttachments; ++i)
 		{
 			const RenderPassAttachment& attachment = active_renderpass[cmd]->desc.attachments[i];
 			if (attachment.initial_layout == attachment.final_layout)
@@ -3491,23 +3491,23 @@ namespace wiGraphics
 
 		active_renderpass[cmd] = nullptr;
 	}
-	void GraphicsDevice_DX12::BindScissorRects(UINT numRects, const Rect* rects, CommandList cmd) {
+	void GraphicsDevice_DX12::BindScissorRects(uint32_t numRects, const Rect* rects, CommandList cmd) {
 		assert(rects != nullptr);
 		assert(numRects <= 8);
 		D3D12_RECT pRects[8];
-		for (UINT i = 0; i < numRects; ++i) {
-			pRects[i].bottom = rects[i].bottom;
-			pRects[i].left = rects[i].left;
-			pRects[i].right = rects[i].right;
-			pRects[i].top = rects[i].top;
+		for (uint32_t i = 0; i < numRects; ++i) {
+			pRects[i].bottom = (LONG)rects[i].bottom;
+			pRects[i].left = (LONG)rects[i].left;
+			pRects[i].right = (LONG)rects[i].right;
+			pRects[i].top = (LONG)rects[i].top;
 		}
 		GetDirectCommandList(cmd)->RSSetScissorRects(numRects, pRects);
 	}
-	void GraphicsDevice_DX12::BindViewports(UINT NumViewports, const ViewPort* pViewports, CommandList cmd)
+	void GraphicsDevice_DX12::BindViewports(uint32_t NumViewports, const Viewport* pViewports, CommandList cmd)
 	{
 		assert(NumViewports <= 6);
 		D3D12_VIEWPORT d3dViewPorts[6];
-		for (UINT i = 0; i < NumViewports; ++i)
+		for (uint32_t i = 0; i < NumViewports; ++i)
 		{
 			d3dViewPorts[i].TopLeftX = pViewports[i].TopLeftX;
 			d3dViewPorts[i].TopLeftY = pViewports[i].TopLeftY;
@@ -3518,7 +3518,7 @@ namespace wiGraphics
 		}
 		GetDirectCommandList(cmd)->RSSetViewports(NumViewports, d3dViewPorts);
 	}
-	void GraphicsDevice_DX12::BindResource(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource)
+	void GraphicsDevice_DX12::BindResource(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource)
 	{
 		assert(slot < GPU_RESOURCE_HEAP_SRV_COUNT);
 		auto& table = GetFrameResources().descriptors[cmd]->tables[stage];
@@ -3529,17 +3529,17 @@ namespace wiGraphics
 			table.dirty_resources = true;
 		}
 	}
-	void GraphicsDevice_DX12::BindResources(SHADERSTAGE stage, const GPUResource* const* resources, UINT slot, UINT count, CommandList cmd)
+	void GraphicsDevice_DX12::BindResources(SHADERSTAGE stage, const GPUResource* const* resources, uint32_t slot, uint32_t count, CommandList cmd)
 	{
 		if (resources != nullptr)
 		{
-			for (UINT i = 0; i < count; ++i)
+			for (uint32_t i = 0; i < count; ++i)
 			{
 				BindResource(stage, resources[i], slot + i, cmd, -1);
 			}
 		}
 	}
-	void GraphicsDevice_DX12::BindUAV(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource)
+	void GraphicsDevice_DX12::BindUAV(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource)
 	{
 		assert(slot < GPU_RESOURCE_HEAP_UAV_COUNT);
 		auto& table = GetFrameResources().descriptors[cmd]->tables[stage];
@@ -3550,23 +3550,23 @@ namespace wiGraphics
 			table.dirty_resources = true;
 		}
 	}
-	void GraphicsDevice_DX12::BindUAVs(SHADERSTAGE stage, const GPUResource* const* resources, UINT slot, UINT count, CommandList cmd)
+	void GraphicsDevice_DX12::BindUAVs(SHADERSTAGE stage, const GPUResource* const* resources, uint32_t slot, uint32_t count, CommandList cmd)
 	{
 		if (resources != nullptr)
 		{
-			for (UINT i = 0; i < count; ++i)
+			for (uint32_t i = 0; i < count; ++i)
 			{
 				BindUAV(stage, resources[i], slot + i, cmd, -1);
 			}
 		}
 	}
-	void GraphicsDevice_DX12::UnbindResources(UINT slot, UINT num, CommandList cmd)
+	void GraphicsDevice_DX12::UnbindResources(uint32_t slot, uint32_t num, CommandList cmd)
 	{
 	}
-	void GraphicsDevice_DX12::UnbindUAVs(UINT slot, UINT num, CommandList cmd)
+	void GraphicsDevice_DX12::UnbindUAVs(uint32_t slot, uint32_t num, CommandList cmd)
 	{
 	}
-	void GraphicsDevice_DX12::BindSampler(SHADERSTAGE stage, const Sampler* sampler, UINT slot, CommandList cmd)
+	void GraphicsDevice_DX12::BindSampler(SHADERSTAGE stage, const Sampler* sampler, uint32_t slot, CommandList cmd)
 	{
 		assert(slot < GPU_SAMPLER_HEAP_COUNT);
 		auto& table = GetFrameResources().descriptors[cmd]->tables[stage];
@@ -3576,7 +3576,7 @@ namespace wiGraphics
 			table.dirty_samplers = true;
 		}
 	}
-	void GraphicsDevice_DX12::BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, UINT slot, CommandList cmd)
+	void GraphicsDevice_DX12::BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, uint32_t slot, CommandList cmd)
 	{
 		assert(slot < GPU_RESOURCE_HEAP_CBV_COUNT);
 		auto& table = GetFrameResources().descriptors[cmd]->tables[stage];
@@ -3586,11 +3586,11 @@ namespace wiGraphics
 			table.dirty_resources = true;
 		}
 	}
-	void GraphicsDevice_DX12::BindVertexBuffers(const GPUBuffer* const* vertexBuffers, UINT slot, UINT count, const UINT* strides, const UINT* offsets, CommandList cmd)
+	void GraphicsDevice_DX12::BindVertexBuffers(const GPUBuffer* const* vertexBuffers, uint32_t slot, uint32_t count, const uint32_t* strides, const uint32_t* offsets, CommandList cmd)
 	{
 		assert(count <= 8);
 		D3D12_VERTEX_BUFFER_VIEW res[8] = { 0 };
-		for (UINT i = 0; i < count; ++i)
+		for (uint32_t i = 0; i < count; ++i)
 		{
 			if (vertexBuffers[i] != nullptr)
 			{
@@ -3604,9 +3604,9 @@ namespace wiGraphics
 				res[i].StrideInBytes = strides[i];
 			}
 		}
-		GetDirectCommandList(cmd)->IASetVertexBuffers(static_cast<UINT>(slot), static_cast<UINT>(count), res);
+		GetDirectCommandList(cmd)->IASetVertexBuffers(static_cast<uint32_t>(slot), static_cast<uint32_t>(count), res);
 	}
-	void GraphicsDevice_DX12::BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, UINT offset, CommandList cmd)
+	void GraphicsDevice_DX12::BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint32_t offset, CommandList cmd)
 	{
 		D3D12_INDEX_BUFFER_VIEW res = {};
 		if (indexBuffer != nullptr)
@@ -3617,7 +3617,7 @@ namespace wiGraphics
 		}
 		GetDirectCommandList(cmd)->IASetIndexBuffer(&res);
 	}
-	void GraphicsDevice_DX12::BindStencilRef(UINT value, CommandList cmd)
+	void GraphicsDevice_DX12::BindStencilRef(uint32_t value, CommandList cmd)
 	{
 		GetDirectCommandList(cmd)->OMSetStencilRef(value);
 	}
@@ -3732,9 +3732,9 @@ namespace wiGraphics
 				D3D12_INPUT_ELEMENT_DESC* elements = nullptr;
 				if (pso->desc.il != nullptr)
 				{
-					desc.InputLayout.NumElements = (UINT)pso->desc.il->desc.size();
+					desc.InputLayout.NumElements = (uint32_t)pso->desc.il->desc.size();
 					elements = new D3D12_INPUT_ELEMENT_DESC[desc.InputLayout.NumElements];
-					for (UINT i = 0; i < desc.InputLayout.NumElements; ++i)
+					for (uint32_t i = 0; i < desc.InputLayout.NumElements; ++i)
 					{
 						elements[i].SemanticName = pso->desc.il->desc[i].SemanticName;
 						elements[i].SemanticIndex = pso->desc.il->desc[i].SemanticIndex;
@@ -3760,7 +3760,7 @@ namespace wiGraphics
 				}
 				else
 				{
-					for (UINT i = 0; i < active_renderpass[cmd]->desc.numAttachments; ++i)
+					for (uint32_t i = 0; i < active_renderpass[cmd]->desc.numAttachments; ++i)
 					{
 						const RenderPassAttachment& attachment = active_renderpass[cmd]->desc.attachments[i];
 
@@ -3891,42 +3891,42 @@ namespace wiGraphics
 		prev_pipeline_hash[cmd] = 0; // note: same bind point for compute and graphics in dx12!
 		GetDirectCommandList(cmd)->SetPipelineState((ID3D12PipelineState*)cs->resource);
 	}
-	void GraphicsDevice_DX12::Draw(UINT vertexCount, UINT startVertexLocation, CommandList cmd)
+	void GraphicsDevice_DX12::Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		GetDirectCommandList(cmd)->DrawInstanced(vertexCount, 1, startVertexLocation, 0);
 	}
-	void GraphicsDevice_DX12::DrawIndexed(UINT indexCount, UINT startIndexLocation, UINT baseVertexLocation, CommandList cmd)
+	void GraphicsDevice_DX12::DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		GetDirectCommandList(cmd)->DrawIndexedInstanced(indexCount, 1, startIndexLocation, baseVertexLocation, 0);
 	}
-	void GraphicsDevice_DX12::DrawInstanced(UINT vertexCount, UINT instanceCount, UINT startVertexLocation, UINT startInstanceLocation, CommandList cmd)
+	void GraphicsDevice_DX12::DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		GetDirectCommandList(cmd)->DrawInstanced(vertexCount, instanceCount, startVertexLocation, startInstanceLocation);
 	}
-	void GraphicsDevice_DX12::DrawIndexedInstanced(UINT indexCount, UINT instanceCount, UINT startIndexLocation, UINT baseVertexLocation, UINT startInstanceLocation, CommandList cmd)
+	void GraphicsDevice_DX12::DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, uint32_t startInstanceLocation, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		GetDirectCommandList(cmd)->DrawIndexedInstanced(indexCount, instanceCount, startIndexLocation, baseVertexLocation, startInstanceLocation);
 	}
-	void GraphicsDevice_DX12::DrawInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd)
+	void GraphicsDevice_DX12::DrawInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		GetDirectCommandList(cmd)->ExecuteIndirect(drawInstancedIndirectCommandSignature, 1, (ID3D12Resource*)args->resource, args_offset, nullptr, 0);
 	}
-	void GraphicsDevice_DX12::DrawIndexedInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd)
+	void GraphicsDevice_DX12::DrawIndexedInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		GetDirectCommandList(cmd)->ExecuteIndirect(drawIndexedInstancedIndirectCommandSignature, 1, (ID3D12Resource*)args->resource, args_offset, nullptr, 0);
 	}
-	void GraphicsDevice_DX12::Dispatch(UINT threadGroupCountX, UINT threadGroupCountY, UINT threadGroupCountZ, CommandList cmd)
+	void GraphicsDevice_DX12::Dispatch(uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		GetDirectCommandList(cmd)->Dispatch(threadGroupCountX, threadGroupCountY, threadGroupCountZ);
 	}
-	void GraphicsDevice_DX12::DispatchIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd)
+	void GraphicsDevice_DX12::DispatchIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		GetDirectCommandList(cmd)->ExecuteIndirect(dispatchIndirectCommandSignature, 1, (ID3D12Resource*)args->resource, args_offset, nullptr, 0);
@@ -3935,7 +3935,7 @@ namespace wiGraphics
 	{
 		GetDirectCommandList(cmd)->CopyResource((ID3D12Resource*)pDst->resource, (ID3D12Resource*)pSrc->resource);
 	}
-	void GraphicsDevice_DX12::CopyTexture2D_Region(const Texture* pDst, UINT dstMip, UINT dstX, UINT dstY, const Texture* pSrc, UINT srcMip, CommandList cmd)
+	void GraphicsDevice_DX12::CopyTexture2D_Region(const Texture* pDst, uint32_t dstMip, uint32_t dstX, uint32_t dstY, const Texture* pSrc, uint32_t srcMip, CommandList cmd)
 	{
 		D3D12_RESOURCE_DESC dst_desc = ((ID3D12Resource*)pDst->resource)->GetDesc();
 		D3D12_RESOURCE_DESC src_desc = ((ID3D12Resource*)pSrc->resource)->GetDesc();
@@ -4031,13 +4031,13 @@ namespace wiGraphics
 		switch (query->desc.Type)
 		{
 		case GPU_QUERY_TYPE_TIMESTAMP:
-			GetDirectCommandList(cmd)->BeginQuery(querypool_timestamp, D3D12_QUERY_TYPE_TIMESTAMP, (UINT)query->resource);
+			GetDirectCommandList(cmd)->BeginQuery(querypool_timestamp, D3D12_QUERY_TYPE_TIMESTAMP, (uint32_t)query->resource);
 			break;
 		case GPU_QUERY_TYPE_OCCLUSION_PREDICATE:
-			GetDirectCommandList(cmd)->BeginQuery(querypool_occlusion, D3D12_QUERY_TYPE_BINARY_OCCLUSION, (UINT)query->resource);
+			GetDirectCommandList(cmd)->BeginQuery(querypool_occlusion, D3D12_QUERY_TYPE_BINARY_OCCLUSION, (uint32_t)query->resource);
 			break;
 		case GPU_QUERY_TYPE_OCCLUSION:
-			GetDirectCommandList(cmd)->BeginQuery(querypool_occlusion, D3D12_QUERY_TYPE_OCCLUSION, (UINT)query->resource);
+			GetDirectCommandList(cmd)->BeginQuery(querypool_occlusion, D3D12_QUERY_TYPE_OCCLUSION, (uint32_t)query->resource);
 			break;
 		}
 	}
@@ -4046,16 +4046,16 @@ namespace wiGraphics
 		switch (query->desc.Type)
 		{
 		case GPU_QUERY_TYPE_TIMESTAMP:
-			GetDirectCommandList(cmd)->EndQuery(querypool_timestamp, D3D12_QUERY_TYPE_TIMESTAMP, (UINT)query->resource);
-			GetDirectCommandList(cmd)->ResolveQueryData(querypool_timestamp, D3D12_QUERY_TYPE_TIMESTAMP, (UINT)query->resource, 1, querypool_timestamp_readback, (UINT64)query->resource * sizeof(UINT64));
+			GetDirectCommandList(cmd)->EndQuery(querypool_timestamp, D3D12_QUERY_TYPE_TIMESTAMP, (uint32_t)query->resource);
+			GetDirectCommandList(cmd)->ResolveQueryData(querypool_timestamp, D3D12_QUERY_TYPE_TIMESTAMP, (uint32_t)query->resource, 1, querypool_timestamp_readback, (uint64_t)query->resource * sizeof(uint64_t));
 			break;
 		case GPU_QUERY_TYPE_OCCLUSION_PREDICATE:
-			GetDirectCommandList(cmd)->EndQuery(querypool_occlusion, D3D12_QUERY_TYPE_BINARY_OCCLUSION, (UINT)query->resource);
-			GetDirectCommandList(cmd)->ResolveQueryData(querypool_occlusion, D3D12_QUERY_TYPE_BINARY_OCCLUSION, (UINT)query->resource, 1, querypool_occlusion_readback, (UINT64)query->resource * sizeof(UINT64));
+			GetDirectCommandList(cmd)->EndQuery(querypool_occlusion, D3D12_QUERY_TYPE_BINARY_OCCLUSION, (uint32_t)query->resource);
+			GetDirectCommandList(cmd)->ResolveQueryData(querypool_occlusion, D3D12_QUERY_TYPE_BINARY_OCCLUSION, (uint32_t)query->resource, 1, querypool_occlusion_readback, (uint64_t)query->resource * sizeof(uint64_t));
 			break;
 		case GPU_QUERY_TYPE_OCCLUSION:
-			GetDirectCommandList(cmd)->EndQuery(querypool_occlusion, D3D12_QUERY_TYPE_OCCLUSION, (UINT)query->resource);
-			GetDirectCommandList(cmd)->ResolveQueryData(querypool_occlusion, D3D12_QUERY_TYPE_OCCLUSION, (UINT)query->resource, 1, querypool_occlusion_readback, (UINT64)query->resource * sizeof(UINT64));
+			GetDirectCommandList(cmd)->EndQuery(querypool_occlusion, D3D12_QUERY_TYPE_OCCLUSION, (uint32_t)query->resource);
+			GetDirectCommandList(cmd)->ResolveQueryData(querypool_occlusion, D3D12_QUERY_TYPE_OCCLUSION, (uint32_t)query->resource, 1, querypool_occlusion_readback, (uint64_t)query->resource * sizeof(uint64_t));
 			break;
 		}
 	}
@@ -4063,7 +4063,7 @@ namespace wiGraphics
 	{
 		D3D12_RANGE range;
 		range.Begin = (SIZE_T)query->resource * sizeof(SIZE_T);
-		range.End = range.Begin + sizeof(UINT64);
+		range.End = range.Begin + sizeof(uint64_t);
 		D3D12_RANGE nullrange = {};
 		void* data = nullptr;
 
@@ -4074,7 +4074,7 @@ namespace wiGraphics
 			break;
 		case GPU_QUERY_TYPE_TIMESTAMP:
 			querypool_timestamp_readback->Map(0, &range, &data);
-			result->result_timestamp = *(UINT64*)((SIZE_T)data + range.Begin);
+			result->result_timestamp = *(uint64_t*)((SIZE_T)data + range.Begin);
 			querypool_timestamp_readback->Unmap(0, &nullrange);
 			break;
 		case GPU_QUERY_TYPE_TIMESTAMP_DISJOINT:
@@ -4088,7 +4088,7 @@ namespace wiGraphics
 			break;
 		case GPU_QUERY_TYPE_OCCLUSION:
 			querypool_occlusion_readback->Map(0, &range, &data);
-			result->result_passed_sample_count = *(UINT64*)((SIZE_T)data + range.Begin);
+			result->result_passed_sample_count = *(uint64_t*)((SIZE_T)data + range.Begin);
 			querypool_occlusion_readback->Unmap(0, &nullrange);
 			result->result_passed = result->result_passed_sample_count > 0 ? 1 : 0;
 			break;
@@ -4096,11 +4096,11 @@ namespace wiGraphics
 
 		return true;
 	}
-	void GraphicsDevice_DX12::Barrier(const GPUBarrier* barriers, UINT numBarriers, CommandList cmd)
+	void GraphicsDevice_DX12::Barrier(const GPUBarrier* barriers, uint32_t numBarriers, CommandList cmd)
 	{
 		D3D12_RESOURCE_BARRIER barrierdescs[8];
 
-		for (UINT i = 0; i < numBarriers; ++i)
+		for (uint32_t i = 0; i < numBarriers; ++i)
 		{
 			const GPUBarrier& barrier = barriers[i];
 			D3D12_RESOURCE_BARRIER& barrierdesc = barrierdescs[i];
@@ -4159,7 +4159,7 @@ namespace wiGraphics
 		assert(dest != nullptr); // todo: this needs to be handled as well
 
 		result.buffer = &allocator.buffer;
-		result.offset = (UINT)allocator.calculateOffset(dest);
+		result.offset = (uint32_t)allocator.calculateOffset(dest);
 		result.data = (void*)dest;
 		return result;
 	}

--- a/WickedEngine/wiGraphicsDevice_DX12.h
+++ b/WickedEngine/wiGraphicsDevice_DX12.h
@@ -48,8 +48,8 @@ namespace wiGraphics
 		ID3D12QueryHeap* querypool_occlusion = nullptr;
 		static const size_t timestamp_query_count = 1024;
 		static const size_t occlusion_query_count = 1024;
-		wiContainers::ThreadSafeRingBuffer<UINT, timestamp_query_count> free_timestampqueries;
-		wiContainers::ThreadSafeRingBuffer<UINT, occlusion_query_count> free_occlusionqueries;
+		wiContainers::ThreadSafeRingBuffer<uint32_t, timestamp_query_count> free_timestampqueries;
+		wiContainers::ThreadSafeRingBuffer<uint32_t, occlusion_query_count> free_occlusionqueries;
 		ID3D12Resource* querypool_timestamp_readback = nullptr;
 		ID3D12Resource* querypool_occlusion_readback = nullptr;
 		D3D12MA::Allocation* allocation_querypool_timestamp_readback = nullptr;
@@ -60,13 +60,13 @@ namespace wiGraphics
 			ID3D12DescriptorHeap*	heap = nullptr;
 			size_t					heap_begin;
 			uint32_t				itemCount;
-			UINT					maxCount;
-			UINT					itemSize;
+			uint32_t					maxCount;
+			uint32_t					itemSize;
 			bool*					itemsAlive = nullptr;
 			uint32_t				lastAlloc;
 			wiSpinLock				lock;
 
-			DescriptorAllocator(ID3D12Device* device, D3D12_DESCRIPTOR_HEAP_TYPE type, UINT maxCount);
+			DescriptorAllocator(ID3D12Device* device, D3D12_DESCRIPTOR_HEAP_TYPE type, uint32_t maxCount);
 			~DescriptorAllocator();
 
 			size_t allocate();
@@ -82,8 +82,8 @@ namespace wiGraphics
 		ID3D12DescriptorHeap*	null_sampler_heap_CPU = nullptr;
 		D3D12_CPU_DESCRIPTOR_HANDLE null_resource_heap_cpu_start = {};
 		D3D12_CPU_DESCRIPTOR_HANDLE null_sampler_heap_cpu_start = {};
-		UINT resource_descriptor_size = 0;
-		UINT sampler_descriptor_size = 0;
+		uint32_t resource_descriptor_size = 0;
+		uint32_t sampler_descriptor_size = 0;
 
 		struct FrameResources
 		{
@@ -101,8 +101,8 @@ namespace wiGraphics
 				D3D12_GPU_DESCRIPTOR_HANDLE resource_heap_gpu_start = {};
 				D3D12_CPU_DESCRIPTOR_HANDLE sampler_heap_cpu_start = {};
 				D3D12_GPU_DESCRIPTOR_HANDLE sampler_heap_gpu_start = {};
-				UINT ringOffset_resources = 0;
-				UINT ringOffset_samplers = 0;
+				uint32_t ringOffset_resources = 0;
+				uint32_t ringOffset_samplers = 0;
 
 				struct Table
 				{
@@ -130,7 +130,7 @@ namespace wiGraphics
 
 				} tables[SHADERSTAGE_COUNT];
 
-				DescriptorTableFrameAllocator(GraphicsDevice_DX12* device, UINT maxRenameCount_resources, UINT maxRenameCount_samplers);
+				DescriptorTableFrameAllocator(GraphicsDevice_DX12* device, uint32_t maxRenameCount_resources, uint32_t maxRenameCount_samplers);
 				~DescriptorTableFrameAllocator();
 
 				void reset();
@@ -232,7 +232,7 @@ namespace wiGraphics
 
 		HRESULT CreateBuffer(const GPUBufferDesc *pDesc, const SubresourceData* pInitialData, GPUBuffer *pBuffer) override;
 		HRESULT CreateTexture(const TextureDesc* pDesc, const SubresourceData *pInitialData, Texture *pTexture) override;
-		HRESULT CreateInputLayout(const VertexLayoutDesc *pInputElementDescs, UINT NumElements, const ShaderByteCode* shaderCode, VertexLayout *pInputLayout) override;
+		HRESULT CreateInputLayout(const VertexLayoutDesc *pInputElementDescs, uint32_t NumElements, const ShaderByteCode* shaderCode, VertexLayout *pInputLayout) override;
 		HRESULT CreateVertexShader(const void *pShaderBytecode, SIZE_T BytecodeLength, VertexShader *pVertexShader) override;
 		HRESULT CreatePixelShader(const void *pShaderBytecode, SIZE_T BytecodeLength, PixelShader *pPixelShader) override;
 		HRESULT CreateGeometryShader(const void *pShaderBytecode, SIZE_T BytecodeLength, GeometryShader *pGeometryShader) override;
@@ -247,7 +247,7 @@ namespace wiGraphics
 		HRESULT CreatePipelineState(const PipelineStateDesc* pDesc, PipelineState* pso) override;
 		HRESULT CreateRenderPass(const RenderPassDesc* pDesc, RenderPass* renderpass) override;
 
-		int CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, UINT firstSlice, UINT sliceCount, UINT firstMip, UINT mipCount) override;
+		int CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, uint32_t firstSlice, uint32_t sliceCount, uint32_t firstMip, uint32_t mipCount) override;
 
 		void DestroyResource(GPUResource* pResource) override;
 		void DestroyBuffer(GPUBuffer *pBuffer) override;
@@ -287,38 +287,38 @@ namespace wiGraphics
 
 		void RenderPassBegin(const RenderPass* renderpass, CommandList cmd) override;
 		void RenderPassEnd(CommandList cmd) override;
-		void BindScissorRects(UINT numRects, const Rect* rects, CommandList cmd) override;
-		void BindViewports(UINT NumViewports, const ViewPort *pViewports, CommandList cmd) override;
-		void BindResource(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource = -1) override;
-		void BindResources(SHADERSTAGE stage, const GPUResource *const* resources, UINT slot, UINT count, CommandList cmd) override;
-		void BindUAV(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource = -1) override;
-		void BindUAVs(SHADERSTAGE stage, const GPUResource *const* resources, UINT slot, UINT count, CommandList cmd) override;
-		void UnbindResources(UINT slot, UINT num, CommandList cmd) override;
-		void UnbindUAVs(UINT slot, UINT num, CommandList cmd) override;
-		void BindSampler(SHADERSTAGE stage, const Sampler* sampler, UINT slot, CommandList cmd) override;
-		void BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, UINT slot, CommandList cmd) override;
-		void BindVertexBuffers(const GPUBuffer *const* vertexBuffers, UINT slot, UINT count, const UINT* strides, const UINT* offsets, CommandList cmd) override;
-		void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, UINT offset, CommandList cmd) override;
-		void BindStencilRef(UINT value, CommandList cmd) override;
+		void BindScissorRects(uint32_t numRects, const Rect* rects, CommandList cmd) override;
+		void BindViewports(uint32_t NumViewports, const Viewport* pViewports, CommandList cmd) override;
+		void BindResource(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource = -1) override;
+		void BindResources(SHADERSTAGE stage, const GPUResource *const* resources, uint32_t slot, uint32_t count, CommandList cmd) override;
+		void BindUAV(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource = -1) override;
+		void BindUAVs(SHADERSTAGE stage, const GPUResource *const* resources, uint32_t slot, uint32_t count, CommandList cmd) override;
+		void UnbindResources(uint32_t slot, uint32_t num, CommandList cmd) override;
+		void UnbindUAVs(uint32_t slot, uint32_t num, CommandList cmd) override;
+		void BindSampler(SHADERSTAGE stage, const Sampler* sampler, uint32_t slot, CommandList cmd) override;
+		void BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, uint32_t slot, CommandList cmd) override;
+		void BindVertexBuffers(const GPUBuffer *const* vertexBuffers, uint32_t slot, uint32_t count, const uint32_t* strides, const uint32_t* offsets, CommandList cmd) override;
+		void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint32_t offset, CommandList cmd) override;
+		void BindStencilRef(uint32_t value, CommandList cmd) override;
 		void BindBlendFactor(float r, float g, float b, float a, CommandList cmd) override;
 		void BindPipelineState(const PipelineState* pso, CommandList cmd) override;
 		void BindComputeShader(const ComputeShader* cs, CommandList cmd) override;
-		void Draw(UINT vertexCount, UINT startVertexLocation, CommandList cmd) override;
-		void DrawIndexed(UINT indexCount, UINT startIndexLocation, UINT baseVertexLocation, CommandList cmd) override;
-		void DrawInstanced(UINT vertexCount, UINT instanceCount, UINT startVertexLocation, UINT startInstanceLocation, CommandList cmd) override;
-		void DrawIndexedInstanced(UINT indexCount, UINT instanceCount, UINT startIndexLocation, UINT baseVertexLocation, UINT startInstanceLocation, CommandList cmd) override;
-		void DrawInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd) override;
-		void DrawIndexedInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd) override;
-		void Dispatch(UINT threadGroupCountX, UINT threadGroupCountY, UINT threadGroupCountZ, CommandList cmd) override;
-		void DispatchIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd) override;
+		void Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd) override;
+		void DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, CommandList cmd) override;
+		void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd) override;
+		void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, uint32_t startInstanceLocation, CommandList cmd) override;
+		void DrawInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd) override;
+		void DrawIndexedInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd) override;
+		void Dispatch(uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ, CommandList cmd) override;
+		void DispatchIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd) override;
 		void CopyResource(const GPUResource* pDst, const GPUResource* pSrc, CommandList cmd) override;
-		void CopyTexture2D_Region(const Texture* pDst, UINT dstMip, UINT dstX, UINT dstY, const Texture* pSrc, UINT srcMip, CommandList cmd) override;
+		void CopyTexture2D_Region(const Texture* pDst, uint32_t dstMip, uint32_t dstX, uint32_t dstY, const Texture* pSrc, uint32_t srcMip, CommandList cmd) override;
 		void MSAAResolve(const Texture* pDst, const Texture* pSrc, CommandList cmd) override;
 		void UpdateBuffer(const GPUBuffer* buffer, const void* data, CommandList cmd, int dataSize = -1) override;
 		void QueryBegin(const GPUQuery *query, CommandList cmd) override;
 		void QueryEnd(const GPUQuery *query, CommandList cmd) override;
 		bool QueryRead(const GPUQuery* query, GPUQueryResult* result) override;
-		void Barrier(const GPUBarrier* barriers, UINT numBarriers, CommandList cmd) override;
+		void Barrier(const GPUBarrier* barriers, uint32_t numBarriers, CommandList cmd) override;
 
 		GPUAllocation AllocateGPU(size_t dataSize, CommandList cmd) override;
 

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -782,7 +782,7 @@ namespace wiGraphics
 		dataEnd = dataBegin + size;
 
 		// Because the "buffer" is created by hand in this, fill the desc to indicate how it can be used:
-		this->buffer.desc.ByteWidth = (UINT)((size_t)dataEnd - (size_t)dataBegin);
+		this->buffer.desc.ByteWidth = (uint32_t)((size_t)dataEnd - (size_t)dataBegin);
 		this->buffer.desc.Usage = USAGE_DYNAMIC;
 		this->buffer.desc.BindFlags = BIND_VERTEX_BUFFER | BIND_INDEX_BUFFER | BIND_SHADER_RESOURCE;
 		this->buffer.desc.MiscFlags = RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
@@ -876,7 +876,7 @@ namespace wiGraphics
 
 
 
-	GraphicsDevice_Vulkan::FrameResources::DescriptorTableFrameAllocator::DescriptorTableFrameAllocator(GraphicsDevice_Vulkan* device, UINT maxRenameCount) : device(device)
+	GraphicsDevice_Vulkan::FrameResources::DescriptorTableFrameAllocator::DescriptorTableFrameAllocator(GraphicsDevice_Vulkan* device, uint32_t maxRenameCount) : device(device)
 	{
 		VkResult res;
 
@@ -1958,7 +1958,7 @@ namespace wiGraphics
 
 		// Create frame resources:
 		{
-			for (UINT fr = 0; fr < BACKBUFFER_COUNT; ++fr)
+			for (uint32_t fr = 0; fr < BACKBUFFER_COUNT; ++fr)
 			{
 				// Fence:
 				{
@@ -2163,7 +2163,7 @@ namespace wiGraphics
 			VkQueryPoolCreateInfo poolInfo = {};
 			poolInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
 
-			for (UINT i = 0; i < timestamp_query_count; ++i)
+			for (uint32_t i = 0; i < timestamp_query_count; ++i)
 			{
 				free_timestampqueries.push_back(i);
 			}
@@ -2173,7 +2173,7 @@ namespace wiGraphics
 			assert(res == VK_SUCCESS);
 			timestamps_to_reset.reserve(timestamp_query_count);
 
-			for (UINT i = 0; i < occlusion_query_count; ++i)
+			for (uint32_t i = 0; i < occlusion_query_count; ++i)
 			{
 				free_occlusionqueries.push_back(i);
 			}
@@ -2450,7 +2450,7 @@ namespace wiGraphics
 
 		if (pTexture->desc.MipLevels == 0)
 		{
-			pTexture->desc.MipLevels = static_cast<UINT>(log2(std::max(pTexture->desc.Width, pTexture->desc.Height)));
+			pTexture->desc.MipLevels = static_cast<uint32_t>(log2(std::max(pTexture->desc.Width, pTexture->desc.Height)));
 		}
 
 		VmaAllocationCreateInfo allocInfo = {};
@@ -2535,12 +2535,12 @@ namespace wiGraphics
 				std::vector<VkBufferImageCopy> copyRegions;
 
 				size_t cpyoffset = 0;
-				UINT initDataIdx = 0;
-				for (UINT slice = 0; slice < pDesc->ArraySize; ++slice)
+				uint32_t initDataIdx = 0;
+				for (uint32_t slice = 0; slice < pDesc->ArraySize; ++slice)
 				{
 					uint32_t width = pDesc->Width;
 					uint32_t height = pDesc->Height;
-					for (UINT mip = 0; mip < pDesc->MipLevels; ++mip)
+					for (uint32_t mip = 0; mip < pDesc->MipLevels; ++mip)
 					{
 						const SubresourceData& subresourceData = pInitialData[initDataIdx++];
 						size_t cpysize = subresourceData.SysMemPitch * height;
@@ -2666,14 +2666,14 @@ namespace wiGraphics
 
 		return res == VK_SUCCESS ? S_OK : E_FAIL;
 	}
-	HRESULT GraphicsDevice_Vulkan::CreateInputLayout(const VertexLayoutDesc *pInputElementDescs, UINT NumElements, const ShaderByteCode* shaderCode, VertexLayout *pInputLayout)
+	HRESULT GraphicsDevice_Vulkan::CreateInputLayout(const VertexLayoutDesc *pInputElementDescs, uint32_t NumElements, const ShaderByteCode* shaderCode, VertexLayout *pInputLayout)
 	{
 		DestroyInputLayout(pInputLayout);
 		pInputLayout->Register(this);
 
 		pInputLayout->desc.clear();
 		pInputLayout->desc.reserve((size_t)NumElements);
-		for (UINT i = 0; i < NumElements; ++i)
+		for (uint32_t i = 0; i < NumElements; ++i)
 		{
 			pInputLayout->desc.push_back(pInputElementDescs[i]);
 		}
@@ -3062,7 +3062,7 @@ namespace wiGraphics
 
 		renderpass->hash = 0;
 		wiHelper::hash_combine(renderpass->hash, pDesc->numAttachments);
-		for (UINT i = 0; i < pDesc->numAttachments; ++i)
+		for (uint32_t i = 0; i < pDesc->numAttachments; ++i)
 		{
 			wiHelper::hash_combine(renderpass->hash, pDesc->attachments[i].texture->desc.Format);
 			wiHelper::hash_combine(renderpass->hash, pDesc->attachments[i].texture->desc.SampleCount);
@@ -3081,7 +3081,7 @@ namespace wiGraphics
 		const RenderPassDesc& desc = renderpass->desc;
 
 		uint32_t validAttachmentCount = 0;
-		for (UINT i = 0; i < renderpass->desc.numAttachments; ++i)
+		for (uint32_t i = 0; i < renderpass->desc.numAttachments; ++i)
 		{
 			const Texture* texture = desc.attachments[i].texture;
 			const TextureDesc& texdesc = texture->desc;
@@ -3238,7 +3238,7 @@ namespace wiGraphics
 		return res == VK_SUCCESS ? S_OK : E_FAIL;
 	}
 
-	int GraphicsDevice_Vulkan::CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, UINT firstSlice, UINT sliceCount, UINT firstMip, UINT mipCount)
+	int GraphicsDevice_Vulkan::CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, uint32_t firstSlice, uint32_t sliceCount, uint32_t firstMip, uint32_t mipCount)
 	{
 		VkImageViewCreateInfo view_desc = {};
 		view_desc.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -3805,10 +3805,10 @@ namespace wiGraphics
 					vkDestroyFramebuffer(device, (VkFramebuffer)item.handle, nullptr);
 					break;
 				case DestroyItem::QUERY_TIMESTAMP:
-					free_timestampqueries.push_back((UINT)item.handle);
+					free_timestampqueries.push_back((uint32_t)item.handle);
 					break;
 				case DestroyItem::QUERY_OCCLUSION:
-					free_timestampqueries.push_back((UINT)item.handle);
+					free_timestampqueries.push_back((uint32_t)item.handle);
 					break;
 				default:
 					break;
@@ -3889,7 +3889,7 @@ namespace wiGraphics
 		assert(res == VK_SUCCESS);
 
 		VkViewport viewports[6];
-		for (UINT i = 0; i < ARRAYSIZE(viewports); ++i)
+		for (uint32_t i = 0; i < ARRAYSIZE(viewports); ++i)
 		{
 			viewports[i].x = 0;
 			viewports[i].y = 0;
@@ -3988,7 +3988,7 @@ namespace wiGraphics
 			renderPassInfo.clearValueCount = renderpass->desc.numAttachments;
 			renderPassInfo.pClearValues = clearColors;
 
-			for (UINT i = 0; i < desc.numAttachments; ++i)
+			for (uint32_t i = 0; i < desc.numAttachments; ++i)
 			{
 				const ClearValue& clear = desc.attachments[i].texture->desc.clear;
 				if (desc.attachments[i].type == RenderPassAttachment::RENDERTARGET)
@@ -4018,23 +4018,23 @@ namespace wiGraphics
 
 		active_renderpass[cmd] = VK_NULL_HANDLE;
 	}
-	void GraphicsDevice_Vulkan::BindScissorRects(UINT numRects, const Rect* rects, CommandList cmd) {
+	void GraphicsDevice_Vulkan::BindScissorRects(uint32_t numRects, const Rect* rects, CommandList cmd) {
 		assert(rects != nullptr);
 		assert(numRects <= 8);
 		VkRect2D scissors[8];
-		for(UINT i = 0; i < numRects; ++i) {
+		for(uint32_t i = 0; i < numRects; ++i) {
 			scissors[i].extent.width = abs(rects[i].right - rects[i].left);
 			scissors[i].extent.height = abs(rects[i].top - rects[i].bottom);
-			scissors[i].offset.x = std::max(0l, rects[i].left);
-			scissors[i].offset.y = std::max(0l, rects[i].top);
+			scissors[i].offset.x = std::max(0, rects[i].left);
+			scissors[i].offset.y = std::max(0, rects[i].top);
 		}
 		vkCmdSetScissor(GetDirectCommandList(cmd), 0, numRects, scissors);
 	}
-	void GraphicsDevice_Vulkan::BindViewports(UINT NumViewports, const ViewPort *pViewports, CommandList cmd)
+	void GraphicsDevice_Vulkan::BindViewports(uint32_t NumViewports, const Viewport* pViewports, CommandList cmd)
 	{
 		assert(NumViewports <= 6);
 		VkViewport viewports[6];
-		for (UINT i = 0; i < NumViewports; ++i)
+		for (uint32_t i = 0; i < NumViewports; ++i)
 		{
 			viewports[i].x = pViewports[i].TopLeftX;
 			viewports[i].y = pViewports[i].TopLeftY;
@@ -4045,7 +4045,7 @@ namespace wiGraphics
 		}
 		vkCmdSetViewport(GetDirectCommandList(cmd), 0, NumViewports, viewports);
 	}
-	void GraphicsDevice_Vulkan::BindResource(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource)
+	void GraphicsDevice_Vulkan::BindResource(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource)
 	{
 		assert(slot < GPU_RESOURCE_HEAP_SRV_COUNT);
 		auto& table = GetFrameResources().descriptors[cmd]->tables[stage];
@@ -4056,17 +4056,17 @@ namespace wiGraphics
 			table.dirty = true;
 		}
 	}
-	void GraphicsDevice_Vulkan::BindResources(SHADERSTAGE stage, const GPUResource *const* resources, UINT slot, UINT count, CommandList cmd)
+	void GraphicsDevice_Vulkan::BindResources(SHADERSTAGE stage, const GPUResource *const* resources, uint32_t slot, uint32_t count, CommandList cmd)
 	{
 		if (resources != nullptr)
 		{
-			for (UINT i = 0; i < count; ++i)
+			for (uint32_t i = 0; i < count; ++i)
 			{
 				BindResource(stage, resources[i], slot + i, cmd, -1);
 			}
 		}
 	}
-	void GraphicsDevice_Vulkan::BindUAV(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource)
+	void GraphicsDevice_Vulkan::BindUAV(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource)
 	{
 		assert(slot < GPU_RESOURCE_HEAP_UAV_COUNT);
 		auto& table = GetFrameResources().descriptors[cmd]->tables[stage];
@@ -4077,23 +4077,23 @@ namespace wiGraphics
 			table.dirty = true;
 		}
 	}
-	void GraphicsDevice_Vulkan::BindUAVs(SHADERSTAGE stage, const GPUResource *const* resources, UINT slot, UINT count, CommandList cmd)
+	void GraphicsDevice_Vulkan::BindUAVs(SHADERSTAGE stage, const GPUResource *const* resources, uint32_t slot, uint32_t count, CommandList cmd)
 	{
 		if (resources != nullptr)
 		{
-			for (UINT i = 0; i < count; ++i)
+			for (uint32_t i = 0; i < count; ++i)
 			{
 				BindUAV(stage, resources[i], slot + i, cmd, -1);
 			}
 		}
 	}
-	void GraphicsDevice_Vulkan::UnbindResources(UINT slot, UINT num, CommandList cmd)
+	void GraphicsDevice_Vulkan::UnbindResources(uint32_t slot, uint32_t num, CommandList cmd)
 	{
 	}
-	void GraphicsDevice_Vulkan::UnbindUAVs(UINT slot, UINT num, CommandList cmd)
+	void GraphicsDevice_Vulkan::UnbindUAVs(uint32_t slot, uint32_t num, CommandList cmd)
 	{
 	}
-	void GraphicsDevice_Vulkan::BindSampler(SHADERSTAGE stage, const Sampler* sampler, UINT slot, CommandList cmd)
+	void GraphicsDevice_Vulkan::BindSampler(SHADERSTAGE stage, const Sampler* sampler, uint32_t slot, CommandList cmd)
 	{
 		assert(slot < GPU_SAMPLER_HEAP_COUNT);
 		auto& table = GetFrameResources().descriptors[cmd]->tables[stage];
@@ -4103,7 +4103,7 @@ namespace wiGraphics
 			table.dirty = true;
 		}
 	}
-	void GraphicsDevice_Vulkan::BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, UINT slot, CommandList cmd)
+	void GraphicsDevice_Vulkan::BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, uint32_t slot, CommandList cmd)
 	{
 		assert(slot < GPU_RESOURCE_HEAP_CBV_COUNT);
 		auto& table = GetFrameResources().descriptors[cmd]->tables[stage];
@@ -4113,12 +4113,12 @@ namespace wiGraphics
 			table.dirty = true;
 		}
 	}
-	void GraphicsDevice_Vulkan::BindVertexBuffers(const GPUBuffer *const* vertexBuffers, UINT slot, UINT count, const UINT* strides, const UINT* offsets, CommandList cmd)
+	void GraphicsDevice_Vulkan::BindVertexBuffers(const GPUBuffer *const* vertexBuffers, uint32_t slot, uint32_t count, const uint32_t* strides, const uint32_t* offsets, CommandList cmd)
 	{
 		VkDeviceSize voffsets[8] = {};
 		VkBuffer vbuffers[8] = {};
 		assert(count <= 8);
-		for (UINT i = 0; i < count; ++i)
+		for (uint32_t i = 0; i < count; ++i)
 		{
 			if (vertexBuffers[i] == nullptr)
 			{
@@ -4136,14 +4136,14 @@ namespace wiGraphics
 
 		vkCmdBindVertexBuffers(GetDirectCommandList(cmd), static_cast<uint32_t>(slot), static_cast<uint32_t>(count), vbuffers, voffsets);
 	}
-	void GraphicsDevice_Vulkan::BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, UINT offset, CommandList cmd)
+	void GraphicsDevice_Vulkan::BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint32_t offset, CommandList cmd)
 	{
 		if (indexBuffer != nullptr)
 		{
 			vkCmdBindIndexBuffer(GetDirectCommandList(cmd), (VkBuffer)indexBuffer->resource, (VkDeviceSize)offset, format == INDEXFORMAT_16BIT ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32);
 		}
 	}
-	void GraphicsDevice_Vulkan::BindStencilRef(UINT value, CommandList cmd)
+	void GraphicsDevice_Vulkan::BindStencilRef(uint32_t value, CommandList cmd)
 	{
 		vkCmdSetStencilReference(GetDirectCommandList(cmd), VK_STENCIL_FRONT_AND_BACK, value);
 	}
@@ -4527,8 +4527,8 @@ namespace wiGraphics
 				// Blending:
 				uint32_t numBlendAttachments = 0;
 				VkPipelineColorBlendAttachmentState colorBlendAttachments[8];
-				const UINT blend_loopCount = active_renderpass[cmd] == nullptr ? 1 : active_renderpass[cmd]->desc.numAttachments;
-				for (UINT i = 0; i < blend_loopCount; ++i)
+				const uint32_t blend_loopCount = active_renderpass[cmd] == nullptr ? 1 : active_renderpass[cmd]->desc.numAttachments;
+				for (uint32_t i = 0; i < blend_loopCount; ++i)
 				{
 					if (active_renderpass[cmd] != nullptr && active_renderpass[cmd]->desc.attachments[i].type != RenderPassAttachment::RENDERTARGET)
 					{
@@ -4622,42 +4622,42 @@ namespace wiGraphics
 	{
 		vkCmdBindPipeline(GetDirectCommandList(cmd), VK_PIPELINE_BIND_POINT_COMPUTE, (VkPipeline)cs->resource);
 	}
-	void GraphicsDevice_Vulkan::Draw(UINT vertexCount, UINT startVertexLocation, CommandList cmd)
+	void GraphicsDevice_Vulkan::Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		vkCmdDraw(GetDirectCommandList(cmd), static_cast<uint32_t>(vertexCount), 1, startVertexLocation, 0);
 	}
-	void GraphicsDevice_Vulkan::DrawIndexed(UINT indexCount, UINT startIndexLocation, UINT baseVertexLocation, CommandList cmd)
+	void GraphicsDevice_Vulkan::DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		vkCmdDrawIndexed(GetDirectCommandList(cmd), static_cast<uint32_t>(indexCount), 1, startIndexLocation, baseVertexLocation, 0);
 	}
-	void GraphicsDevice_Vulkan::DrawInstanced(UINT vertexCount, UINT instanceCount, UINT startVertexLocation, UINT startInstanceLocation, CommandList cmd)
+	void GraphicsDevice_Vulkan::DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		vkCmdDraw(GetDirectCommandList(cmd), static_cast<uint32_t>(vertexCount), static_cast<uint32_t>(instanceCount), startVertexLocation, startInstanceLocation);
 	}
-	void GraphicsDevice_Vulkan::DrawIndexedInstanced(UINT indexCount, UINT instanceCount, UINT startIndexLocation, UINT baseVertexLocation, UINT startInstanceLocation, CommandList cmd)
+	void GraphicsDevice_Vulkan::DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, uint32_t startInstanceLocation, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		vkCmdDrawIndexed(GetDirectCommandList(cmd), static_cast<uint32_t>(indexCount), static_cast<uint32_t>(instanceCount), startIndexLocation, baseVertexLocation, startInstanceLocation);
 	}
-	void GraphicsDevice_Vulkan::DrawInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd)
+	void GraphicsDevice_Vulkan::DrawInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		vkCmdDrawIndirect(GetDirectCommandList(cmd), (VkBuffer)args->resource, (VkDeviceSize)args_offset, 1, (uint32_t)sizeof(IndirectDrawArgsInstanced));
 	}
-	void GraphicsDevice_Vulkan::DrawIndexedInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd)
+	void GraphicsDevice_Vulkan::DrawIndexedInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		vkCmdDrawIndexedIndirect(GetDirectCommandList(cmd), (VkBuffer)args->resource, (VkDeviceSize)args_offset, 1, (uint32_t)sizeof(IndirectDrawArgsIndexedInstanced));
 	}
-	void GraphicsDevice_Vulkan::Dispatch(UINT threadGroupCountX, UINT threadGroupCountY, UINT threadGroupCountZ, CommandList cmd)
+	void GraphicsDevice_Vulkan::Dispatch(uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		vkCmdDispatch(GetDirectCommandList(cmd), threadGroupCountX, threadGroupCountY, threadGroupCountZ);
 	}
-	void GraphicsDevice_Vulkan::DispatchIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd)
+	void GraphicsDevice_Vulkan::DispatchIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd)
 	{
 		GetFrameResources().descriptors[cmd]->validate(cmd);
 		vkCmdDispatchIndirect(GetDirectCommandList(cmd), (VkBuffer)args->resource, (VkDeviceSize)args_offset);
@@ -4737,7 +4737,7 @@ namespace wiGraphics
 			);
 		}
 	}
-	void GraphicsDevice_Vulkan::CopyTexture2D_Region(const Texture* pDst, UINT dstMip, UINT dstX, UINT dstY, const Texture* pSrc, UINT srcMip, CommandList cmd)
+	void GraphicsDevice_Vulkan::CopyTexture2D_Region(const Texture* pDst, uint32_t dstMip, uint32_t dstX, uint32_t dstY, const Texture* pSrc, uint32_t srcMip, CommandList cmd)
 	{
 	}
 	void GraphicsDevice_Vulkan::MSAAResolve(const Texture* pDst, const Texture* pSrc, CommandList cmd)
@@ -4891,8 +4891,8 @@ namespace wiGraphics
 			assert(0); // not implemented yet
 			break;
 		case GPU_QUERY_TYPE_TIMESTAMP:
-			res = vkGetQueryPoolResults(device, querypool_timestamp, (uint32_t)query->resource, 1, sizeof(UINT64),
-				&result->result_timestamp, sizeof(UINT64), VK_QUERY_RESULT_64_BIT);
+			res = vkGetQueryPoolResults(device, querypool_timestamp, (uint32_t)query->resource, 1, sizeof(uint64_t),
+				&result->result_timestamp, sizeof(uint64_t), VK_QUERY_RESULT_64_BIT);
 			timestamps_to_reset.push_back((uint32_t)query->resource);
 			break;
 		case GPU_QUERY_TYPE_TIMESTAMP_DISJOINT:
@@ -4901,8 +4901,8 @@ namespace wiGraphics
 			break;
 		case GPU_QUERY_TYPE_OCCLUSION_PREDICATE:
 		case GPU_QUERY_TYPE_OCCLUSION:
-			res = vkGetQueryPoolResults(device, querypool_occlusion, (uint32_t)query->resource, 1, sizeof(UINT64),
-				&result->result_passed_sample_count, sizeof(UINT64), VK_QUERY_RESULT_64_BIT);
+			res = vkGetQueryPoolResults(device, querypool_occlusion, (uint32_t)query->resource, 1, sizeof(uint64_t),
+				&result->result_passed_sample_count, sizeof(uint64_t), VK_QUERY_RESULT_64_BIT);
 			result->result_passed = result->result_passed_sample_count > 0 ? 1 : 0;
 			occlusions_to_reset.push_back((uint32_t)query->resource);
 			break;
@@ -4910,7 +4910,7 @@ namespace wiGraphics
 
 		return res == VK_SUCCESS;
 	}
-	void GraphicsDevice_Vulkan::Barrier(const GPUBarrier* barriers, UINT numBarriers, CommandList cmd)
+	void GraphicsDevice_Vulkan::Barrier(const GPUBarrier* barriers, uint32_t numBarriers, CommandList cmd)
 	{
 		VkMemoryBarrier memorybarriers[8];
 		VkImageMemoryBarrier imagebarriers[8];
@@ -4919,7 +4919,7 @@ namespace wiGraphics
 		uint32_t imagebarrier_count = 0;
 		uint32_t bufferbarrier_count = 0;
 
-		for (UINT i = 0; i < numBarriers; ++i)
+		for (uint32_t i = 0; i < numBarriers; ++i)
 		{
 			const GPUBarrier& barrier = barriers[i];
 
@@ -5012,7 +5012,7 @@ namespace wiGraphics
 		assert(dest != nullptr); // todo: this needs to be handled as well
 
 		result.buffer = &allocator.buffer;
-		result.offset = (UINT)allocator.calculateOffset(dest);
+		result.offset = (uint32_t)allocator.calculateOffset(dest);
 		result.data = (void*)dest;
 		return result;
 	}

--- a/WickedEngine/wiGraphicsDevice_Vulkan.h
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.h
@@ -140,7 +140,7 @@ namespace wiGraphics
 					const Sampler* SAM[GPU_SAMPLER_HEAP_COUNT];
 
 					std::vector<VkDescriptorSet> descriptorSet_GPU;
-					UINT ringOffset;
+					uint32_t ringOffset;
 					bool dirty;
 
 					void reset()
@@ -157,7 +157,7 @@ namespace wiGraphics
 
 				} tables[SHADERSTAGE_COUNT];
 
-				DescriptorTableFrameAllocator(GraphicsDevice_Vulkan* device, UINT maxRenameCount);
+				DescriptorTableFrameAllocator(GraphicsDevice_Vulkan* device, uint32_t maxRenameCount);
 				~DescriptorTableFrameAllocator();
 
 				void reset();
@@ -260,7 +260,7 @@ namespace wiGraphics
 
 		HRESULT CreateBuffer(const GPUBufferDesc *pDesc, const SubresourceData* pInitialData, GPUBuffer *pBuffer) override;
 		HRESULT CreateTexture(const TextureDesc* pDesc, const SubresourceData *pInitialData, Texture *pTexture) override;
-		HRESULT CreateInputLayout(const VertexLayoutDesc *pInputElementDescs, UINT NumElements, const ShaderByteCode* shaderCode, VertexLayout *pInputLayout) override;
+		HRESULT CreateInputLayout(const VertexLayoutDesc *pInputElementDescs, uint32_t NumElements, const ShaderByteCode* shaderCode, VertexLayout *pInputLayout) override;
 		HRESULT CreateVertexShader(const void *pShaderBytecode, SIZE_T BytecodeLength, VertexShader *pVertexShader) override;
 		HRESULT CreatePixelShader(const void *pShaderBytecode, SIZE_T BytecodeLength, PixelShader *pPixelShader) override;
 		HRESULT CreateGeometryShader(const void *pShaderBytecode, SIZE_T BytecodeLength, GeometryShader *pGeometryShader) override;
@@ -275,7 +275,7 @@ namespace wiGraphics
 		HRESULT CreatePipelineState(const PipelineStateDesc* pDesc, PipelineState* pso) override;
 		HRESULT CreateRenderPass(const RenderPassDesc* pDesc, RenderPass* renderpass) override;
 
-		int CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, UINT firstSlice, UINT sliceCount, UINT firstMip, UINT mipCount) override;
+		int CreateSubresource(Texture* texture, SUBRESOURCE_TYPE type, uint32_t firstSlice, uint32_t sliceCount, uint32_t firstMip, uint32_t mipCount) override;
 
 		void DestroyResource(GPUResource* pResource) override;
 		void DestroyBuffer(GPUBuffer *pBuffer) override;
@@ -315,38 +315,38 @@ namespace wiGraphics
 
 		void RenderPassBegin(const RenderPass* renderpass, CommandList cmd) override;
 		void RenderPassEnd(CommandList cmd) override;
-		void BindScissorRects(UINT numRects, const Rect* rects, CommandList cmd) override;
-		void BindViewports(UINT NumViewports, const ViewPort *pViewports, CommandList cmd) override;
-		void BindResource(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource = -1) override;
-		void BindResources(SHADERSTAGE stage, const GPUResource *const* resources, UINT slot, UINT count, CommandList cmd) override;
-		void BindUAV(SHADERSTAGE stage, const GPUResource* resource, UINT slot, CommandList cmd, int subresource = -1) override;
-		void BindUAVs(SHADERSTAGE stage, const GPUResource *const* resources, UINT slot, UINT count, CommandList cmd) override;
-		void UnbindResources(UINT slot, UINT num, CommandList cmd) override;
-		void UnbindUAVs(UINT slot, UINT num, CommandList cmd) override;
-		void BindSampler(SHADERSTAGE stage, const Sampler* sampler, UINT slot, CommandList cmd) override;
-		void BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, UINT slot, CommandList cmd) override;
-		void BindVertexBuffers(const GPUBuffer *const* vertexBuffers, UINT slot, UINT count, const UINT* strides, const UINT* offsets, CommandList cmd) override;
-		void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, UINT offset, CommandList cmd) override;
-		void BindStencilRef(UINT value, CommandList cmd) override;
+		void BindScissorRects(uint32_t numRects, const Rect* rects, CommandList cmd) override;
+		void BindViewports(uint32_t NumViewports, const Viewport *pViewports, CommandList cmd) override;
+		void BindResource(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource = -1) override;
+		void BindResources(SHADERSTAGE stage, const GPUResource *const* resources, uint32_t slot, uint32_t count, CommandList cmd) override;
+		void BindUAV(SHADERSTAGE stage, const GPUResource* resource, uint32_t slot, CommandList cmd, int subresource = -1) override;
+		void BindUAVs(SHADERSTAGE stage, const GPUResource *const* resources, uint32_t slot, uint32_t count, CommandList cmd) override;
+		void UnbindResources(uint32_t slot, uint32_t num, CommandList cmd) override;
+		void UnbindUAVs(uint32_t slot, uint32_t num, CommandList cmd) override;
+		void BindSampler(SHADERSTAGE stage, const Sampler* sampler, uint32_t slot, CommandList cmd) override;
+		void BindConstantBuffer(SHADERSTAGE stage, const GPUBuffer* buffer, uint32_t slot, CommandList cmd) override;
+		void BindVertexBuffers(const GPUBuffer *const* vertexBuffers, uint32_t slot, uint32_t count, const uint32_t* strides, const uint32_t* offsets, CommandList cmd) override;
+		void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint32_t offset, CommandList cmd) override;
+		void BindStencilRef(uint32_t value, CommandList cmd) override;
 		void BindBlendFactor(float r, float g, float b, float a, CommandList cmd) override;
 		void BindPipelineState(const PipelineState* pso, CommandList cmd) override;
 		void BindComputeShader(const ComputeShader* cs, CommandList cmd) override;
-		void Draw(UINT vertexCount, UINT startVertexLocation, CommandList cmd) override;
-		void DrawIndexed(UINT indexCount, UINT startIndexLocation, UINT baseVertexLocation, CommandList cmd) override;
-		void DrawInstanced(UINT vertexCount, UINT instanceCount, UINT startVertexLocation, UINT startInstanceLocation, CommandList cmd) override;
-		void DrawIndexedInstanced(UINT indexCount, UINT instanceCount, UINT startIndexLocation, UINT baseVertexLocation, UINT startInstanceLocation, CommandList cmd) override;
-		void DrawInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd) override;
-		void DrawIndexedInstancedIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd) override;
-		void Dispatch(UINT threadGroupCountX, UINT threadGroupCountY, UINT threadGroupCountZ, CommandList cmd) override;
-		void DispatchIndirect(const GPUBuffer* args, UINT args_offset, CommandList cmd) override;
+		void Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd) override;
+		void DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, CommandList cmd) override;
+		void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd) override;
+		void DrawIndexedInstanced(uint32_t indexCount, uint32_t instanceCount, uint32_t startIndexLocation, uint32_t baseVertexLocation, uint32_t startInstanceLocation, CommandList cmd) override;
+		void DrawInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd) override;
+		void DrawIndexedInstancedIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd) override;
+		void Dispatch(uint32_t threadGroupCountX, uint32_t threadGroupCountY, uint32_t threadGroupCountZ, CommandList cmd) override;
+		void DispatchIndirect(const GPUBuffer* args, uint32_t args_offset, CommandList cmd) override;
 		void CopyResource(const GPUResource* pDst, const GPUResource* pSrc, CommandList cmd) override;
-		void CopyTexture2D_Region(const Texture* pDst, UINT dstMip, UINT dstX, UINT dstY, const Texture* pSrc, UINT srcMip, CommandList cmd) override;
+		void CopyTexture2D_Region(const Texture* pDst, uint32_t dstMip, uint32_t dstX, uint32_t dstY, const Texture* pSrc, uint32_t srcMip, CommandList cmd) override;
 		void MSAAResolve(const Texture* pDst, const Texture* pSrc, CommandList cmd) override;
 		void UpdateBuffer(const GPUBuffer* buffer, const void* data, CommandList cmd, int dataSize = -1) override;
 		void QueryBegin(const GPUQuery *query, CommandList cmd) override;
 		void QueryEnd(const GPUQuery *query, CommandList cmd) override;
 		bool QueryRead(const GPUQuery* query, GPUQueryResult* result) override;
-		void Barrier(const GPUBarrier* barriers, UINT numBarriers, CommandList cmd) override;
+		void Barrier(const GPUBarrier* barriers, uint32_t numBarriers, CommandList cmd) override;
 
 		GPUAllocation AllocateGPU(size_t dataSize, CommandList cmd) override;
 

--- a/WickedEngine/wiHelper.cpp
+++ b/WickedEngine/wiHelper.cpp
@@ -82,9 +82,9 @@ namespace wiHelper
 		device->WaitForGPU();
 
 		TextureDesc desc = texture.GetDesc();
-		UINT data_count = desc.Width * desc.Height;
-		UINT data_stride = device->GetFormatStride(desc.Format);
-		UINT data_size = data_count * data_stride;
+		uint32_t data_count = desc.Width * desc.Height;
+		uint32_t data_stride = device->GetFormatStride(desc.Format);
+		uint32_t data_size = data_count * data_stride;
 
 		vector<uint8_t> data(data_size);
 
@@ -107,7 +107,7 @@ namespace wiHelper
 	{
 		using namespace wiGraphics;
 
-		UINT data_count = desc.Width * desc.Height;
+		uint32_t data_count = desc.Width * desc.Height;
 
 		if (desc.Format == FORMAT_R10G10B10A2_UNORM)
 		{
@@ -115,7 +115,7 @@ namespace wiHelper
 
 			uint32_t* data32 = (uint32_t*)textureData.data();
 
-			for (UINT i = 0; i < data_count; ++i)
+			for (uint32_t i = 0; i < data_count; ++i)
 			{
 				uint32_t pixel = data32[i];
 				float r = ((pixel >> 0) & 1023) / 1023.0f;

--- a/WickedEngine/wiImage.cpp
+++ b/WickedEngine/wiImage.cpp
@@ -57,7 +57,7 @@ namespace wiImage
 
 		device->BindResource(PS, texture, TEXSLOT_ONDEMAND0, cmd);
 
-		UINT stencilRef = params.stencilRef;
+		uint32_t stencilRef = params.stencilRef;
 		if (params.stencilRefMode == STENCILREFMODE_USER)
 		{
 			stencilRef = wiRenderer::CombineStencilrefs(STENCILREF_EMPTY, (uint8_t)stencilRef);

--- a/WickedEngine/wiOcean.cpp
+++ b/WickedEngine/wiOcean.cpp
@@ -67,7 +67,7 @@ float Phillips(XMFLOAT2 K, XMFLOAT2 W, float v, float a, float dir_depend)
 	return phillips * expf(-Ksqr * w * w);
 }
 
-void createBufferAndUAV(void* data, UINT byte_width, UINT byte_stride, GPUBuffer* pBuffer)
+void createBufferAndUAV(void* data, uint32_t byte_width, uint32_t byte_stride, GPUBuffer* pBuffer)
 {
 	// Create buffer
 	GPUBufferDesc buf_desc;
@@ -85,7 +85,7 @@ void createBufferAndUAV(void* data, UINT byte_width, UINT byte_stride, GPUBuffer
 
 }
 
-void createTextureAndViews(UINT width, UINT height, FORMAT format, Texture* pTex)
+void createTextureAndViews(uint32_t width, uint32_t height, FORMAT format, Texture* pTex)
 {
 	GraphicsDevice* device = wiRenderer::GetDevice();
 
@@ -102,7 +102,7 @@ void createTextureAndViews(UINT width, UINT height, FORMAT format, Texture* pTex
 
 	device->CreateTexture(&tex_desc, nullptr, pTex);
 
-	for (UINT i = 0; i < pTex->GetDesc().MipLevels; ++i)
+	for (uint32_t i = 0; i < pTex->GetDesc().MipLevels; ++i)
 	{
 		int subresource_index;
 		subresource_index = device->CreateSubresource(pTex, SRV, 0, 1, i, 1);
@@ -136,7 +136,7 @@ wiOcean::wiOcean(const WeatherComponent& weather)
 
 	// RW buffer allocations
 	// H0
-	UINT float2_stride = 2 * sizeof(float);
+	uint32_t float2_stride = 2 * sizeof(float);
 	createBufferAndUAV(h0_data, input_full_size * float2_stride, float2_stride, &m_pBuffer_Float2_H0);
 
 	// Notice: The following 3 buffers should be half sized buffer because of conjugate symmetric input. But
@@ -163,13 +163,13 @@ wiOcean::wiOcean(const WeatherComponent& weather)
 
 
 	// Constant buffers
-	UINT actual_dim = params.dmap_dim;
-	UINT input_width = actual_dim + 4;
+	uint32_t actual_dim = params.dmap_dim;
+	uint32_t input_width = actual_dim + 4;
 	// We use full sized data here. The value "output_width" should be actual_dim/2+1 though.
-	UINT output_width = actual_dim;
-	UINT output_height = actual_dim;
-	UINT dtx_offset = actual_dim * actual_dim;
-	UINT dty_offset = actual_dim * actual_dim * 2;
+	uint32_t output_width = actual_dim;
+	uint32_t output_height = actual_dim;
+	uint32_t dtx_offset = actual_dim * actual_dim;
+	uint32_t dty_offset = actual_dim * actual_dim * 2;
 	Ocean_Simulation_ImmutableCB immutable_consts = { actual_dim, input_width, output_width, output_height, dtx_offset, dty_offset };
 	SubresourceData init_cb0;
 	init_cb0.pSysMem = &immutable_consts;
@@ -275,8 +275,8 @@ void wiOcean::UpdateDisplacementMap(const WeatherComponent& weather, float time,
 	device->BindConstantBuffer(CS, &m_pPerFrameCB, CB_GETBINDSLOT(Ocean_Simulation_PerFrameCB), cmd);
 
 	// Run the CS
-	UINT group_count_x = (params.dmap_dim + OCEAN_COMPUTE_TILESIZE - 1) / OCEAN_COMPUTE_TILESIZE;
-	UINT group_count_y = (params.dmap_dim + OCEAN_COMPUTE_TILESIZE - 1) / OCEAN_COMPUTE_TILESIZE;
+	uint32_t group_count_x = (params.dmap_dim + OCEAN_COMPUTE_TILESIZE - 1) / OCEAN_COMPUTE_TILESIZE;
+	uint32_t group_count_y = (params.dmap_dim + OCEAN_COMPUTE_TILESIZE - 1) / OCEAN_COMPUTE_TILESIZE;
 	device->Dispatch(group_count_x, group_count_y, 1, cmd);
 	device->Barrier(&GPUBarrier::Memory(), 1, cmd);
 

--- a/WickedEngine/wiRawInput.cpp
+++ b/WickedEngine/wiRawInput.cpp
@@ -83,7 +83,7 @@ bool wiRawInput::RegisterKeyboardMouse(HWND hWnd)
 
 void wiRawInput::RetrieveData(LPARAM lParam)
 {
-	UINT dwSize;
+	uint32_t dwSize;
 
 	GetRawInputData((HRAWINPUT)lParam, RID_INPUT, NULL, &dwSize, sizeof(RAWINPUTHEADER));
 	LPBYTE lpb = new BYTE[dwSize];
@@ -113,7 +113,7 @@ void wiRawInput::RetrieveBufferedData()
 	//static uint64_t rawBuffer[1024 / 8];
 	//
 	//// Then in some function,
-	//UINT bytes = sizeof(rawBuffer);
+	//uint32_t bytes = sizeof(rawBuffer);
 	//// Loop through reading raw input until no events are left,
 	//while (1) {
 	//	// Fill up buffer,
@@ -133,7 +133,7 @@ void wiRawInput::RetrieveBufferedData()
 	//}
 
 	//////while (true){
-	////	UINT cbSize;
+	////	uint32_t cbSize;
 	////	//Sleep(1000);
 
 	////	GetRawInputBuffer(NULL, &cbSize, sizeof(RAWINPUTHEADER));
@@ -145,8 +145,8 @@ void wiRawInput::RetrieveBufferedData()
 	////	}
 	////	for (;;)
 	////	{
-	////		UINT cbSizeT = cbSize;
-	////		UINT nInput = GetRawInputBuffer(pRawInput, &cbSizeT, sizeof(RAWINPUTHEADER));
+	////		uint32_t cbSizeT = cbSize;
+	////		uint32_t nInput = GetRawInputBuffer(pRawInput, &cbSizeT, sizeof(RAWINPUTHEADER));
 	////		if (nInput == 0)
 	////		{
 	////			break;
@@ -158,7 +158,7 @@ void wiRawInput::RetrieveBufferedData()
 	////			break;
 	////		}
 	////		PRAWINPUT pri = pRawInput;
-	////		for (UINT i = 0; i < nInput; ++i)
+	////		for (uint32_t i = 0; i < nInput; ++i)
 	////		{
 	////			paRawInput[i] = pri;
 	////			pri = NEXTRAWINPUTBLOCK(pri);

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -112,14 +112,14 @@ XMFLOAT2 temporalAAJitter = XMFLOAT2(0, 0);
 XMFLOAT2 temporalAAJitterPrev = XMFLOAT2(0, 0);
 float RESOLUTIONSCALE = 1.0f;
 GPUQueryRing<2> occlusionQueries[256];
-UINT entityArrayOffset_Lights = 0;
-UINT entityArrayCount_Lights = 0;
-UINT entityArrayOffset_Decals = 0;
-UINT entityArrayCount_Decals = 0;
-UINT entityArrayOffset_ForceFields = 0;
-UINT entityArrayCount_ForceFields = 0;
-UINT entityArrayOffset_EnvProbes = 0;
-UINT entityArrayCount_EnvProbes = 0;
+uint32_t entityArrayOffset_Lights = 0;
+uint32_t entityArrayCount_Lights = 0;
+uint32_t entityArrayOffset_Decals = 0;
+uint32_t entityArrayCount_Decals = 0;
+uint32_t entityArrayOffset_ForceFields = 0;
+uint32_t entityArrayCount_ForceFields = 0;
+uint32_t entityArrayOffset_EnvProbes = 0;
+uint32_t entityArrayCount_EnvProbes = 0;
 Texture* enviroMap = nullptr;
 float GameSpeed = 1;
 bool debugLightCulling = false;
@@ -134,16 +134,16 @@ Entity cameraTransform = INVALID_ENTITY;
 struct VoxelizedSceneData
 {
 	bool enabled = false;
-	UINT res = 128;
+	uint32_t res = 128;
 	float voxelsize = 1;
 	XMFLOAT3 center = XMFLOAT3(0, 0, 0);
 	XMFLOAT3 extents = XMFLOAT3(0, 0, 0);
-	UINT numCones = 8;
+	uint32_t numCones = 8;
 	float rayStepSize = 0.5f;
 	bool secondaryBounceEnabled = true;
 	bool reflectionsEnabled = true;
 	bool centerChangedThisFrame = true;
-	UINT mips = 7;
+	uint32_t mips = 7;
 } voxelSceneData;
 
 std::unique_ptr<wiOcean> ocean;
@@ -1385,7 +1385,7 @@ void BindEnvironmentTextures(SHADERSTAGE stage, CommandList cmd)
 	}
 }
 
-void RenderMeshes(const RenderQueue& renderQueue, RENDERPASS renderPass, UINT renderTypeFlags, CommandList cmd, bool tessellation = false)
+void RenderMeshes(const RenderQueue& renderQueue, RENDERPASS renderPass, uint32_t renderTypeFlags, CommandList cmd, bool tessellation = false)
 {
 	if (!renderQueue.empty())
 	{
@@ -1430,7 +1430,7 @@ void RenderMeshes(const RenderQueue& renderQueue, RENDERPASS renderPass, UINT re
 
 
 		// Pre-allocate space for all the instances in GPU-buffer:
-		const UINT instanceDataSize = advancedVBRequest ? sizeof(InstBuf) : sizeof(Instance);
+		const uint32_t instanceDataSize = advancedVBRequest ? sizeof(InstBuf) : sizeof(Instance);
 		const size_t alloc_size = renderQueue.batchCount * instanceDataSize;
 		GraphicsDevice::GPUAllocation instances = device->AllocateGPU(alloc_size, cmd);
 
@@ -1657,11 +1657,11 @@ void RenderMeshes(const RenderQueue& renderQueue, RENDERPASS renderPass, UINT re
 							mesh.streamoutBuffer_POS.get() != nullptr ? mesh.streamoutBuffer_POS.get() : mesh.vertexBuffer_POS.get(),
 							instances.buffer
 						};
-						UINT strides[] = {
+						uint32_t strides[] = {
 							sizeof(MeshComponent::Vertex_POS),
 							instanceDataSize
 						};
-						UINT offsets[] = {
+						uint32_t offsets[] = {
 							0,
 							instancedBatch.dataOffset
 						};
@@ -1676,13 +1676,13 @@ void RenderMeshes(const RenderQueue& renderQueue, RENDERPASS renderPass, UINT re
 							mesh.vertexBuffer_UV1.get(),
 							instances.buffer
 						};
-						UINT strides[] = {
+						uint32_t strides[] = {
 							sizeof(MeshComponent::Vertex_POS),
 							sizeof(MeshComponent::Vertex_TEX),
 							sizeof(MeshComponent::Vertex_TEX),
 							instanceDataSize
 						};
-						UINT offsets[] = {
+						uint32_t offsets[] = {
 							0,
 							0,
 							0,
@@ -1702,7 +1702,7 @@ void RenderMeshes(const RenderQueue& renderQueue, RENDERPASS renderPass, UINT re
 							mesh.vertexBuffer_PRE.get() != nullptr ? mesh.vertexBuffer_PRE.get() : mesh.vertexBuffer_POS.get(),
 							instances.buffer
 						};
-						UINT strides[] = {
+						uint32_t strides[] = {
 							sizeof(MeshComponent::Vertex_POS),
 							sizeof(MeshComponent::Vertex_TEX),
 							sizeof(MeshComponent::Vertex_TEX),
@@ -1711,7 +1711,7 @@ void RenderMeshes(const RenderQueue& renderQueue, RENDERPASS renderPass, UINT re
 							sizeof(MeshComponent::Vertex_POS),
 							instanceDataSize
 						};
-						UINT offsets[] = {
+						uint32_t offsets[] = {
 							0,
 							0,
 							0,
@@ -1734,7 +1734,7 @@ void RenderMeshes(const RenderQueue& renderQueue, RENDERPASS renderPass, UINT re
 
 				STENCILREF engineStencilRef = material.engineStencilRef;
 				uint8_t userStencilRef = userStencilRefOverride > 0 ? userStencilRefOverride : material.userStencilRef;
-				UINT stencilRef = CombineStencilrefs(engineStencilRef, userStencilRef);
+				uint32_t stencilRef = CombineStencilrefs(engineStencilRef, userStencilRef);
 				device->BindStencilRef(stencilRef, cmd);
 
 				device->BindPipelineState(pso, cmd);
@@ -1794,13 +1794,13 @@ void RenderImpostors(const CameraComponent& camera, RENDERPASS renderPass, Comma
 
 		device->EventBegin("RenderImpostors", cmd);
 
-		UINT instanceCount = 0;
+		uint32_t instanceCount = 0;
 		for (size_t impostorID = 0; impostorID < scene.impostors.GetCount(); ++impostorID)
 		{
 			const ImpostorComponent& impostor = scene.impostors[impostorID];
 			if (camera.frustum.CheckBox(impostor.aabb))
 			{
-				instanceCount += (UINT)impostor.instanceMatrices.size();
+				instanceCount += (uint32_t)impostor.instanceMatrices.size();
 			}
 		}
 
@@ -1810,11 +1810,11 @@ void RenderImpostors(const CameraComponent& camera, RENDERPASS renderPass, Comma
 		}
 
 		// Pre-allocate space for all the instances in GPU-buffer:
-		const UINT instanceDataSize = sizeof(Instance);
+		const uint32_t instanceDataSize = sizeof(Instance);
 		const size_t alloc_size = instanceCount * instanceDataSize;
 		GraphicsDevice::GPUAllocation instances = device->AllocateGPU(alloc_size, cmd);
 
-		UINT drawableInstanceCount = 0;
+		uint32_t drawableInstanceCount = 0;
 		for (size_t impostorID = 0; impostorID < scene.impostors.GetCount(); ++impostorID)
 		{
 			const ImpostorComponent& impostor = scene.impostors[impostorID];
@@ -3458,7 +3458,7 @@ void UpdatePerFrameData(float dt, uint32_t layerMask)
 					bd.Usage = USAGE_DYNAMIC;
 					bd.CPUAccessFlags = CPU_ACCESS_WRITE;
 
-					bd.ByteWidth = sizeof(ArmatureComponent::ShaderBoneType) * (UINT)armature.boneCollection.size();
+					bd.ByteWidth = sizeof(ArmatureComponent::ShaderBoneType) * (uint32_t)armature.boneCollection.size();
 					bd.BindFlags = BIND_SHADER_RESOURCE;
 					bd.MiscFlags = RESOURCE_MISC_BUFFER_STRUCTURED;
 					bd.StructureByteStride = sizeof(ArmatureComponent::ShaderBoneType);
@@ -3804,8 +3804,8 @@ void UpdateRenderData(CommandList cmd)
 
 		const XMMATRIX viewMatrix = GetCamera().GetView();
 
-		UINT entityCounter = 0;
-		UINT matrixCounter = 0;
+		uint32_t entityCounter = 0;
+		uint32_t matrixCounter = 0;
 
 		entityArrayOffset_Lights = 0;
 		entityArrayCount_Lights = 0;
@@ -4036,7 +4036,7 @@ void UpdateRenderData(CommandList cmd)
 					GPUBuffer* vbs[] = {
 						nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr
 					};
-					const UINT strides[] = {
+					const uint32_t strides[] = {
 						0,0,0,0,0,0,0,0
 					};
 					device->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);
@@ -4073,7 +4073,7 @@ void UpdateRenderData(CommandList cmd)
 				device->BindResources(CS, vbs, SKINNINGSLOT_IN_VERTEX_POS, ARRAYSIZE(vbs), cmd);
 				device->BindUAVs(CS, so, 0, ARRAYSIZE(so), cmd);
 
-				device->Dispatch(((UINT)mesh.vertex_positions.size() + SKINNING_COMPUTE_THREADCOUNT - 1) / SKINNING_COMPUTE_THREADCOUNT, 1, 1, cmd);
+				device->Dispatch(((uint32_t)mesh.vertex_positions.size() + SKINNING_COMPUTE_THREADCOUNT - 1) / SKINNING_COMPUTE_THREADCOUNT, 1, 1, cmd);
 			}
 
 		}
@@ -4115,7 +4115,7 @@ void UpdateRenderData(CommandList cmd)
 			}
 		}
 
-		device->UpdateBuffer(mesh.vertexBuffer_POS.get(), vb, cmd, (UINT)vb_size);
+		device->UpdateBuffer(mesh.vertexBuffer_POS.get(), vb, cmd, (uint32_t)vb_size);
 
 		GetRenderFrameAllocator(cmd).free(vb_size);
 	}
@@ -4766,7 +4766,7 @@ void DrawLensFlares(
 				device->UpdateBuffer(&constantBuffers[CBTYPE_LENSFLARE], &cb, cmd);
 				device->BindConstantBuffer(GS, &constantBuffers[CBTYPE_LENSFLARE], CB_GETBINDSLOT(LensFlareCB), cmd);
 
-				UINT i = 0;
+				uint32_t i = 0;
 				for (const Texture* x : light.lensFlareRimTextures)
 				{
 					if (x != nullptr)
@@ -4837,7 +4837,7 @@ void SetShadowProps2D(int resolution, int count, int softShadowQuality)
 		renderpasses_shadow2D.resize(SHADOWCOUNT_2D);
 		renderpasses_shadow2DTransparent.resize(SHADOWCOUNT_2D);
 
-		for (UINT i = 0; i < SHADOWCOUNT_2D; ++i)
+		for (uint32_t i = 0; i < SHADOWCOUNT_2D; ++i)
 		{
 			int subresource_index;
 			subresource_index = device->CreateSubresource(&shadowMapArray_2D, DSV, i, 1, 0, 1);
@@ -4889,7 +4889,7 @@ void SetShadowPropsCube(int resolution, int count)
 
 		renderpasses_shadowCube.resize(SHADOWCOUNT_CUBE);
 
-		for (UINT i = 0; i < SHADOWCOUNT_CUBE; ++i)
+		for (uint32_t i = 0; i < SHADOWCOUNT_CUBE; ++i)
 		{
 			int subresource_index;
 			subresource_index = device->CreateSubresource(&shadowMapArray_Cube, DSV, i * 6, 6, 0, 1);
@@ -4921,7 +4921,7 @@ void DrawShadowmaps(const CameraComponent& camera, CommandList cmd, uint32_t lay
 		BindConstantBuffers(PS, cmd);
 
 
-		ViewPort vp;
+		Viewport vp;
 
 
 		const Scene& scene = GetScene();
@@ -5409,7 +5409,7 @@ void DrawDebugWorld(const CameraComponent& camera, CommandList cmd)
 		const GPUBuffer* vbs[] = {
 			&wirecubeVB,
 		};
-		const UINT strides[] = {
+		const uint32_t strides[] = {
 			sizeof(XMFLOAT4) + sizeof(XMFLOAT4),
 		};
 		device->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);
@@ -5534,10 +5534,10 @@ void DrawDebugWorld(const CameraComponent& camera, CommandList cmd)
 			const GPUBuffer* vbs[] = {
 				mem.buffer
 			};
-			const UINT strides[] = {
+			const uint32_t strides[] = {
 				sizeof(XMFLOAT4) + sizeof(XMFLOAT4),
 			};
-			const UINT offsets[] = {
+			const uint32_t offsets[] = {
 				mem.offset,
 			};
 			device->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, offsets, cmd);
@@ -5583,10 +5583,10 @@ void DrawDebugWorld(const CameraComponent& camera, CommandList cmd)
 		const GPUBuffer* vbs[] = {
 			mem.buffer,
 		};
-		const UINT strides[] = {
+		const uint32_t strides[] = {
 			sizeof(XMFLOAT4) + sizeof(XMFLOAT4),
 		};
-		const UINT offsets[] = {
+		const uint32_t offsets[] = {
 			mem.offset,
 		};
 		device->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, offsets, cmd);
@@ -5648,10 +5648,10 @@ void DrawDebugWorld(const CameraComponent& camera, CommandList cmd)
 		const GPUBuffer* vbs[] = {
 			mem.buffer,
 		};
-		const UINT strides[] = {
+		const uint32_t strides[] = {
 			sizeof(XMFLOAT4) + sizeof(XMFLOAT4),
 		};
-		const UINT offsets[] = {
+		const uint32_t offsets[] = {
 			mem.offset,
 		};
 		device->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, offsets, cmd);
@@ -5672,7 +5672,7 @@ void DrawDebugWorld(const CameraComponent& camera, CommandList cmd)
 		const GPUBuffer* vbs[] = {
 			&wirecubeVB,
 		};
-		const UINT strides[] = {
+		const uint32_t strides[] = {
 			sizeof(XMFLOAT4) + sizeof(XMFLOAT4),
 		};
 		device->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);
@@ -5734,7 +5734,7 @@ void DrawDebugWorld(const CameraComponent& camera, CommandList cmd)
 		const GPUBuffer* vbs[] = {
 			&wirecubeVB,
 		};
-		const UINT strides[] = {
+		const uint32_t strides[] = {
 			sizeof(XMFLOAT4) + sizeof(XMFLOAT4),
 		};
 		device->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);
@@ -5773,7 +5773,7 @@ void DrawDebugWorld(const CameraComponent& camera, CommandList cmd)
 		device->BindPipelineState(&PSO_debug[DEBUGRENDERING_GRID], cmd);
 
 		static float col = 0.7f;
-		static UINT gridVertexCount = 0;
+		static uint32_t gridVertexCount = 0;
 		static GPUBuffer* grid = nullptr;
 		if (grid == nullptr)
 		{
@@ -5823,7 +5823,7 @@ void DrawDebugWorld(const CameraComponent& camera, CommandList cmd)
 		GPUBuffer* vbs[] = {
 			grid,
 		};
-		const UINT strides[] = {
+		const uint32_t strides[] = {
 			sizeof(XMFLOAT4) + sizeof(XMFLOAT4),
 		};
 		device->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);
@@ -5880,7 +5880,7 @@ void DrawDebugWorld(const CameraComponent& camera, CommandList cmd)
 				const GPUBuffer* vbs[] = {
 					&wirecubeVB,
 				};
-				const UINT strides[] = {
+				const uint32_t strides[] = {
 					sizeof(XMFLOAT4) + sizeof(XMFLOAT4),
 				};
 				device->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);
@@ -5894,13 +5894,13 @@ void DrawDebugWorld(const CameraComponent& camera, CommandList cmd)
 				GPUBuffer* vbs[] = {
 					mesh->streamoutBuffer_POS != nullptr ? mesh->streamoutBuffer_POS.get() : mesh->vertexBuffer_POS.get(),
 				};
-				const UINT strides[] = {
+				const uint32_t strides[] = {
 					sizeof(MeshComponent::Vertex_POS),
 				};
 				device->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);
 				device->BindIndexBuffer(mesh->indexBuffer.get(), mesh->GetIndexFormat(), 0, cmd);
 
-				device->DrawIndexed((UINT)mesh->indices.size(), 0, 0, cmd);
+				device->DrawIndexed((uint32_t)mesh->indices.size(), 0, 0, cmd);
 			}
 		}
 
@@ -5951,7 +5951,7 @@ void DrawDebugWorld(const CameraComponent& camera, CommandList cmd)
 		const GPUBuffer* vbs[] = {
 			&wirecubeVB,
 		};
-		const UINT strides[] = {
+		const uint32_t strides[] = {
 			sizeof(XMFLOAT4) + sizeof(XMFLOAT4),
 		};
 		device->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);
@@ -6094,9 +6094,9 @@ void DrawDeferredDecals(
 	}
 }
 
-static const UINT envmapCount = 16;
-static const UINT envmapRes = 128;
-static const UINT envmapMIPs = 8;
+static const uint32_t envmapCount = 16;
+static const uint32_t envmapRes = 128;
+static const uint32_t envmapMIPs = 8;
 static Texture envrenderingDepthBuffer;
 static std::vector<RenderPass> renderpasses_envmap;
 vector<uint32_t> probesToRefresh(envmapCount);
@@ -6189,7 +6189,7 @@ void ManageEnvProbes()
 
 		renderpasses_envmap.resize(envmapCount);
 
-		for (UINT i = 0; i < envmapCount; ++i)
+		for (uint32_t i = 0; i < envmapCount; ++i)
 		{
 			int subresource_index;
 			subresource_index = device->CreateSubresource(textures[TEXTYPE_CUBEARRAY_ENVMAPARRAY], RTV, i * 6, 6, 0, 1);
@@ -6201,7 +6201,7 @@ void ManageEnvProbes()
 			renderpassdesc.attachments[1] = { RenderPassAttachment::DEPTH_STENCIL, RenderPassAttachment::LOADOP_CLEAR,&envrenderingDepthBuffer, -1 };
 			device->CreateRenderPass(&renderpassdesc, &renderpasses_envmap[subresource_index]);
 		}
-		for (UINT i = 0; i < textures[TEXTYPE_CUBEARRAY_ENVMAPARRAY]->GetDesc().MipLevels; ++i)
+		for (uint32_t i = 0; i < textures[TEXTYPE_CUBEARRAY_ENVMAPARRAY]->GetDesc().MipLevels; ++i)
 		{
 			int subresource_index;
 			subresource_index = device->CreateSubresource(textures[TEXTYPE_CUBEARRAY_ENVMAPARRAY], SRV, 0, desc.ArraySize, i, 1);
@@ -6211,7 +6211,7 @@ void ManageEnvProbes()
 		}
 
 		// debug probe views, individual cubes:
-		for (UINT i = 0; i < envmapCount; ++i)
+		for (uint32_t i = 0; i < envmapCount; ++i)
 		{
 			int subresource_index;
 			subresource_index = device->CreateSubresource(textures[TEXTYPE_CUBEARRAY_ENVMAPARRAY], SRV, i * 6, 6, 0, -1);
@@ -6231,14 +6231,10 @@ void RefreshEnvProbes(CommandList cmd)
 	GraphicsDevice* device = GetDevice();
 	device->EventBegin("EnvironmentProbe Refresh", cmd);
 
-	ViewPort VP;
-	VP.Height = envmapRes;
-	VP.Width = envmapRes;
-	VP.TopLeftX = 0;
-	VP.TopLeftY = 0;
-	VP.MinDepth = 0.0f;
-	VP.MaxDepth = 1.0f;
-	device->BindViewports(1, &VP, cmd);
+	Viewport vp;
+	vp.Height = envmapRes;
+	vp.Width = envmapRes;
+	device->BindViewports(1, &vp, cmd);
 
 	const float zNearP = GetCamera().zNearP;
 	const float zFarP = GetCamera().zFarP;
@@ -6347,7 +6343,7 @@ void RefreshEnvProbes(CommandList cmd)
 
 			desc.Width = 1;
 			desc.Height = 1;
-			for (UINT i = desc.MipLevels - 1; i > 0; --i)
+			for (uint32_t i = desc.MipLevels - 1; i > 0; --i)
 			{
 				device->BindUAV(CS, texture, 0, cmd, i);
 				device->BindResource(CS, texture, TEXSLOT_UNIQUE0, cmd, std::max(0, (int)i - 2));
@@ -6364,8 +6360,8 @@ void RefreshEnvProbes(CommandList cmd)
 				device->BindConstantBuffer(CS, &constantBuffers[CBTYPE_FILTERENVMAP], CB_GETBINDSLOT(FilterEnvmapCB), cmd);
 
 				device->Dispatch(
-					std::max(1u, (UINT)ceilf((float)desc.Width / GENERATEMIPCHAIN_2D_BLOCK_SIZE)),
-					std::max(1u, (UINT)ceilf((float)desc.Height / GENERATEMIPCHAIN_2D_BLOCK_SIZE)),
+					std::max(1u, (uint32_t)ceilf((float)desc.Width / GENERATEMIPCHAIN_2D_BLOCK_SIZE)),
+					std::max(1u, (uint32_t)ceilf((float)desc.Height / GENERATEMIPCHAIN_2D_BLOCK_SIZE)),
 					6,
 					cmd);
 
@@ -6383,9 +6379,9 @@ void RefreshEnvProbes(CommandList cmd)
 	device->EventEnd(cmd); // EnvironmentProbe Refresh
 }
 
-static const UINT maxImpostorCount = 8;
-static const UINT impostorTextureArraySize = maxImpostorCount * impostorCaptureAngles * 3;
-static const UINT impostorTextureDim = 128;
+static const uint32_t maxImpostorCount = 8;
+static const uint32_t impostorTextureArraySize = maxImpostorCount * impostorCaptureAngles * 3;
+static const uint32_t impostorTextureDim = 128;
 static Texture impostorDepthStencil;
 static std::vector<RenderPass> renderpasses_impostor;
 vector<uint32_t> impostorsToRefresh(maxImpostorCount);
@@ -6433,7 +6429,7 @@ void ManageImpostors()
 
 		renderpasses_impostor.resize(desc.ArraySize);
 
-		for (UINT i = 0; i < desc.ArraySize; ++i)
+		for (uint32_t i = 0; i < desc.ArraySize; ++i)
 		{
 			int subresource_index;
 			subresource_index = device->CreateSubresource(textures[TEXTYPE_2D_IMPOSTORARRAY], RTV, i, 1, 0, 1);
@@ -6493,7 +6489,7 @@ void RefreshImpostors(CommandList cmd)
 			mesh.IsSkinned() ? mesh.streamoutBuffer_POS.get() : mesh.vertexBuffer_POS.get(),
 			mem.buffer
 		};
-		UINT strides[] = {
+		uint32_t strides[] = {
 			sizeof(MeshComponent::Vertex_POS),
 			sizeof(MeshComponent::Vertex_TEX),
 			sizeof(MeshComponent::Vertex_TEX),
@@ -6502,7 +6498,7 @@ void RefreshImpostors(CommandList cmd)
 			sizeof(MeshComponent::Vertex_POS),
 			sizeof(InstBuf)
 		};
-		UINT offsets[] = {
+		uint32_t offsets[] = {
 			0,
 			0,
 			0,
@@ -6535,14 +6531,10 @@ void RefreshImpostors(CommandList cmd)
 				int textureIndex = (int)(impostorIndex * impostorCaptureAngles * 3 + prop * impostorCaptureAngles + i);
 				device->RenderPassBegin(&renderpasses_impostor[textureIndex], cmd);
 
-				ViewPort viewPort;
-				viewPort.Height = (float)impostorTextureDim;
-				viewPort.Width = (float)impostorTextureDim;
-				viewPort.TopLeftX = 0;
-				viewPort.TopLeftY = 0;
-				viewPort.MinDepth = 0;
-				viewPort.MaxDepth = 1;
-				device->BindViewports(1, &viewPort, cmd);
+				Viewport viewport;
+				viewport.Height = (float)impostorTextureDim;
+				viewport.Width = (float)impostorTextureDim;
+				device->BindViewports(1, &viewport, cmd);
 
 
 				CameraComponent impostorcamera;
@@ -6626,7 +6618,7 @@ void VoxelRadiance(CommandList cmd)
 		HRESULT hr = device->CreateTexture(&desc, nullptr, textures[TEXTYPE_3D_VOXELRADIANCE]);
 		assert(SUCCEEDED(hr));
 
-		for (UINT i = 0; i < textures[TEXTYPE_3D_VOXELRADIANCE]->GetDesc().MipLevels; ++i)
+		for (uint32_t i = 0; i < textures[TEXTYPE_3D_VOXELRADIANCE]->GetDesc().MipLevels; ++i)
 		{
 			int subresource_index;
 			subresource_index = device->CreateSubresource(textures[TEXTYPE_3D_VOXELRADIANCE], SRV, 0, 1, i, 1);
@@ -6646,7 +6638,7 @@ void VoxelRadiance(CommandList cmd)
 		HRESULT hr = device->CreateTexture(&desc, nullptr, textures[TEXTYPE_3D_VOXELRADIANCE_HELPER]);
 		assert(SUCCEEDED(hr));
 
-		for (UINT i = 0; i < textures[TEXTYPE_3D_VOXELRADIANCE_HELPER]->GetDesc().MipLevels; ++i)
+		for (uint32_t i = 0; i < textures[TEXTYPE_3D_VOXELRADIANCE_HELPER]->GetDesc().MipLevels; ++i)
 		{
 			int subresource_index;
 			subresource_index = device->CreateSubresource(textures[TEXTYPE_3D_VOXELRADIANCE_HELPER], SRV, 0, 1, i, 1);
@@ -6658,7 +6650,7 @@ void VoxelRadiance(CommandList cmd)
 	if (!resourceBuffers[RBTYPE_VOXELSCENE].IsValid())
 	{
 		GPUBufferDesc desc;
-		desc.StructureByteStride = sizeof(UINT) * 2;
+		desc.StructureByteStride = sizeof(uint32_t) * 2;
 		desc.ByteWidth = desc.StructureByteStride * voxelSceneData.res * voxelSceneData.res * voxelSceneData.res;
 		desc.BindFlags = BIND_UNORDERED_ACCESS | BIND_SHADER_RESOURCE;
 		desc.CPUAccessFlags = 0;
@@ -6696,14 +6688,10 @@ void VoxelRadiance(CommandList cmd)
 
 	if (!renderQueue.empty())
 	{
-		ViewPort VP;
-		VP.TopLeftX = 0;
-		VP.TopLeftY = 0;
-		VP.Width = (float)voxelSceneData.res;
-		VP.Height = (float)voxelSceneData.res;
-		VP.MinDepth = 0.0f;
-		VP.MaxDepth = 1.0f;
-		device->BindViewports(1, &VP, cmd);
+		Viewport vp;
+		vp.Width = (float)voxelSceneData.res;
+		vp.Height = (float)voxelSceneData.res;
+		device->BindViewports(1, &vp, cmd);
 
 		GPUResource* UAVs[] = { &resourceBuffers[RBTYPE_VOXELSCENE] };
 		device->BindUAVs(PS, UAVs, 0, 1, cmd);
@@ -6732,7 +6720,7 @@ void VoxelRadiance(CommandList cmd)
 		{
 			device->BindComputeShader(computeShaders[CSTYPE_VOXELSCENECOPYCLEAR], cmd);
 		}
-		device->Dispatch((UINT)(voxelSceneData.res * voxelSceneData.res * voxelSceneData.res / 256), 1, 1, cmd);
+		device->Dispatch((uint32_t)(voxelSceneData.res * voxelSceneData.res * voxelSceneData.res / 256), 1, 1, cmd);
 		device->EventEnd(cmd);
 
 		if (voxelSceneData.secondaryBounceEnabled)
@@ -6745,14 +6733,14 @@ void VoxelRadiance(CommandList cmd)
 			device->BindResource(CS, textures[TEXTYPE_3D_VOXELRADIANCE], 0, cmd);
 			device->BindResource(CS, &resourceBuffers[RBTYPE_VOXELSCENE], 1, cmd);
 			device->BindComputeShader(computeShaders[CSTYPE_VOXELRADIANCESECONDARYBOUNCE], cmd);
-			device->Dispatch((UINT)(voxelSceneData.res * voxelSceneData.res * voxelSceneData.res / 64), 1, 1, cmd);
+			device->Dispatch((uint32_t)(voxelSceneData.res * voxelSceneData.res * voxelSceneData.res / 64), 1, 1, cmd);
 			device->EventEnd(cmd);
 
 			device->EventBegin("Voxel Scene Clear Normals", cmd);
 			device->UnbindResources(1, 1, cmd);
 			device->BindUAV(CS, &resourceBuffers[RBTYPE_VOXELSCENE], 0, cmd);
 			device->BindComputeShader(computeShaders[CSTYPE_VOXELCLEARONLYNORMAL], cmd);
-			device->Dispatch((UINT)(voxelSceneData.res * voxelSceneData.res * voxelSceneData.res / 256), 1, 1, cmd);
+			device->Dispatch((uint32_t)(voxelSceneData.res * voxelSceneData.res * voxelSceneData.res / 256), 1, 1, cmd);
 			device->EventEnd(cmd);
 
 			result = textures[TEXTYPE_3D_VOXELRADIANCE_HELPER];
@@ -6882,8 +6870,8 @@ void ComputeTiledLightCulling(
 		SAFE_DELETE(textures[TEXTYPE_2D_DEBUGUAV]);
 
 		TextureDesc desc;
-		desc.Width = (UINT)_width;
-		desc.Height = (UINT)_height;
+		desc.Width = (uint32_t)_width;
+		desc.Height = (uint32_t)_height;
 		desc.MipLevels = 1;
 		desc.ArraySize = 1;
 		desc.Format = FORMAT_R8G8B8A8_UNORM;
@@ -6922,7 +6910,7 @@ void ComputeTiledLightCulling(
 		dispatchParams.xDispatchParams_numThreads.x = dispatchParams.xDispatchParams_numThreadGroups.x * TILED_CULLING_BLOCKSIZE;
 		dispatchParams.xDispatchParams_numThreads.y = dispatchParams.xDispatchParams_numThreadGroups.y * TILED_CULLING_BLOCKSIZE;
 		dispatchParams.xDispatchParams_numThreads.z = 1;
-		dispatchParams.xDispatchParams_value0 = (UINT)(frameCulling.culledLights.size() + frameCulling.culledEnvProbes.size() + frameCulling.culledDecals.size());
+		dispatchParams.xDispatchParams_value0 = (uint32_t)(frameCulling.culledLights.size() + frameCulling.culledEnvProbes.size() + frameCulling.culledDecals.size());
 		device->UpdateBuffer(&constantBuffers[CBTYPE_DISPATCHPARAMS], &dispatchParams, cmd);
 		device->BindConstantBuffer(CS, &constantBuffers[CBTYPE_DISPATCHPARAMS], CB_GETBINDSLOT(DispatchParamsCB), cmd);
 
@@ -7054,7 +7042,7 @@ void GenerateMipChain(const Texture& texture, MIPGENFILTER filter, CommandList c
 					break;
 				}
 
-				for (UINT i = 0; i < desc.MipLevels - 1; ++i)
+				for (uint32_t i = 0; i < desc.MipLevels - 1; ++i)
 				{
 					device->BindUAV(CS, &texture, 0, cmd, i + 1);
 					device->BindResource(CS, &texture, TEXSLOT_UNIQUE0, cmd, i);
@@ -7099,7 +7087,7 @@ void GenerateMipChain(const Texture& texture, MIPGENFILTER filter, CommandList c
 					break;
 				}
 
-				for (UINT i = 0; i < desc.MipLevels - 1; ++i)
+				for (uint32_t i = 0; i < desc.MipLevels - 1; ++i)
 				{
 					device->BindUAV(CS, &texture, 0, cmd, i + 1);
 					device->BindResource(CS, &texture, TEXSLOT_UNIQUE0, cmd, i);
@@ -7154,7 +7142,7 @@ void GenerateMipChain(const Texture& texture, MIPGENFILTER filter, CommandList c
 				break;
 			}
 
-			for (UINT i = 0; i < desc.MipLevels - 1; ++i)
+			for (uint32_t i = 0; i < desc.MipLevels - 1; ++i)
 			{
 				device->BindUAV(CS, &texture, 0, cmd, i + 1);
 				device->BindResource(CS, &texture, TEXSLOT_UNIQUE0, cmd, i);
@@ -7204,7 +7192,7 @@ void GenerateMipChain(const Texture& texture, MIPGENFILTER filter, CommandList c
 			break;
 		}
 
-		for (UINT i = 0; i < desc.MipLevels - 1; ++i)
+		for (uint32_t i = 0; i < desc.MipLevels - 1; ++i)
 		{
 			device->BindUAV(CS, &texture, 0, cmd, i + 1);
 			device->BindResource(CS, &texture, TEXSLOT_UNIQUE0, cmd, i);
@@ -7243,7 +7231,7 @@ void GenerateMipChain(const Texture& texture, MIPGENFILTER filter, CommandList c
 	}
 }
 
-void CopyTexture2D(const Texture& dst, UINT DstMIP, UINT DstX, UINT DstY, const Texture& src, UINT SrcMIP, CommandList cmd, BORDEREXPANDSTYLE borderExpand)
+void CopyTexture2D(const Texture& dst, uint32_t DstMIP, uint32_t DstX, uint32_t DstY, const Texture& src, uint32_t SrcMIP, CommandList cmd, BORDEREXPANDSTYLE borderExpand)
 {
 	GraphicsDevice* device = GetDevice();
 
@@ -7662,8 +7650,8 @@ void ManageDecalAtlas()
 			assert(bins.size() == 1 && "The regions won't fit into the texture!");
 
 			TextureDesc desc;
-			desc.Width = (UINT)bins[0].size.w;
-			desc.Height = (UINT)bins[0].size.h;
+			desc.Width = (uint32_t)bins[0].size.w;
+			desc.Height = (uint32_t)bins[0].size.h;
 			desc.MipLevels = 0;
 			desc.ArraySize = 1;
 			desc.Format = FORMAT_R8G8B8A8_UNORM;
@@ -7676,7 +7664,7 @@ void ManageDecalAtlas()
 			device->CreateTexture(&desc, nullptr, &decalAtlas);
 			device->SetName(&decalAtlas, "decalAtlas");
 
-			for (UINT i = 0; i < decalAtlas.GetDesc().MipLevels; ++i)
+			for (uint32_t i = 0; i < decalAtlas.GetDesc().MipLevels; ++i)
 			{
 				int subresource_index;
 				subresource_index = device->CreateSubresource(&decalAtlas, UAV, 0, 1, i, 1);
@@ -7725,7 +7713,7 @@ void RefreshDecalAtlas(CommandList cmd)
 
 	if (repackAtlas_Decal)
 	{
-		for (UINT mip = 0; mip < decalAtlas.GetDesc().MipLevels; ++mip)
+		for (uint32_t mip = 0; mip < decalAtlas.GetDesc().MipLevels; ++mip)
 		{
 			for (auto& it : packedDecals)
 			{
@@ -7859,8 +7847,8 @@ void ManageLightmapAtlas()
 			assert(bins.size() == 1 && "The regions won't fit into the texture!");
 
 			TextureDesc desc;
-			desc.Width = (UINT)bins[0].size.w;
-			desc.Height = (UINT)bins[0].size.h;
+			desc.Width = (uint32_t)bins[0].size.w;
+			desc.Height = (uint32_t)bins[0].size.h;
 			desc.MipLevels = 1;
 			desc.ArraySize = 1;
 			desc.Format = RTFormat_lightmap_global;
@@ -7931,7 +7919,7 @@ void RenderObjectLightMap(const ObjectComponent& object, CommandList cmd)
 		device->RenderPassBegin(object.renderpass_lightmap_accumulate.get(), cmd);
 	}
 
-	ViewPort vp;
+	Viewport vp;
 	vp.Width = (float)desc.Width;
 	vp.Height = (float)desc.Height;
 	device->BindViewports(1, &vp, cmd);
@@ -7948,12 +7936,12 @@ void RenderObjectLightMap(const ObjectComponent& object, CommandList cmd)
 		mesh.vertexBuffer_ATL.get(),
 		mem.buffer,
 	};
-	UINT strides[] = {
+	uint32_t strides[] = {
 		sizeof(MeshComponent::Vertex_POS),
 		sizeof(MeshComponent::Vertex_TEX),
 		sizeof(InstancePrev),
 	};
-	UINT offsets[] = {
+	uint32_t offsets[] = {
 		0,
 		0,
 		mem.offset,
@@ -7979,7 +7967,7 @@ void RenderObjectLightMap(const ObjectComponent& object, CommandList cmd)
 	device->BindConstantBuffer(PS, &constantBuffers[CBTYPE_RAYTRACE], CB_GETBINDSLOT(RaytracingCB), cmd);
 
 	device->BindPipelineState(&PSO_renderlightmap, cmd);
-	device->DrawIndexedInstanced((UINT)mesh.indices.size(), 1, 0, 0, 0, cmd);
+	device->DrawIndexedInstanced((uint32_t)mesh.indices.size(), 1, 0, 0, 0, cmd);
 
 	device->RenderPassEnd(cmd);
 
@@ -8748,7 +8736,7 @@ void Postprocess_SSS(
 
 		device->RenderPassBegin(rt_write, cmd);
 
-		ViewPort vp;
+		Viewport vp;
 		vp.Width = (float)desc.Width;
 		vp.Height = (float)desc.Height;
 		device->BindViewports(1, &vp, cmd);
@@ -9401,7 +9389,7 @@ int GetShadowRes2D() { return SHADOWRES_2D; }
 int GetShadowResCube() { return SHADOWRES_CUBE; }
 void SetTransparentShadowsEnabled(float value) { TRANSPARENTSHADOWSENABLED = value; }
 float GetTransparentShadowsEnabled() { return TRANSPARENTSHADOWSENABLED; }
-XMUINT2 GetInternalResolution() { return XMUINT2((UINT)ceilf(GetDevice()->GetScreenWidth()*GetResolutionScale()), (UINT)ceilf(GetDevice()->GetScreenHeight()*GetResolutionScale())); }
+XMUINT2 GetInternalResolution() { return XMUINT2((uint32_t)ceilf(GetDevice()->GetScreenWidth()*GetResolutionScale()), (uint32_t)ceilf(GetDevice()->GetScreenHeight()*GetResolutionScale())); }
 bool ResolutionChanged()
 {
 	//detect internal resolution change:

--- a/WickedEngine/wiRenderer.h
+++ b/WickedEngine/wiRenderer.h
@@ -32,7 +32,7 @@ namespace wiRenderer
 	static const wiGraphics::FORMAT DSFormat_small = wiGraphics::FORMAT_D16_UNORM;
 	static const wiGraphics::FORMAT DSFormat_small_alias = wiGraphics::FORMAT_R16_TYPELESS;
 
-	inline UINT CombineStencilrefs(STENCILREF engineStencilRef, uint8_t userStencilRef)
+	inline uint32_t CombineStencilrefs(STENCILREF engineStencilRef, uint8_t userStencilRef)
 	{
 		return (userStencilRef << 4) | static_cast<uint8_t>(engineStencilRef);
 	}
@@ -361,8 +361,8 @@ namespace wiRenderer
 	// Performs copy operation even between different texture formats
 	//	Can also expand border region according to desired sampler func
 	void CopyTexture2D(
-		const wiGraphics::Texture& dst, UINT DstMIP, UINT DstX, UINT DstY, 
-		const wiGraphics::Texture& src, UINT SrcMIP, 
+		const wiGraphics::Texture& dst, uint32_t DstMIP, uint32_t DstX, uint32_t DstY, 
+		const wiGraphics::Texture& src, uint32_t SrcMIP, 
 		wiGraphics::CommandList cmd,
 		BORDEREXPANDSTYLE borderExpand = BORDEREXPAND_DISABLE);
 

--- a/WickedEngine/wiResourceManager.cpp
+++ b/WickedEngine/wiResourceManager.cpp
@@ -171,9 +171,9 @@ const void* wiResourceManager::add(const wiHashString& name, Data_Type newType)
 					}
 
 					std::vector<SubresourceData> InitData;
-					for (UINT arrayIndex = 0; arrayIndex < desc.ArraySize; ++arrayIndex)
+					for (uint32_t arrayIndex = 0; arrayIndex < desc.ArraySize; ++arrayIndex)
 					{
-						for (UINT mip = 0; mip < desc.MipLevels; ++mip)
+						for (uint32_t mip = 0; mip < desc.MipLevels; ++mip)
 						{
 							auto imageData = dds.GetImageData(mip, arrayIndex);
 							SubresourceData subresourceData;
@@ -235,16 +235,16 @@ const void* wiResourceManager::add(const wiHashString& name, Data_Type newType)
 					desc.Format = FORMAT_R8G8B8A8_UNORM;
 					desc.Height = static_cast<uint32_t>(height);
 					desc.Width = static_cast<uint32_t>(width);
-					desc.MipLevels = (UINT)log2(std::max(width, height));
+					desc.MipLevels = (uint32_t)log2(std::max(width, height));
 					desc.MiscFlags = 0;
 					desc.Usage = USAGE_DEFAULT;
 
-					UINT mipwidth = width;
+					uint32_t mipwidth = width;
 					std::vector<SubresourceData> InitData(desc.MipLevels);
-					for (UINT mip = 0; mip < desc.MipLevels; ++mip)
+					for (uint32_t mip = 0; mip < desc.MipLevels; ++mip)
 					{
 						InitData[mip].pSysMem = rgb; // attention! we don't fill the mips here correctly, just always point to the mip0 data by default. Mip levels will be created using compute shader when needed!
-						InitData[mip].SysMemPitch = static_cast<UINT>(mipwidth * channelCount);
+						InitData[mip].SysMemPitch = static_cast<uint32_t>(mipwidth * channelCount);
 						mipwidth = std::max(1u, mipwidth / 2);
 					}
 
@@ -253,7 +253,7 @@ const void* wiResourceManager::add(const wiHashString& name, Data_Type newType)
 					assert(SUCCEEDED(hr));
 					device->SetName(image, nameStr);
 
-					for (UINT i = 0; i < image->GetDesc().MipLevels; ++i)
+					for (uint32_t i = 0; i < image->GetDesc().MipLevels; ++i)
 					{
 						int subresource_index;
 						subresource_index = device->CreateSubresource(image, SRV, 0, 1, i, 1);

--- a/WickedEngine/wiSceneSystem.cpp
+++ b/WickedEngine/wiSceneSystem.cpp
@@ -347,7 +347,7 @@ namespace wiSceneSystem
 
 			SubresourceData InitData;
 			InitData.pSysMem = gpuIndexData;
-			bd.ByteWidth = (UINT)(stride * indices.size());
+			bd.ByteWidth = (uint32_t)(stride * indices.size());
 			indexBuffer.reset(new GPUBuffer);
 			hr = device->CreateBuffer(&bd, &InitData, indexBuffer.get());
 			assert(SUCCEEDED(hr));
@@ -392,7 +392,7 @@ namespace wiSceneSystem
 			bd.CPUAccessFlags = 0;
 			bd.BindFlags = BIND_VERTEX_BUFFER | BIND_SHADER_RESOURCE;
 			bd.MiscFlags = RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
-			bd.ByteWidth = (UINT)(sizeof(Vertex_POS) * vertices.size());
+			bd.ByteWidth = (uint32_t)(sizeof(Vertex_POS) * vertices.size());
 
 			SubresourceData InitData;
 			InitData.pSysMem = vertices.data();
@@ -427,7 +427,7 @@ namespace wiSceneSystem
 			bd.BindFlags = BIND_SHADER_RESOURCE;
 			bd.CPUAccessFlags = 0;
 			bd.MiscFlags = RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
-			bd.ByteWidth = (UINT)(sizeof(Vertex_BON) * vertices.size());
+			bd.ByteWidth = (uint32_t)(sizeof(Vertex_BON) * vertices.size());
 
 			SubresourceData InitData;
 			InitData.pSysMem = vertices.data();
@@ -440,7 +440,7 @@ namespace wiSceneSystem
 			bd.CPUAccessFlags = 0;
 			bd.MiscFlags = RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
 
-			bd.ByteWidth = (UINT)(sizeof(Vertex_POS) * vertex_positions.size());
+			bd.ByteWidth = (uint32_t)(sizeof(Vertex_POS) * vertex_positions.size());
 			streamoutBuffer_POS.reset(new GPUBuffer);
 			hr = device->CreateBuffer(&bd, nullptr, streamoutBuffer_POS.get());
 			assert(SUCCEEDED(hr));
@@ -461,7 +461,7 @@ namespace wiSceneSystem
 			bd.BindFlags = BIND_VERTEX_BUFFER | BIND_SHADER_RESOURCE;
 			bd.MiscFlags = 0;
 			bd.StructureByteStride = sizeof(Vertex_TEX);
-			bd.ByteWidth = (UINT)(bd.StructureByteStride * vertices.size());
+			bd.ByteWidth = (uint32_t)(bd.StructureByteStride * vertices.size());
 			bd.Format = Vertex_TEX::FORMAT;
 
 			SubresourceData InitData;
@@ -486,7 +486,7 @@ namespace wiSceneSystem
 			bd.BindFlags = BIND_VERTEX_BUFFER | BIND_SHADER_RESOURCE;
 			bd.MiscFlags = 0;
 			bd.StructureByteStride = sizeof(Vertex_TEX);
-			bd.ByteWidth = (UINT)(bd.StructureByteStride * vertices.size());
+			bd.ByteWidth = (uint32_t)(bd.StructureByteStride * vertices.size());
 			bd.Format = Vertex_TEX::FORMAT;
 
 			SubresourceData InitData;
@@ -505,7 +505,7 @@ namespace wiSceneSystem
 			bd.BindFlags = BIND_VERTEX_BUFFER | BIND_SHADER_RESOURCE;
 			bd.MiscFlags = 0;
 			bd.StructureByteStride = sizeof(Vertex_COL);
-			bd.ByteWidth = (UINT)(bd.StructureByteStride * vertex_colors.size());
+			bd.ByteWidth = (uint32_t)(bd.StructureByteStride * vertex_colors.size());
 			bd.Format = FORMAT_R8G8B8A8_UNORM;
 
 			SubresourceData InitData;
@@ -530,7 +530,7 @@ namespace wiSceneSystem
 			bd.BindFlags = BIND_VERTEX_BUFFER | BIND_SHADER_RESOURCE;
 			bd.MiscFlags = 0;
 			bd.StructureByteStride = sizeof(Vertex_TEX);
-			bd.ByteWidth = (UINT)(bd.StructureByteStride * vertices.size());
+			bd.ByteWidth = (uint32_t)(bd.StructureByteStride * vertices.size());
 			bd.Format = Vertex_TEX::FORMAT;
 
 			SubresourceData InitData;
@@ -880,9 +880,9 @@ namespace wiSceneSystem
 		HRESULT hr;
 
 		TextureDesc desc = lightmap->GetDesc();
-		UINT data_count = desc.Width * desc.Height;
-		UINT data_stride = device->GetFormatStride(desc.Format);
-		UINT data_size = data_count * data_stride;
+		uint32_t data_count = desc.Width * desc.Height;
+		uint32_t data_stride = device->GetFormatStride(desc.Format);
+		uint32_t data_size = data_count * data_stride;
 
 		lightmapWidth = desc.Width;
 		lightmapHeight = desc.Height;
@@ -2236,7 +2236,7 @@ namespace wiSceneSystem
 		return INVALID_ENTITY;
 	}
 
-	PickResult Pick(const RAY& ray, UINT renderTypeMask, uint32_t layerMask, const Scene& scene)
+	PickResult Pick(const RAY& ray, uint32_t renderTypeMask, uint32_t layerMask, const Scene& scene)
 	{
 		PickResult result;
 

--- a/WickedEngine/wiSceneSystem.h
+++ b/WickedEngine/wiSceneSystem.h
@@ -167,7 +167,7 @@ namespace wiSceneSystem
 			assert(value < 16);
 			userStencilRef = value & 0x0F;
 		}
-		inline UINT GetStencilRef() const
+		inline uint32_t GetStencilRef() const
 		{
 			return wiRenderer::CombineStencilrefs(engineStencilRef, userStencilRef);
 		}
@@ -1247,6 +1247,6 @@ namespace wiSceneSystem
 	//	renderTypeMask	:	filter based on render type
 	//	layerMask		:	filter based on layer
 	//	scene			:	the scene that will be traced against the ray
-	PickResult Pick(const RAY& ray, UINT renderTypeMask = RENDERTYPE_OPAQUE, uint32_t layerMask = ~0, const Scene& scene = GetScene());
+	PickResult Pick(const RAY& ray, uint32_t renderTypeMask = RENDERTYPE_OPAQUE, uint32_t layerMask = ~0, const Scene& scene = GetScene());
 }
 

--- a/WickedEngine/wiSceneSystem_BindLua.cpp
+++ b/WickedEngine/wiSceneSystem_BindLua.cpp
@@ -97,12 +97,12 @@ int Pick(lua_State* L)
 		Ray_BindLua* ray = Luna<Ray_BindLua>::lightcheck(L, 1);
 		if (ray != nullptr)
 		{
-			UINT renderTypeMask = RENDERTYPE_OPAQUE;
+			uint32_t renderTypeMask = RENDERTYPE_OPAQUE;
 			uint32_t layerMask = 0xFFFFFFFF;
 			Scene* scene = &wiSceneSystem::GetScene();
 			if (argc > 1)
 			{
-				renderTypeMask = (UINT)wiLua::SGetInt(L, 2);
+				renderTypeMask = (uint32_t)wiLua::SGetInt(L, 2);
 				if (argc > 2)
 				{
 					int mask = wiLua::SGetInt(L, 3);

--- a/WickedEngine/wiTextureHelper.cpp
+++ b/WickedEngine/wiTextureHelper.cpp
@@ -195,7 +195,7 @@ namespace wiTextureHelper
 	}
 
 
-	HRESULT CreateTexture(wiGraphics::Texture& texture, const uint8_t* data, UINT width, UINT height, FORMAT format)
+	HRESULT CreateTexture(wiGraphics::Texture& texture, const uint8_t* data, uint32_t width, uint32_t height, FORMAT format)
 	{
 		if (data == nullptr)
 		{

--- a/WickedEngine/wiTextureHelper.h
+++ b/WickedEngine/wiTextureHelper.h
@@ -17,6 +17,6 @@ namespace wiTextureHelper
 	const wiGraphics::Texture* getTransparent();
 	const wiGraphics::Texture* getColor(wiColor color);
 
-	HRESULT CreateTexture(wiGraphics::Texture& texture, const uint8_t* data, UINT width, UINT height, wiGraphics::FORMAT format = wiGraphics::FORMAT_R8G8B8A8_UNORM);
+	HRESULT CreateTexture(wiGraphics::Texture& texture, const uint8_t* data, uint32_t width, uint32_t height, wiGraphics::FORMAT format = wiGraphics::FORMAT_R8G8B8A8_UNORM);
 };
 

--- a/WickedEngine/wiWidget.cpp
+++ b/WickedEngine/wiWidget.cpp
@@ -48,10 +48,10 @@ void wiWidget::Update(wiGUI* gui, float dt)
 	XMStoreFloat3(&translation, T);
 	XMStoreFloat3(&scale, S);
 
-	scissorRect.bottom = (LONG)(translation.y + scale.y);
-	scissorRect.left = (LONG)(translation.x);
-	scissorRect.right = (LONG)(translation.x + scale.x);
-	scissorRect.top = (LONG)(translation.y);
+	scissorRect.bottom = (int32_t)(translation.y + scale.y);
+	scissorRect.left = (int32_t)(translation.x);
+	scissorRect.right = (int32_t)(translation.x + scale.x);
+	scissorRect.top = (int32_t)(translation.y);
 }
 void wiWidget::AttachTo(TransformComponent* parent)
 {
@@ -1843,7 +1843,7 @@ void wiColorPicker::Render(const wiGUI* gui, CommandList cmd) const
 
 			GPUBufferDesc desc;
 			desc.BindFlags = BIND_VERTEX_BUFFER;
-			desc.ByteWidth = (UINT)(vertices_saturation.size() * sizeof(Vertex));
+			desc.ByteWidth = (uint32_t)(vertices_saturation.size() * sizeof(Vertex));
 			desc.CPUAccessFlags = CPU_ACCESS_WRITE;
 			desc.MiscFlags = 0;
 			desc.StructureByteStride = 0;
@@ -1910,7 +1910,7 @@ void wiColorPicker::Render(const wiGUI* gui, CommandList cmd) const
 
 			GPUBufferDesc desc;
 			desc.BindFlags = BIND_VERTEX_BUFFER;
-			desc.ByteWidth = (UINT)(vertices.size() * sizeof(Vertex));
+			desc.ByteWidth = (uint32_t)(vertices.size() * sizeof(Vertex));
 			desc.CPUAccessFlags = 0;
 			desc.MiscFlags = 0;
 			desc.StructureByteStride = 0;
@@ -1937,7 +1937,7 @@ void wiColorPicker::Render(const wiGUI* gui, CommandList cmd) const
 
 			GPUBufferDesc desc;
 			desc.BindFlags = BIND_VERTEX_BUFFER;
-			desc.ByteWidth = (UINT)(vertices.size() * sizeof(Vertex));
+			desc.ByteWidth = (uint32_t)(vertices.size() * sizeof(Vertex));
 			desc.CPUAccessFlags = 0;
 			desc.MiscFlags = 0;
 			desc.StructureByteStride = 0;
@@ -1978,7 +1978,7 @@ void wiColorPicker::Render(const wiGUI* gui, CommandList cmd) const
 
 			GPUBufferDesc desc;
 			desc.BindFlags = BIND_VERTEX_BUFFER;
-			desc.ByteWidth = (UINT)sizeof(vertices);
+			desc.ByteWidth = (uint32_t)sizeof(vertices);
 			desc.CPUAccessFlags = 0;
 			desc.MiscFlags = 0;
 			desc.StructureByteStride = 0;
@@ -2001,7 +2001,7 @@ void wiColorPicker::Render(const wiGUI* gui, CommandList cmd) const
 
 			GPUBufferDesc desc;
 			desc.BindFlags = BIND_VERTEX_BUFFER;
-			desc.ByteWidth = (UINT)sizeof(vertices);
+			desc.ByteWidth = (uint32_t)sizeof(vertices);
 			desc.CPUAccessFlags = 0;
 			desc.MiscFlags = 0;
 			desc.StructureByteStride = 0;
@@ -2056,7 +2056,7 @@ void wiColorPicker::Render(const wiGUI* gui, CommandList cmd) const
 		const GPUBuffer* vbs[] = {
 			&vb_saturation,
 		};
-		const UINT strides[] = {
+		const uint32_t strides[] = {
 			sizeof(Vertex),
 		};
 		wiRenderer::GetDevice()->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);
@@ -2074,7 +2074,7 @@ void wiColorPicker::Render(const wiGUI* gui, CommandList cmd) const
 		const GPUBuffer* vbs[] = {
 			&vb_hue,
 		};
-		const UINT strides[] = {
+		const uint32_t strides[] = {
 			sizeof(Vertex),
 		};
 		wiRenderer::GetDevice()->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);
@@ -2101,7 +2101,7 @@ void wiColorPicker::Render(const wiGUI* gui, CommandList cmd) const
 		const GPUBuffer* vbs[] = {
 			&vb_picker_hue,
 		};
-		const UINT strides[] = {
+		const uint32_t strides[] = {
 			sizeof(Vertex),
 		};
 		wiRenderer::GetDevice()->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);
@@ -2152,7 +2152,7 @@ void wiColorPicker::Render(const wiGUI* gui, CommandList cmd) const
 		const GPUBuffer* vbs[] = {
 			&vb_picker_saturation,
 		};
-		const UINT strides[] = {
+		const uint32_t strides[] = {
 			sizeof(Vertex),
 		};
 		wiRenderer::GetDevice()->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);
@@ -2170,7 +2170,7 @@ void wiColorPicker::Render(const wiGUI* gui, CommandList cmd) const
 		const GPUBuffer* vbs[] = {
 			&vb_preview,
 		};
-		const UINT strides[] = {
+		const uint32_t strides[] = {
 			sizeof(Vertex),
 		};
 		wiRenderer::GetDevice()->BindVertexBuffers(vbs, 0, ARRAYSIZE(vbs), strides, nullptr, cmd);


### PR DESCRIPTION
Fixes #54 