### PR TITLE
Fix - add normal for morph target

### DIFF
--- a/Editor/ModelImporter_GLTF.cpp
+++ b/Editor/ModelImporter_GLTF.cpp
@@ -812,6 +812,15 @@ void ImportModel_GLTF(const std::string& fileName, Scene& scene)
 								mesh.targets[i].vertex_positions[vertexOffset + j] = ((XMFLOAT3*)data)[j];
 							}
 						}
+						else if (!attr_name.compare("NORMAL"))
+						{
+						    mesh.targets[i].vertex_normals.resize(vertexOffset + vertexCount);
+						    assert(stride == 12);
+						    for (size_t j = 0; j < vertexCount; ++j)
+						    {
+								mesh.targets[i].vertex_normals[vertexOffset + j] = ((XMFLOAT3*)data)[j];
+						    }
+						}
 				    }
 				}
 			}

--- a/WickedEngine/wiScene.h
+++ b/WickedEngine/wiScene.h
@@ -309,6 +309,7 @@ namespace wiScene
 		struct MeshMorphTarget
 		{
 		    std::vector<XMFLOAT3> vertex_positions;
+		    std::vector<XMFLOAT3> vertex_normals;
 		    float_t weight;
 		};
 		std::vector<MeshMorphTarget> targets;

--- a/WickedEngine/wiScene_Serializers.cpp
+++ b/WickedEngine/wiScene_Serializers.cpp
@@ -344,6 +344,7 @@ namespace wiScene
 			    for (size_t i = 0; i < targetCount; ++i)
 			    {
 					archive >> targets[i].vertex_positions;
+					archive >> targets[i].vertex_normals;
 					archive >> targets[i].weight;
 			    }
 			}
@@ -402,8 +403,9 @@ namespace wiScene
 			    archive << targets.size();
 			    for (size_t i = 0; i < targets.size(); ++i)
 			    {
-				archive << targets[i].vertex_positions;
-				archive << targets[i].weight;
+					archive << targets[i].vertex_positions;
+					archive << targets[i].vertex_normals;
+					archive << targets[i].weight;
 			    }
 			}
 


### PR DESCRIPTION
I don't want to increase archive version so here is a quick fix for morph target. Hopefully no one has created the wiscene asset using last committed version.

In blender export, glTF file contains both position and normal (without tangent) which I think might be used in updating the normal for morph target. There is no implementation for normal yet. Just prepare the file to prevent breaking the assets.

Fix #179