### PR TITLE
Linux SDL2 build fix

### DIFF
--- a/WickedEngine/CMakeLists.txt
+++ b/WickedEngine/CMakeLists.txt
@@ -86,7 +86,7 @@ target_include_directories(WickedEngine PUBLIC
 
 target_link_libraries(WickedEngine PUBLIC
 	Vulkan::Vulkan
-	${SDL2_LIBRARIES}
+	${SDL2_LIBRARIES} SDL2::SDL2
 	Bullet
 	LUA
 	Utility


### PR DESCRIPTION
FindPackage(SDL2) update

SDL2 cmake package was updated on certain systems, breaking the
compilation. This fixes it.