### PR TITLE
Inline raytracing shaderpath update

### DIFF
--- a/WickedEngine/MainComponent.cpp
+++ b/WickedEngine/MainComponent.cpp
@@ -104,6 +104,11 @@ void MainComponent::Initialize()
 #endif
 		}
 
+		if (wiRenderer::GetDevice()->CheckCapability(GRAPHICSDEVICE_CAPABILITY_RAYTRACING_INLINE))
+		{
+		    wiRenderer::SetShaderPath(wiRenderer::GetShaderPath() + "inlinert/");
+		}
+
 	}
 
 

--- a/WickedEngine/compile_shaders_hlsl6.py
+++ b/WickedEngine/compile_shaders_hlsl6.py
@@ -1,4 +1,5 @@
 import os
+import threading
 import xml.etree.ElementTree as ET
 from subprocess import check_output
 
@@ -9,11 +10,20 @@ from subprocess import check_output
 tree = ET.parse('Shaders_SOURCE.vcxitems.filters')
 root = tree.getroot()
 
-outputdir = "hlsl6"
-
 from pathlib import Path
-Path("shaders/" + outputdir).mkdir(parents=True, exist_ok=True)
+Path("shaders/hlsl6").mkdir(parents=True, exist_ok=True)
+Path("shaders/hlsl6/inlinert").mkdir(parents=True, exist_ok=True)
 
+threads = []
+
+def compile(cmd):
+    try:
+        print(cmd)
+        result = check_output(cmd, shell=True).decode()
+        if len(result) > 0:
+            print(result)
+    except:
+        print("DXC error")
 
 namespace = "{http://schemas.microsoft.com/developer/msbuild/2003}"
 for item in root.iter():
@@ -48,25 +58,36 @@ for item in root.iter():
                 cmd += "as"
 
             cmd += "_6_5 "
-
-            cmd += " -Fo " + "shaders/" + outputdir + "/" + os.path.splitext(name)[0] + ".cso "
             
             cmd += " -flegacy-macro-expansion "
             
             cmd += " -D HLSL6 "
-            #cmd += " -D RAYTRACING_INLINE "
-            #cmd += " -D RAYTRACING_GEOMETRYINDEX "
-            
-            print(cmd)
-            
-            try:
-                print(check_output(cmd, shell=True).decode())
-            except:
-                print("DXC error")
+
+            output_name = os.path.splitext(name)[0] + ".cso "
+
+            #inline raytracing disabled:
+            cmd1 = cmd
+            cmd1 += " -Fo " + "shaders/hlsl6/" + output_name
+            t = threading.Thread(target=compile, args=(cmd1,))
+            threads.append(t)
+            t.start()
+
+                
+            #inline raytracing enabled:
+            cmd2 = cmd
+            cmd2 += " -D RAYTRACING_INLINE "
+            cmd2 += " -D RAYTRACING_GEOMETRYINDEX "
+            cmd2 += " -Fo " + "shaders/hlsl6/inlinert/" + output_name
+            t = threading.Thread(target=compile, args=(cmd2,))
+            threads.append(t)
+            t.start()
             
             break
             
     except:
         continue
 
+
+for t in threads:
+    t.join()
 

--- a/WickedEngine/globals.hlsli
+++ b/WickedEngine/globals.hlsli
@@ -7,7 +7,9 @@ TEXTURE2D(texture_depth, float, TEXSLOT_DEPTH);
 TEXTURE2D(texture_lineardepth, float, TEXSLOT_LINEARDEPTH);
 TEXTURE2D(texture_gbuffer0, float4, TEXSLOT_GBUFFER0);
 TEXTURE2D(texture_gbuffer1, float4, TEXSLOT_GBUFFER1);
+#ifdef RAYTRACING_INLINE
 RAYTRACINGACCELERATIONSTRUCTURE(scene_acceleration_structure, TEXSLOT_ACCELERATION_STRUCTURE);
+#endif // RAYTRACING_INLINE
 TEXTURECUBE(texture_globalenvmap, float4, TEXSLOT_GLOBALENVMAP);
 TEXTURE2D(texture_globallightmap, float4, TEXSLOT_GLOBALLIGHTMAP);
 TEXTURECUBEARRAY(texture_envmaparray, float4, TEXSLOT_ENVMAPARRAY);

--- a/WickedEngine/rtaoLIB.hlsl
+++ b/WickedEngine/rtaoLIB.hlsl
@@ -2,6 +2,10 @@
 #include "ShaderInterop_Postprocess.h"
 #include "raytracingHF.hlsli"
 
+#ifndef RAYTRACING_INLINE
+RAYTRACINGACCELERATIONSTRUCTURE(scene_acceleration_structure, TEXSLOT_ACCELERATION_STRUCTURE);
+#endif // RAYTRACING_INLINE
+
 TEXTURE2D(texture_normals, float3, TEXSLOT_ONDEMAND0);
 
 RWTEXTURE2D(output, unorm float, 0);

--- a/WickedEngine/rtreflectionLIB.hlsl
+++ b/WickedEngine/rtreflectionLIB.hlsl
@@ -6,6 +6,10 @@
 #include "stochasticSSRHF.hlsli"
 #include "lightingHF.hlsli"
 
+#ifndef RAYTRACING_INLINE
+RAYTRACINGACCELERATIONSTRUCTURE(scene_acceleration_structure, TEXSLOT_ACCELERATION_STRUCTURE);
+#endif // RAYTRACING_INLINE
+
 RWTEXTURE2D(output, float4, 0);
 
 ConstantBuffer<ShaderMaterial> subsets_material[MAX_DESCRIPTOR_INDEXING] : register(b0, space1);

--- a/WickedEngine/wiFont.cpp
+++ b/WickedEngine/wiFont.cpp
@@ -559,7 +559,7 @@ float textHeight_internal(const T* text, const wiFontParams& params)
 template<typename T>
 void Draw_internal(const T* text, size_t text_length, const wiFontParams& params, CommandList cmd)
 {
-	if (!initialized.load())
+	if (text_length <= 0 || !initialized.load())
 	{
 		return;
 	}
@@ -584,6 +584,12 @@ void Draw_internal(const T* text, size_t text_length, const wiFontParams& params
 	}
 	volatile FontVertex* textBuffer = (volatile FontVertex*)mem.data;
 	const uint32_t quadCount = WriteVertices(textBuffer, text, newProps);
+	UpdatePendingGlyphs();
+
+	if (quadCount <= 0)
+	{
+	    return;
+	}
 
 	device->EventBegin("Font", cmd);
 
@@ -625,8 +631,6 @@ void Draw_internal(const T* text, size_t text_length, const wiFontParams& params
 	device->DrawInstanced(4, quadCount, 0, 0, cmd);
 
 	device->EventEnd(cmd);
-
-	UpdatePendingGlyphs();
 }
 
 void Draw(const char* text, const wiFontParams& params, CommandList cmd)

--- a/WickedEngine/wiVersion.cpp
+++ b/WickedEngine/wiVersion.cpp
@@ -9,7 +9,7 @@ namespace wiVersion
 	// minor features, major updates, breaking API changes
 	const int minor = 49;
 	// minor bug fixes, alterations, refactors, updates
-	const int revision = 11;
+	const int revision = 13;
 
 	const std::string version_string = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(revision);
 


### PR DESCRIPTION
Because we can only load raytracing shaders if there is driver support for it. We choose shaderpath at runtime based on driver support, but shaders are precompiled. raytracing can be in any shader with inline raytracing.