### PR TITLE
Use wiResource structs instead of texture pointers for deferred mip g…

### DIFF
--- a/Editor/ModelImporter_GLTF.cpp
+++ b/Editor/ModelImporter_GLTF.cpp
@@ -138,8 +138,6 @@ std::shared_ptr<wiResource> RegisterTexture(tinygltf::Image *image, const string
 
 				if (tex != nullptr)
 				{
-					wiRenderer::AddDeferredMIPGen(tex, true);
-
 					if (image->uri.empty())
 					{
 						// If the texture was embedded, export it as a file:
@@ -154,7 +152,9 @@ std::shared_ptr<wiResource> RegisterTexture(tinygltf::Image *image, const string
 					}
 
 					// We loaded the texture2d, so register to the resource manager to be retrieved later:
-					return wiResourceManager::Register(image->uri, tex, wiResource::IMAGE);
+					auto resource = wiResourceManager::Register(image->uri, tex, wiResource::IMAGE);
+					wiRenderer::AddDeferredMIPGen(resource, true);
+					return resource;
 				}
 			}
 			else

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -167,7 +167,7 @@ std::vector<PaintRadius> paintrads;
 XMFLOAT4 waterPlane = XMFLOAT4(0, 1, 0, 0);
 
 wiSpinLock deferredMIPGenLock;
-std::vector<std::pair<const Texture*, bool>> deferredMIPGens;
+std::vector<std::pair<std::shared_ptr<wiResource>, bool>> deferredMIPGens;
 
 wiGPUBVH sceneBVH;
 
@@ -4026,7 +4026,7 @@ void UpdateRenderData(CommandList cmd)
 	{
 		MIPGEN_OPTIONS mipopt;
 		mipopt.preserve_coverage = it.second;
-		GenerateMipChain(*it.first, MIPGENFILTER_LINEAR, cmd, mipopt);
+		GenerateMipChain(*it.first->texture, MIPGENFILTER_LINEAR, cmd, mipopt);
 	}
 	deferredMIPGens.clear();
 	deferredMIPGenLock.unlock();
@@ -11166,10 +11166,10 @@ void DrawPaintRadius(const PaintRadius& paintrad)
 	paintrads.push_back(paintrad);
 }
 
-void AddDeferredMIPGen(const Texture* tex, bool preserve_coverage)
+void AddDeferredMIPGen(std::shared_ptr<wiResource> resource, bool preserve_coverage)
 {
 	deferredMIPGenLock.lock();
-	deferredMIPGens.push_back(std::make_pair(tex, preserve_coverage));
+	deferredMIPGens.push_back(std::make_pair(resource, preserve_coverage));
 	deferredMIPGenLock.unlock();
 }
 

--- a/WickedEngine/wiRenderer.h
+++ b/WickedEngine/wiRenderer.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 struct RAY;
+struct wiResource;
 
 namespace wiRenderer
 {
@@ -536,7 +537,7 @@ namespace wiRenderer
 	void DrawPaintRadius(const PaintRadius& paintrad);
 
 	// Add a texture that should be mipmapped whenever it is feasible to do so
-	void AddDeferredMIPGen(const wiGraphics::Texture* tex, bool preserve_coverage = false);
+	void AddDeferredMIPGen(std::shared_ptr<wiResource> res, bool preserve_coverage = false);
 
 	struct CustomShader
 	{

--- a/WickedEngine/wiResourceManager.cpp
+++ b/WickedEngine/wiResourceManager.cpp
@@ -266,11 +266,6 @@ namespace wiResourceManager
 						assert(subresource_index == i);
 					}
 
-					if (image != nullptr && image->GetDesc().MipLevels > 1)
-					{
-						wiRenderer::AddDeferredMIPGen(image, true);
-					}
-
 					success = image;
 				}
 
@@ -293,6 +288,12 @@ namespace wiResourceManager
 		{
 			resource->data = success;
 			resource->type = type;
+
+			if (type == wiResource::IMAGE && resource->texture->GetDesc().MipLevels > 1)
+			{
+				wiRenderer::AddDeferredMIPGen(resource, true);
+			}
+
 			return resource;
 		}
 


### PR DESCRIPTION
…eneration

Taking a quick stab at fixing a crash I was running into pretty rarely with deferred mipmap generation. I modeled this after the [bvh fix](https://github.com/turanszkij/WickedEngine/commit/a92d5e7665776bf9eb60e0e7f00f952ef0647c7a#diff-7f6c8a0f0c1e358ba75c62db5bc000acL77) to use wiResources instead of raw texture pointers

A stack trace of the crash is attached.
![deferred-mip-crash](https://user-images.githubusercontent.com/128300/79677532-aa05fb00-81af-11ea-976c-9d97b022b29a.png)
