### PR TITLE
Set the correct type on the texture returned from GetBackBuffer

### DIFF
--- a/WickedEngine/wiGraphicsDevice_DX11.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX11.cpp
@@ -1281,6 +1281,7 @@ Texture GraphicsDevice_DX11::GetBackBuffer()
 {
 	Texture result;
 	result.resource = (wiCPUHandle)backBuffer;
+	result.type = GPUResource::GPU_RESOURCE_TYPE::TEXTURE;
 
 	D3D11_TEXTURE2D_DESC desc;
 	backBuffer->GetDesc(&desc);

--- a/WickedEngine/wiGraphicsDevice_DX12.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX12.cpp
@@ -1996,6 +1996,7 @@ namespace wiGraphics
 	{
 		Texture result;
 		result.resource = (wiCPUHandle)GetFrameResources().backBuffer;
+		result.type = GPUResource::GPU_RESOURCE_TYPE::TEXTURE;
 		result.RTV = (wiCPUHandle)GetFrameResources().backBufferRTV.ptr;
 		return result;
 	}


### PR DESCRIPTION
This resolves the assertion error caused when trying to take a screenshot. I'm fairly new to the codebase so please let me know if there is a better/more appropriate way of fixing this. 