### PR TITLE
D3D12: Fix OBJECT_DELETED_WHILE_STILL_IN_USE errors upon swapchain resize and shutdown

### DIFF
--- a/WickedEngine/wiGraphicsDevice_DX12.h
+++ b/WickedEngine/wiGraphicsDevice_DX12.h
@@ -144,7 +144,12 @@ namespace wiGraphics
 		std::mutex copyQueueLock;
 		bool copyQueueUse = false;
 		Microsoft::WRL::ComPtr<ID3D12Fence> copyFence; // GPU only
+		HANDLE copyFenceEvent;
 		UINT64 copyFenceValue = 0;
+
+		Microsoft::WRL::ComPtr<ID3D12Fence> directFence;
+		HANDLE directFenceEvent;
+		UINT64 directFenceValue = 0;
 
 		struct FrameResources
 		{


### PR DESCRIPTION
GraphicsDevice_DX12::WaitForGPU() now waits for the copy and direct queues to complete rather than waiting for the frame fence which was not sufficient.

This fixes OBJECT_DELETED_WHILE_STILL_IN_USE errors upon swapchain resize and shutdown.