### PR TITLE
Supports for building using CMake on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,6 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 project(WickedEngine)
 
-# Configure CMake global variables
-set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
-set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
-set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
-
 if (WIN32)
     set(PLATFORM "Windows")
     add_compile_definitions(WIN32=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,29 @@
 cmake_minimum_required(VERSION 3.7)
 
+# Configure CMake global variables
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Use solution folders to organize projects
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 project(WickedEngine)
 
-set(CMAKE_CXX_STANDARD 17)
+# Configure CMake global variables
+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
+set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
+set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
 
 if (WIN32)
     set(PLATFORM "Windows")
     add_compile_definitions(WIN32=1)
     # add_compile_definitions(_WIN32=1) this is a given from the compiler
+    set(DXC_TARGET "${CMAKE_CURRENT_SOURCE_DIR}/WickedEngine/dxc.exe")
 elseif(UNIX)
     set(PLATFORM "SDL2")
     add_compile_definitions(SDL2=1)
+    set(DXC_TARGET "dxc")
 endif()
 
 add_subdirectory(WickedEngine)

--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -1,38 +1,58 @@
-find_package(Threads REQUIRED)
+if (NOT WIN32)
+	find_package(Threads REQUIRED)
+endif ()
 
-add_executable(WickedEngineEditor 
-    main_${PLATFORM}.cpp
-    $<$<STREQUAL:${PLATFORM},Windows>:App_${PLATFORM}.cpp>
-    AnimationWindow.cpp
-    CameraWindow.cpp
-    DecalWindow.cpp
-    Editor.cpp
-    EmitterWindow.cpp
-    EnvProbeWindow.cpp
-    ForceFieldWindow.cpp
-    HairParticleWindow.cpp
-    IKWindow.cpp
-    LayerWindow.cpp
-    LightWindow.cpp
-    MaterialWindow.cpp
-    MeshWindow.cpp
-    ModelImporter_GLTF.cpp
-    ModelImporter_OBJ.cpp
-    NameWindow.cpp
-    ObjectWindow.cpp
-    PaintToolWindow.cpp
-    PostprocessWindow.cpp
-    RendererWindow.cpp
-    SoundWindow.cpp
-    SpringWindow.cpp
-    stdafx.cpp
-    TransformWindow.cpp
-    Translator.cpp
-    WeatherWindow.cpp
-    xatlas.cpp
+set (SOURCE_FILES
+	main_${PLATFORM}.cpp
+	#$<$<STREQUAL:${PLATFORM},Windows>:App_${PLATFORM}.cpp>
+	AnimationWindow.cpp
+	CameraWindow.cpp
+	DecalWindow.cpp
+	Editor.cpp
+	EmitterWindow.cpp
+	EnvProbeWindow.cpp
+	ForceFieldWindow.cpp
+	HairParticleWindow.cpp
+	IKWindow.cpp
+	LayerWindow.cpp
+	LightWindow.cpp
+	MaterialWindow.cpp
+	MeshWindow.cpp
+	ModelImporter_GLTF.cpp
+	ModelImporter_OBJ.cpp
+	NameWindow.cpp
+	ObjectWindow.cpp
+	PaintToolWindow.cpp
+	PostprocessWindow.cpp
+	RendererWindow.cpp
+	SoundWindow.cpp
+	SpringWindow.cpp
+	stdafx.cpp
+	TransformWindow.cpp
+	Translator.cpp
+	WeatherWindow.cpp
+	xatlas.cpp
 )
 
-target_link_libraries(WickedEngineEditor PUBLIC
-	WickedEngine 
-	Threads::Threads
-)
+if (WIN32)
+	list (APPEND SOURCE_FILES
+		Editor.rc
+	)
+
+	add_executable(WickedEngineEditor WIN32 ${SOURCE_FILES})
+
+	target_link_libraries(WickedEngineEditor PUBLIC
+		WickedEngine_Windows 
+	)
+
+	if (MSVC)
+		set_property(TARGET Tests PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+	endif ()
+else ()
+	add_executable(WickedEngineEditor ${SOURCE_FILES})
+
+	target_link_libraries(WickedEngineEditor PUBLIC
+		WickedEngine 
+		Threads::Threads
+	)
+endif ()

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_package(Threads REQUIRED)
+if (NOT WIN32)
+	find_package(Threads REQUIRED)
+endif ()
 
 set (SOURCE_FILES
 	stdafx.cpp

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,12 +1,37 @@
 find_package(Threads REQUIRED)
 
-add_executable(Tests
-	main_SDL2.cpp
+set (SOURCE_FILES
 	stdafx.cpp
 	Tests.cpp
+	Tests.h
+	stdafx.h
 )
 
-target_link_libraries(Tests PUBLIC 
-	WickedEngine
-	Threads::Threads
-)
+if (WIN32)
+	list (APPEND SOURCE_FILES
+		main_Windows.cpp
+		main_Windows.h
+		Tests.rc
+	)
+
+	add_executable(Tests WIN32 ${SOURCE_FILES})
+
+	target_link_libraries(Tests PUBLIC 
+		WickedEngine_Windows
+	)
+else()
+	list (APPEND SOURCE_FILES
+		main_SDL2.cpp
+	)
+
+	add_executable(Tests ${SOURCE_FILES})
+
+	target_link_libraries(Tests PUBLIC 
+		WickedEngine
+		Threads::Threads
+	)
+endif ()
+
+if (MSVC)
+	set_property(TARGET Tests PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+endif ()

--- a/WickedEngine/BULLET/CMakeLists.txt
+++ b/WickedEngine/BULLET/CMakeLists.txt
@@ -144,3 +144,4 @@ add_library(Bullet STATIC
 )
 
 target_include_directories(Bullet PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+set_property(TARGET "Bullet" PROPERTY FOLDER "ThirdParty")

--- a/WickedEngine/CMakeLists.txt
+++ b/WickedEngine/CMakeLists.txt
@@ -1,118 +1,137 @@
-find_package(Vulkan REQUIRED)
-find_package(SDL2 REQUIRED)
 
-if(NOT TARGET SDL2::SDL2)
-	# using old SDL2 cmake, lets create a SDL2 target ourselves
-	find_library(SDL2_LIBRARY_FILE_LOCATION SDL2 REQUIRED)
+if (WIN32)
+	# TODO: Choose whether to use SDL2 on windows as well
+	set(TARGET_NAME WickedEngine_Windows)
+else ()
+	set(TARGET_NAME WickedEngine)
+	find_package(Vulkan REQUIRED)
+	find_package(SDL2 REQUIRED)
 
-	add_library(SDL2::SDL2 SHARED IMPORTED)
-	set_target_properties(SDL2::SDL2 PROPERTIES
-		INTERFACE_INCLUDE_DIRECTORIES ${SDL2_INCLUDE_DIRS}
-		INTERFACE_LINK_LIBRARIES ${SDL2_LIBRARIES}
-		IMPORTED_LOCATION ${SDL2_LIBRARY_FILE_LOCATION}
-	)
+	if(NOT TARGET SDL2::SDL2)
+		# using old SDL2 cmake, lets create a SDL2 target ourselves
+		find_library(SDL2_LIBRARY_FILE_LOCATION SDL2 REQUIRED)
 
-	unset(SDL2_LIBRARY_FILE_LOCATION)
-endif()
+		add_library(SDL2::SDL2 SHARED IMPORTED)
+		set_target_properties(SDL2::SDL2 PROPERTIES
+			INTERFACE_INCLUDE_DIRECTORIES ${SDL2_INCLUDE_DIRS}
+			INTERFACE_LINK_LIBRARIES ${SDL2_LIBRARIES}
+			IMPORTED_LOCATION ${SDL2_LIBRARY_FILE_LOCATION}
+		)
+
+		unset(SDL2_LIBRARY_FILE_LOCATION)
+	endif()
+endif()    
 
 add_subdirectory(BULLET)
 add_subdirectory(LUA)
 add_subdirectory(Utility)
 add_subdirectory(shaders)
 
-add_library(WickedEngine STATIC
-    LoadingScreen.cpp
-    LoadingScreen_BindLua.cpp
-    MainComponent.cpp
-    MainComponent_BindLua.cpp
-    Matrix_BindLua.cpp
-    RenderPath_BindLua.cpp
-    RenderPath2D.cpp
-    RenderPath2D_BindLua.cpp
-    RenderPath3D.cpp
-    RenderPath3D_BindLua.cpp
-    RenderPath3D_PathTracing.cpp
-    SpriteAnim_BindLua.cpp
-    Texture_BindLua.cpp
-    Vector_BindLua.cpp
-    wiArchive.cpp
-    wiAudio.cpp
-    wiAudio_BindLua.cpp
-    wiBackLog.cpp
-    wiBackLog_BindLua.cpp
-    wiEmittedParticle.cpp
-    wiEvent.cpp
-    wiFadeManager.cpp
-    wiFFTGenerator.cpp
-    wiFont.cpp
-    wiGPUBVH.cpp
-    wiGPUSortLib.cpp
-    wiGraphicsDevice.cpp
-    # wiGraphicsDevice_DX11.cpp
-    # wiGraphicsDevice_DX12.cpp
-    wiGraphicsDevice_Vulkan.cpp
-    wiGUI.cpp
-    wiHairParticle.cpp
-    wiHelper.cpp
-    wiImage.cpp
-    wiImageParams_BindLua.cpp
-    wiInitializer.cpp
-    wiInput.cpp
-    wiInput_BindLua.cpp
-    wiIntersect.cpp
-    wiIntersect_BindLua.cpp
-    wiJobSystem.cpp
-    wiLua.cpp
-    wiMath.cpp
-    wiNetwork_BindLua.cpp
-    wiNetwork_Linux.cpp
-    # wiNetwork_UWP.cpp
-    # wiNetwork_Windows.cpp
-    wiOcean.cpp
-    wiPhysicsEngine_Bullet.cpp
-    wiProfiler.cpp
-    wiRandom.cpp
-    wiRawInput.cpp
-    wiRectPacker.cpp
-    wiRenderer.cpp
-    wiRenderer_BindLua.cpp
-    wiResourceManager.cpp
-    wiScene.cpp
-    wiScene_BindLua.cpp
-    wiScene_Serializers.cpp
-    wiSDLInput.cpp
-    wiSprite.cpp
-    wiSprite_BindLua.cpp
-    wiSpriteFont.cpp
-    wiSpriteFont_BindLua.cpp
-    wiStartupArguments.cpp
-    wiTextureHelper.cpp
-    wiTimer.cpp
-    wiVersion.cpp
-    wiWidget.cpp
-    wiXInput.cpp
+add_library(${TARGET_NAME} STATIC
+	LoadingScreen.cpp
+	LoadingScreen_BindLua.cpp
+	MainComponent.cpp
+	MainComponent_BindLua.cpp
+	Matrix_BindLua.cpp
+	RenderPath_BindLua.cpp
+	RenderPath2D.cpp
+	RenderPath2D_BindLua.cpp
+	RenderPath3D.cpp
+	RenderPath3D_BindLua.cpp
+	RenderPath3D_PathTracing.cpp
+	SpriteAnim_BindLua.cpp
+	Texture_BindLua.cpp
+	Vector_BindLua.cpp
+	wiArchive.cpp
+	wiAudio.cpp
+	wiAudio_BindLua.cpp
+	wiBackLog.cpp
+	wiBackLog_BindLua.cpp
+	wiEmittedParticle.cpp
+	wiEvent.cpp
+	wiFadeManager.cpp
+	wiFFTGenerator.cpp
+	wiFont.cpp
+	wiGPUBVH.cpp
+	wiGPUSortLib.cpp
+	wiGraphicsDevice.cpp
+	wiGraphicsDevice_DX11.cpp
+	wiGraphicsDevice_DX12.cpp
+	wiGraphicsDevice_Vulkan.cpp
+	wiGUI.cpp
+	wiHairParticle.cpp
+	wiHelper.cpp
+	wiImage.cpp
+	wiImageParams_BindLua.cpp
+	wiInitializer.cpp
+	wiInput.cpp
+	wiInput_BindLua.cpp
+	wiIntersect.cpp
+	wiIntersect_BindLua.cpp
+	wiJobSystem.cpp
+	wiLua.cpp
+	wiMath.cpp
+	wiNetwork_BindLua.cpp
+	wiNetwork_Linux.cpp
+	wiNetwork_Windows.cpp
+	wiNetwork_UWP.cpp
+	wiOcean.cpp
+	wiPhysicsEngine_Bullet.cpp
+	wiProfiler.cpp
+	wiRandom.cpp
+	wiRawInput.cpp
+	wiRectPacker.cpp
+	wiRenderer.cpp
+	wiRenderer_BindLua.cpp
+	wiResourceManager.cpp
+	wiScene.cpp
+	wiScene_BindLua.cpp
+	wiScene_Serializers.cpp
+	wiSDLInput.cpp
+	wiSprite.cpp
+	wiSprite_BindLua.cpp
+	wiSpriteFont.cpp
+	wiSpriteFont_BindLua.cpp
+	wiStartupArguments.cpp
+	wiTextureHelper.cpp
+	wiTimer.cpp
+	wiVersion.cpp
+	wiWidget.cpp
+	wiXInput.cpp
 	wiBlueNoise.cpp
 )
 
-target_include_directories(WickedEngine PUBLIC
+target_include_directories(${TARGET_NAME} PUBLIC
 	${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_link_libraries(WickedEngine PUBLIC
-	Vulkan::Vulkan
-	SDL2::SDL2
+target_link_libraries(${TARGET_NAME} PUBLIC
 	Bullet
 	LUA
 	Utility
 )
 
-if (NOT WIN32)
-	target_link_libraries(WickedEngine PRIVATE dl)
+if (WIN32)
+	target_compile_definitions(${TARGET_NAME} PUBLIC
+		UNICODE _UNICODE
+	)
+
+	add_dependencies(${TARGET_NAME}
+		Shaders_DXC
+	)
+else ()
+	target_link_libraries(${TARGET_NAME} PUBLIC
+		Vulkan::Vulkan
+		SDL2::SDL2
+	)
+
+	target_link_libraries(${TARGET_NAME} PRIVATE dl)
 endif()
 
-add_dependencies(WickedEngine
-	Shaders_SPIRV)
+add_dependencies(${TARGET_NAME}
+	Shaders_SPIRV
+)
 
 if (PLATFORM MATCHES "SDL2")
-    target_compile_definitions(WickedEngine PUBLIC SDL2=1)
+	target_compile_definitions(${TARGET_NAME} PUBLIC SDL2=1)
 endif()

--- a/WickedEngine/LUA/CMakeLists.txt
+++ b/WickedEngine/LUA/CMakeLists.txt
@@ -34,3 +34,5 @@ add_library(LUA STATIC
     lvm.c
     lzio.c
 )
+
+set_property(TARGET "LUA" PROPERTY FOLDER "ThirdParty")

--- a/WickedEngine/Utility/CMakeLists.txt
+++ b/WickedEngine/Utility/CMakeLists.txt
@@ -1,4 +1,15 @@
-add_library(Utility STATIC
-    utility_common.cpp
+set (SOURCE_FILES
+	utility_common.cpp
 	spirv_reflect.c
+	stb_vorbis.c
 )
+
+if (WIN32)
+	list (APPEND SOURCE_FILES
+		D3D12MemAlloc.cpp
+	)
+endif ()
+
+add_library(Utility STATIC ${SOURCE_FILES})
+
+set_property(TARGET "Utility" PROPERTY FOLDER "ThirdParty")

--- a/WickedEngine/shaders/CMakeLists.txt
+++ b/WickedEngine/shaders/CMakeLists.txt
@@ -1,398 +1,445 @@
 # compile shaders
 
-set(OUTPUT_DIR spirv)
+set(SPIRV_OUTPUT_DIR spirv)
+set(DXC_OUTPUT_DIR hlsl6)
 
 set(SHADERS_CS
-        "hairparticle_simulateCS.hlsl"
-        "hairparticle_finishUpdateCS.hlsl"
-        "emittedparticle_simulateCS.hlsl"
-        "generateMIPChainCubeCS_float4.hlsl"
-        "generateMIPChainCubeCS_unorm4.hlsl"
-        "generateMIPChainCubeArrayCS_float4.hlsl"
-        "generateMIPChainCubeArrayCS_unorm4.hlsl"
-        "generateMIPChain3DCS_float4.hlsl"
-        "generateMIPChain3DCS_unorm4.hlsl"
-        "generateMIPChain2DCS_float4.hlsl"
-        "generateMIPChain2DCS_unorm4.hlsl"
-        "blur_gaussian_float4CS.hlsl"
-        "bloomseparateCS.hlsl"
-        "depthoffield_mainCS.hlsl"
-        "depthoffield_neighborhoodMaxCOCCS.hlsl"
-        "depthoffield_prepassCS.hlsl"
-        "depthoffield_upsampleCS.hlsl"
-        "depthoffield_tileMaxCOC_verticalCS.hlsl"
-        "depthoffield_tileMaxCOC_horizontalCS.hlsl"
-        "voxelRadianceSecondaryBounceCS.hlsl"
-        "voxelSceneCopyClearCS.hlsl"
-        "voxelClearOnlyNormalCS.hlsl"
-        "upsample_bilateral_float1CS.hlsl"
-        "upsample_bilateral_float4CS.hlsl"
-        "upsample_bilateral_unorm1CS.hlsl"
-        "upsample_bilateral_unorm4CS.hlsl"
-        "temporalaaCS.hlsl"
-        "tileFrustumsCS.hlsl"
-        "tonemapCS.hlsl"
-        "ssr_resolveCS.hlsl"
-        "ssr_temporalCS.hlsl"
-        "ssaoCS.hlsl"
-        "ssr_medianCS.hlsl"
-        "ssr_raytraceCS.hlsl"
-        "sharpenCS.hlsl"
-        "skinningCS.hlsl"
-        "skinningCS_LDS.hlsl"
-        "resolveMSAADepthStencilCS.hlsl"
-        "raytrace_shadeCS.hlsl"
-        "raytrace_tilesortCS.hlsl"
-        "raytrace_kickjobsCS.hlsl"
-        "raytrace_launchCS.hlsl"
-        "paint_textureCS.hlsl"
-        "raytrace_closesthitCS.hlsl"
-        "oceanUpdateDisplacementMapCS.hlsl"
-        "oceanUpdateGradientFoldingCS.hlsl"
-        "oceanSimulatorCS.hlsl"
-        "msao_interleaveCS.hlsl"
-        "msao_preparedepthbuffers1CS.hlsl"
-        "msao_preparedepthbuffers2CS.hlsl"
-        "msao_blurupsampleCS.hlsl"
-        "msao_blurupsampleCS_blendout.hlsl"
-        "msao_blurupsampleCS_premin.hlsl"
-        "msao_blurupsampleCS_premin_blendout.hlsl"
-        "msaoCS.hlsl"
-        "motionblur_neighborhoodMaxVelocityCS.hlsl"
-        "motionblur_tileMaxVelocity_horizontalCS.hlsl"
-        "motionblur_tileMaxVelocity_verticalCS.hlsl"
-        "luminancePass2CS.hlsl"
-        "motionblur_kickjobsCS.hlsl"
-        "motionblurCS.hlsl"
-        "motionblurCS_cheap.hlsl"
-        "motionblurCS_earlyexit.hlsl"
-        "lineardepthCS.hlsl"
-        "luminancePass1CS.hlsl"
-        "lightShaftsCS.hlsl"
-        "lightCullingCS_ADVANCED_DEBUG.hlsl"
-        "lightCullingCS_DEBUG.hlsl"
-        "lightCullingCS.hlsl"
-        "lightCullingCS_ADVANCED.hlsl"
-        "hbaoCS.hlsl"
-        "gpusortlib_sortInnerCS.hlsl"
-        "gpusortlib_sortStepCS.hlsl"
-        "gpusortlib_kickoffSortCS.hlsl"
-        "gpusortlib_sortCS.hlsl"
-        "fxaaCS.hlsl"
-        "filterEnvMapCS.hlsl"
-        "fft_512x512_c2c_CS.hlsl"
-        "fft_512x512_c2c_v2_CS.hlsl"
-        "emittedparticle_sphpartitionCS.hlsl"
-        "emittedparticle_sphpartitionoffsetsCS.hlsl"
-        "emittedparticle_sphpartitionoffsetsresetCS.hlsl"
-        "emittedparticle_simulateCS_SORTING.hlsl"
-        "emittedparticle_simulateCS_SORTING_DEPTHCOLLISIONS.hlsl"
-        "emittedparticle_sphdensityCS.hlsl"
-        "emittedparticle_sphforceCS.hlsl"
-        "emittedparticle_kickoffUpdateCS.hlsl"
-        "emittedparticle_simulateCS_DEPTHCOLLISIONS.hlsl"
-        "emittedparticle_emitCS.hlsl"
-        "emittedparticle_emitCS_FROMMESH.hlsl"
-        "emittedparticle_emitCS_volume.hlsl"
-        "emittedparticle_finishUpdateCS.hlsl"
-        "downsample4xCS.hlsl"
-        "depthoffield_prepassCS_earlyexit.hlsl"
-        "depthoffield_mainCS_cheap.hlsl"
-        "depthoffield_mainCS_earlyexit.hlsl"
-        "depthoffield_postfilterCS.hlsl"
-        "depthoffield_kickjobsCS.hlsl"
-        "copytexture2D_float4_borderexpandCS.hlsl"
-        "copytexture2D_unorm4_borderexpandCS.hlsl"
-        "copytexture2D_unorm4CS.hlsl"
-        "copytexture2D_float4CS.hlsl"
-        "chromatic_aberrationCS.hlsl"
-        "bvh_hierarchyCS.hlsl"
-        "bvh_primitivesCS.hlsl"
-        "bvh_propagateaabbCS.hlsl"
-        "blur_gaussian_wide_unorm1CS.hlsl"
-        "blur_gaussian_wide_unorm4CS.hlsl"
-        "blur_gaussian_unorm1CS.hlsl"
-        "blur_gaussian_unorm4CS.hlsl"
-        "blur_gaussian_wide_float1CS.hlsl"
-        "blur_gaussian_wide_float3CS.hlsl"
-        "blur_gaussian_wide_float4CS.hlsl"
-        "blur_bilateral_wide_unorm4CS.hlsl"
-        "blur_gaussian_float1CS.hlsl"
-        "blur_gaussian_float3CS.hlsl"
-        "blur_bilateral_unorm4CS.hlsl"
-        "blur_bilateral_wide_float1CS.hlsl"
-        "blur_bilateral_wide_float3CS.hlsl"
-        "blur_bilateral_wide_float4CS.hlsl"
-        "blur_bilateral_wide_unorm1CS.hlsl"
-        "blur_bilateral_float1CS.hlsl"
-        "blur_bilateral_float3CS.hlsl"
-        "blur_bilateral_float4CS.hlsl"
-        "blur_bilateral_unorm1CS.hlsl"
-        "bloomcombineCS.hlsl"
-        "voxelSceneCopyClearCS_TemporalSmoothing.hlsl"
-        "normalsfromdepthCS.hlsl"
-        "volumetricCloud_shapenoiseCS.hlsl"
-        "volumetricCloud_detailnoiseCS.hlsl"
-        "volumetricCloud_curlnoiseCS.hlsl"
-        "volumetricCloud_weathermapCS.hlsl"
-        "volumetricCloud_renderCS.hlsl"
-        "volumetricCloud_reprojectCS.hlsl"
-        "volumetricCloud_finalCS.hlsl"
-        "shadingRateClassificationCS.hlsl"
-        "shadingRateClassificationCS_DEBUG.hlsl"
-        "skyAtmosphere_transmittanceLutCS.hlsl"
-        "skyAtmosphere_skyViewLutCS.hlsl"
-        "skyAtmosphere_multiScatteredLuminanceLutCS.hlsl"
+		"hairparticle_simulateCS.hlsl"
+		"hairparticle_finishUpdateCS.hlsl"
+		"emittedparticle_simulateCS.hlsl"
+		"generateMIPChainCubeCS_float4.hlsl"
+		"generateMIPChainCubeCS_unorm4.hlsl"
+		"generateMIPChainCubeArrayCS_float4.hlsl"
+		"generateMIPChainCubeArrayCS_unorm4.hlsl"
+		"generateMIPChain3DCS_float4.hlsl"
+		"generateMIPChain3DCS_unorm4.hlsl"
+		"generateMIPChain2DCS_float4.hlsl"
+		"generateMIPChain2DCS_unorm4.hlsl"
+		"blur_gaussian_float4CS.hlsl"
+		"bloomseparateCS.hlsl"
+		"depthoffield_mainCS.hlsl"
+		"depthoffield_neighborhoodMaxCOCCS.hlsl"
+		"depthoffield_prepassCS.hlsl"
+		"depthoffield_upsampleCS.hlsl"
+		"depthoffield_tileMaxCOC_verticalCS.hlsl"
+		"depthoffield_tileMaxCOC_horizontalCS.hlsl"
+		"voxelRadianceSecondaryBounceCS.hlsl"
+		"voxelSceneCopyClearCS.hlsl"
+		"voxelClearOnlyNormalCS.hlsl"
+		"upsample_bilateral_float1CS.hlsl"
+		"upsample_bilateral_float4CS.hlsl"
+		"upsample_bilateral_unorm1CS.hlsl"
+		"upsample_bilateral_unorm4CS.hlsl"
+		"temporalaaCS.hlsl"
+		"tileFrustumsCS.hlsl"
+		"tonemapCS.hlsl"
+		"ssr_resolveCS.hlsl"
+		"ssr_temporalCS.hlsl"
+		"ssaoCS.hlsl"
+		"ssr_medianCS.hlsl"
+		"ssr_raytraceCS.hlsl"
+		"sharpenCS.hlsl"
+		"skinningCS.hlsl"
+		"skinningCS_LDS.hlsl"
+		"resolveMSAADepthStencilCS.hlsl"
+		"raytrace_shadeCS.hlsl"
+		"raytrace_tilesortCS.hlsl"
+		"raytrace_kickjobsCS.hlsl"
+		"raytrace_launchCS.hlsl"
+		"paint_textureCS.hlsl"
+		"raytrace_closesthitCS.hlsl"
+		"oceanUpdateDisplacementMapCS.hlsl"
+		"oceanUpdateGradientFoldingCS.hlsl"
+		"oceanSimulatorCS.hlsl"
+		"msao_interleaveCS.hlsl"
+		"msao_preparedepthbuffers1CS.hlsl"
+		"msao_preparedepthbuffers2CS.hlsl"
+		"msao_blurupsampleCS.hlsl"
+		"msao_blurupsampleCS_blendout.hlsl"
+		"msao_blurupsampleCS_premin.hlsl"
+		"msao_blurupsampleCS_premin_blendout.hlsl"
+		"msaoCS.hlsl"
+		"motionblur_neighborhoodMaxVelocityCS.hlsl"
+		"motionblur_tileMaxVelocity_horizontalCS.hlsl"
+		"motionblur_tileMaxVelocity_verticalCS.hlsl"
+		"luminancePass2CS.hlsl"
+		"motionblur_kickjobsCS.hlsl"
+		"motionblurCS.hlsl"
+		"motionblurCS_cheap.hlsl"
+		"motionblurCS_earlyexit.hlsl"
+		"lineardepthCS.hlsl"
+		"luminancePass1CS.hlsl"
+		"lightShaftsCS.hlsl"
+		"lightCullingCS_ADVANCED_DEBUG.hlsl"
+		"lightCullingCS_DEBUG.hlsl"
+		"lightCullingCS.hlsl"
+		"lightCullingCS_ADVANCED.hlsl"
+		"hbaoCS.hlsl"
+		"gpusortlib_sortInnerCS.hlsl"
+		"gpusortlib_sortStepCS.hlsl"
+		"gpusortlib_kickoffSortCS.hlsl"
+		"gpusortlib_sortCS.hlsl"
+		"fxaaCS.hlsl"
+		"filterEnvMapCS.hlsl"
+		"fft_512x512_c2c_CS.hlsl"
+		"fft_512x512_c2c_v2_CS.hlsl"
+		"emittedparticle_sphpartitionCS.hlsl"
+		"emittedparticle_sphpartitionoffsetsCS.hlsl"
+		"emittedparticle_sphpartitionoffsetsresetCS.hlsl"
+		"emittedparticle_simulateCS_SORTING.hlsl"
+		"emittedparticle_simulateCS_SORTING_DEPTHCOLLISIONS.hlsl"
+		"emittedparticle_sphdensityCS.hlsl"
+		"emittedparticle_sphforceCS.hlsl"
+		"emittedparticle_kickoffUpdateCS.hlsl"
+		"emittedparticle_simulateCS_DEPTHCOLLISIONS.hlsl"
+		"emittedparticle_emitCS.hlsl"
+		"emittedparticle_emitCS_FROMMESH.hlsl"
+		"emittedparticle_emitCS_volume.hlsl"
+		"emittedparticle_finishUpdateCS.hlsl"
+		"downsample4xCS.hlsl"
+		"depthoffield_prepassCS_earlyexit.hlsl"
+		"depthoffield_mainCS_cheap.hlsl"
+		"depthoffield_mainCS_earlyexit.hlsl"
+		"depthoffield_postfilterCS.hlsl"
+		"depthoffield_kickjobsCS.hlsl"
+		"copytexture2D_float4_borderexpandCS.hlsl"
+		"copytexture2D_unorm4_borderexpandCS.hlsl"
+		"copytexture2D_unorm4CS.hlsl"
+		"copytexture2D_float4CS.hlsl"
+		"chromatic_aberrationCS.hlsl"
+		"bvh_hierarchyCS.hlsl"
+		"bvh_primitivesCS.hlsl"
+		"bvh_propagateaabbCS.hlsl"
+		"blur_gaussian_wide_unorm1CS.hlsl"
+		"blur_gaussian_wide_unorm4CS.hlsl"
+		"blur_gaussian_unorm1CS.hlsl"
+		"blur_gaussian_unorm4CS.hlsl"
+		"blur_gaussian_wide_float1CS.hlsl"
+		"blur_gaussian_wide_float3CS.hlsl"
+		"blur_gaussian_wide_float4CS.hlsl"
+		"blur_bilateral_wide_unorm4CS.hlsl"
+		"blur_gaussian_float1CS.hlsl"
+		"blur_gaussian_float3CS.hlsl"
+		"blur_bilateral_unorm4CS.hlsl"
+		"blur_bilateral_wide_float1CS.hlsl"
+		"blur_bilateral_wide_float3CS.hlsl"
+		"blur_bilateral_wide_float4CS.hlsl"
+		"blur_bilateral_wide_unorm1CS.hlsl"
+		"blur_bilateral_float1CS.hlsl"
+		"blur_bilateral_float3CS.hlsl"
+		"blur_bilateral_float4CS.hlsl"
+		"blur_bilateral_unorm1CS.hlsl"
+		"bloomcombineCS.hlsl"
+		"voxelSceneCopyClearCS_TemporalSmoothing.hlsl"
+		"normalsfromdepthCS.hlsl"
+		"volumetricCloud_shapenoiseCS.hlsl"
+		"volumetricCloud_detailnoiseCS.hlsl"
+		"volumetricCloud_curlnoiseCS.hlsl"
+		"volumetricCloud_weathermapCS.hlsl"
+		"volumetricCloud_renderCS.hlsl"
+		"volumetricCloud_reprojectCS.hlsl"
+		"volumetricCloud_finalCS.hlsl"
+		"shadingRateClassificationCS.hlsl"
+		"shadingRateClassificationCS_DEBUG.hlsl"
+		"skyAtmosphere_transmittanceLutCS.hlsl"
+		"skyAtmosphere_skyViewLutCS.hlsl"
+		"skyAtmosphere_multiScatteredLuminanceLutCS.hlsl"
 		"skyAtmosphere_skyLuminanceLutCS.hlsl"
-        "rtao_denoise_blurCS.hlsl"
-        "rtao_denoise_temporalCS.hlsl"
-        "rtshadow_denoise_temporalCS.hlsl"
+		"rtao_denoise_blurCS.hlsl"
+		"rtao_denoise_temporalCS.hlsl"
+		"rtshadow_denoise_temporalCS.hlsl"
 )
 
 set(SHADERS_PS
-        "emittedparticlePS_soft.hlsl"
-        "screenPS.hlsl"
-        "imagePS_separatenormalmap.hlsl"
-        "imagePS_separatenormalmap_bicubic.hlsl"
-        "imagePS_backgroundblur_masked.hlsl"
-        "imagePS_masked.hlsl"
-        "imagePS_backgroundblur.hlsl"
-        "imagePS.hlsl"
-        "emittedparticlePS_soft_lighting.hlsl"
-        "oceanSurfacePS.hlsl"
-        "hairparticlePS.hlsl"
-        "impostorPS.hlsl"
-        "volumetricLight_SpotPS.hlsl"
-        "volumetricLight_PointPS.hlsl"
-        "volumetricLight_DirectionalPS.hlsl"
-        "voxelPS.hlsl"
-        "vertexcolorPS.hlsl"
-        "upsample_bilateralPS.hlsl"
-        "sunPS.hlsl"
-        "skyPS_dynamic.hlsl"
-        "skyPS_static.hlsl"
-        "skyPS_velocity.hlsl"
-        "shadowPS_transparent.hlsl"
-        "shadowPS_water.hlsl"
-        "shadowPS_alphatest.hlsl"
-        "renderlightmapPS.hlsl"
-        "raytrace_debugbvhPS.hlsl"
-        "outlinePS.hlsl"
-        "oceanSurfaceSimplePS.hlsl"
-        "objectPS_transparent_pom.hlsl"
-        "objectPS_water.hlsl"
-        "objectPS_voxelizer.hlsl"
-        "objectPS_voxelizer_terrain.hlsl"
-        "objectPS_transparent.hlsl"
-        "objectPS_transparent_planarreflection.hlsl"
-        "objectPS_planarreflection.hlsl"
-        "objectPS_pom.hlsl"
-        "objectPS_terrain.hlsl"
-        "objectPS.hlsl"
-        "objectPS_hologram.hlsl"
-        "objectPS_paintradius.hlsl"
-        "objectPS_simplest.hlsl"
-        "objectPS_debug.hlsl"
-        "objectPS_prepass.hlsl"
-        "objectPS_prepass_alphatest.hlsl"
-        "objectPS_anisotropic.hlsl"
-        "objectPS_transparent_anisotropic.hlsl"
-        "objectPS_cloth.hlsl"
-        "objectPS_transparent_cloth.hlsl"
-        "objectPS_clearcoat.hlsl"
-        "objectPS_transparent_clearcoat.hlsl"
-        "objectPS_cloth_clearcoat.hlsl"
-        "objectPS_transparent_cloth_clearcoat.hlsl"
-        "objectPS_cartoon.hlsl"
-        "objectPS_transparent_cartoon.hlsl"
-        "objectPS_unlit.hlsl"
-        "objectPS_transparent_unlit.hlsl"
-        "lightVisualizerPS.hlsl"
-        "lensFlarePS.hlsl"
-        "impostorPS_wire.hlsl"
-        "impostorPS_simple.hlsl"
-        "impostorPS_prepass.hlsl"
-        "hairparticlePS_simplest.hlsl"
-        "hairparticlePS_prepass.hlsl"
-        "forceFieldVisualizerPS.hlsl"
-        "fontPS.hlsl"
-        "envMap_skyPS_static.hlsl"
-        "envMap_skyPS_dynamic.hlsl"
-        "envMapPS.hlsl"
-        "envMapPS_terrain.hlsl"
-        "emittedparticlePS_soft_distortion.hlsl"
-        "downsampleDepthBuffer4xPS.hlsl"
-        "emittedparticlePS_simplest.hlsl"
-        "cubeMapPS.hlsl"
-        "circlePS.hlsl"
-        "captureImpostorPS_normal.hlsl"
-        "captureImpostorPS_surface.hlsl"
-        "captureImpostorPS_albedo.hlsl"
+		"emittedparticlePS_soft.hlsl"
+		"screenPS.hlsl"
+		"imagePS_separatenormalmap.hlsl"
+		"imagePS_separatenormalmap_bicubic.hlsl"
+		"imagePS_backgroundblur_masked.hlsl"
+		"imagePS_masked.hlsl"
+		"imagePS_backgroundblur.hlsl"
+		"imagePS.hlsl"
+		"emittedparticlePS_soft_lighting.hlsl"
+		"oceanSurfacePS.hlsl"
+		"hairparticlePS.hlsl"
+		"impostorPS.hlsl"
+		"volumetricLight_SpotPS.hlsl"
+		"volumetricLight_PointPS.hlsl"
+		"volumetricLight_DirectionalPS.hlsl"
+		"voxelPS.hlsl"
+		"vertexcolorPS.hlsl"
+		"upsample_bilateralPS.hlsl"
+		"sunPS.hlsl"
+		"skyPS_dynamic.hlsl"
+		"skyPS_static.hlsl"
+		"skyPS_velocity.hlsl"
+		"shadowPS_transparent.hlsl"
+		"shadowPS_water.hlsl"
+		"shadowPS_alphatest.hlsl"
+		"renderlightmapPS.hlsl"
+		"raytrace_debugbvhPS.hlsl"
+		"outlinePS.hlsl"
+		"oceanSurfaceSimplePS.hlsl"
+		"objectPS_transparent_pom.hlsl"
+		"objectPS_water.hlsl"
+		"objectPS_voxelizer.hlsl"
+		"objectPS_voxelizer_terrain.hlsl"
+		"objectPS_transparent.hlsl"
+		"objectPS_transparent_planarreflection.hlsl"
+		"objectPS_planarreflection.hlsl"
+		"objectPS_pom.hlsl"
+		"objectPS_terrain.hlsl"
+		"objectPS.hlsl"
+		"objectPS_hologram.hlsl"
+		"objectPS_paintradius.hlsl"
+		"objectPS_simplest.hlsl"
+		"objectPS_debug.hlsl"
+		"objectPS_prepass.hlsl"
+		"objectPS_prepass_alphatest.hlsl"
+		"objectPS_anisotropic.hlsl"
+		"objectPS_transparent_anisotropic.hlsl"
+		"objectPS_cloth.hlsl"
+		"objectPS_transparent_cloth.hlsl"
+		"objectPS_clearcoat.hlsl"
+		"objectPS_transparent_clearcoat.hlsl"
+		"objectPS_cloth_clearcoat.hlsl"
+		"objectPS_transparent_cloth_clearcoat.hlsl"
+		"objectPS_cartoon.hlsl"
+		"objectPS_transparent_cartoon.hlsl"
+		"objectPS_unlit.hlsl"
+		"objectPS_transparent_unlit.hlsl"
+		"lightVisualizerPS.hlsl"
+		"lensFlarePS.hlsl"
+		"impostorPS_wire.hlsl"
+		"impostorPS_simple.hlsl"
+		"impostorPS_prepass.hlsl"
+		"hairparticlePS_simplest.hlsl"
+		"hairparticlePS_prepass.hlsl"
+		"forceFieldVisualizerPS.hlsl"
+		"fontPS.hlsl"
+		"envMap_skyPS_static.hlsl"
+		"envMap_skyPS_dynamic.hlsl"
+		"envMapPS.hlsl"
+		"envMapPS_terrain.hlsl"
+		"emittedparticlePS_soft_distortion.hlsl"
+		"downsampleDepthBuffer4xPS.hlsl"
+		"emittedparticlePS_simplest.hlsl"
+		"cubeMapPS.hlsl"
+		"circlePS.hlsl"
+		"captureImpostorPS_normal.hlsl"
+		"captureImpostorPS_surface.hlsl"
+		"captureImpostorPS_albedo.hlsl"
 )
 
 set(SHADERS_VS
-        "hairparticleVS.hlsl"
-        "emittedparticleVS.hlsl"
-        "imageVS.hlsl"
-        "fontVS.hlsl"
-        "voxelVS.hlsl"
-        "vertexcolorVS.hlsl"
-        "volumetriclight_directionalVS.hlsl"
-        "volumetriclight_pointVS.hlsl"
-        "volumetriclight_spotVS.hlsl"
-        "vSpotLightVS.hlsl"
-        "vPointLightVS.hlsl"
-        "sphereVS.hlsl"
-        "skyVS.hlsl"
-        "shadowVS_transparent.hlsl"
-        "shadowVS.hlsl"
-        "shadowVS_alphatest.hlsl"
-        "screenVS.hlsl"
-        "renderlightmapVS.hlsl"
-        "raytrace_screenVS.hlsl"
-        "oceanSurfaceVS.hlsl"
-        "objectVS_simple.hlsl"
-        "objectVS_voxelizer.hlsl"
-        "objectVS_common.hlsl"
-        "objectVS_common_tessellation.hlsl"
-        "objectVS_prepass.hlsl"
-        "objectVS_prepass_alphatest.hlsl"
-        "objectVS_prepass_tessellation.hlsl"
-        "objectVS_prepass_alphatest_tessellation.hlsl"
-        "objectVS_debug.hlsl"
-        "lensFlareVS.hlsl"
-        "impostorVS.hlsl"
-        "forceFieldPointVisualizerVS.hlsl"
-        "forceFieldPlaneVisualizerVS.hlsl"
-        "envMap_skyVS.hlsl"
-        "envMapVS.hlsl"
-        "envMap_skyVS_emulation.hlsl"
-        "envMapVS_emulation.hlsl"
-        "cubeShadowVS.hlsl"
-        "cubeShadowVS_alphatest.hlsl"
-        "cubeShadowVS_emulation.hlsl"
-        "cubeShadowVS_alphatest_emulation.hlsl"
-        "cubeShadowVS_transparent.hlsl"
-        "cubeShadowVS_transparent_emulation.hlsl"
-        "cubeVS.hlsl"
+		"hairparticleVS.hlsl"
+		"emittedparticleVS.hlsl"
+		"imageVS.hlsl"
+		"fontVS.hlsl"
+		"voxelVS.hlsl"
+		"vertexcolorVS.hlsl"
+		"volumetriclight_directionalVS.hlsl"
+		"volumetriclight_pointVS.hlsl"
+		"volumetriclight_spotVS.hlsl"
+		"vSpotLightVS.hlsl"
+		"vPointLightVS.hlsl"
+		"sphereVS.hlsl"
+		"skyVS.hlsl"
+		"shadowVS_transparent.hlsl"
+		"shadowVS.hlsl"
+		"shadowVS_alphatest.hlsl"
+		"screenVS.hlsl"
+		"renderlightmapVS.hlsl"
+		"raytrace_screenVS.hlsl"
+		"oceanSurfaceVS.hlsl"
+		"objectVS_simple.hlsl"
+		"objectVS_voxelizer.hlsl"
+		"objectVS_common.hlsl"
+		"objectVS_common_tessellation.hlsl"
+		"objectVS_prepass.hlsl"
+		"objectVS_prepass_alphatest.hlsl"
+		"objectVS_prepass_tessellation.hlsl"
+		"objectVS_prepass_alphatest_tessellation.hlsl"
+		"objectVS_debug.hlsl"
+		"lensFlareVS.hlsl"
+		"impostorVS.hlsl"
+		"forceFieldPointVisualizerVS.hlsl"
+		"forceFieldPlaneVisualizerVS.hlsl"
+		"envMap_skyVS.hlsl"
+		"envMapVS.hlsl"
+		"envMap_skyVS_emulation.hlsl"
+		"envMapVS_emulation.hlsl"
+		"cubeShadowVS.hlsl"
+		"cubeShadowVS_alphatest.hlsl"
+		"cubeShadowVS_emulation.hlsl"
+		"cubeShadowVS_alphatest_emulation.hlsl"
+		"cubeShadowVS_transparent.hlsl"
+		"cubeShadowVS_transparent_emulation.hlsl"
+		"cubeVS.hlsl"
 )
 
 set(SHADERS_GS
-        "envMap_skyGS_emulation.hlsl"
-        "envMapGS_emulation.hlsl"
-        "cubeShadowGS_emulation.hlsl"
-        "cubeShadowGS_alphatest_emulation.hlsl"
-        "cubeShadowGS_transparent_emulation.hlsl"
-        "voxelGS.hlsl"
-        "objectGS_voxelizer.hlsl"
-        "lensFlareGS.hlsl"
+		"envMap_skyGS_emulation.hlsl"
+		"envMapGS_emulation.hlsl"
+		"cubeShadowGS_emulation.hlsl"
+		"cubeShadowGS_alphatest_emulation.hlsl"
+		"cubeShadowGS_transparent_emulation.hlsl"
+		"voxelGS.hlsl"
+		"objectGS_voxelizer.hlsl"
+		"lensFlareGS.hlsl"
 )
 
 set(SHADERS_HS
-        "objectHS.hlsl"
-        "objectHS_prepass.hlsl"
-        "objectHS_prepass_alphatest.hlsl"
+		"objectHS.hlsl"
+		"objectHS_prepass.hlsl"
+		"objectHS_prepass_alphatest.hlsl"
 )
 
 set(SHADERS_DS
-        "objectDS.hlsl"
-        "objectDS_prepass.hlsl"
-        "objectDS_prepass_alphatest.hlsl"
+		"objectDS.hlsl"
+		"objectDS_prepass.hlsl"
+		"objectDS_prepass_alphatest.hlsl"
 )
 
 set(SHADERS_LIB
-        "rtaoLIB.hlsl"
-        "rtreflectionLIB.hlsl"
-        "rtshadowLIB.hlsl"
+		"rtaoLIB.hlsl"
+		"rtreflectionLIB.hlsl"
+		"rtshadowLIB.hlsl"
 )
 
 
 SET(SPIRV_BINARY_FILES)
-
+SET(DXC_BINARY_FILES)
 
 #dxc (DirectX Shader Compiler) is installed as part of the Vulkan SDK
-function(Generate_Shaders SHADERS_SRC_LIST SHADER_TYPE)
-    foreach (Shader IN LISTS ${SHADERS_SRC_LIST})
-        get_filename_component(FILE_NAME ${Shader} NAME_WLE)
-        message(STATUS "CALCULATING DEPENDENCIES FOR SHADER ${SHADER_TYPE} ${FILE_NAME}")
-        if(${SHADER_TYPE} STREQUAL lib)
-            set(VK_VERSION "vulkan1.2")
-        else()
-            set(VK_VERSION "vulkan1.1")
-        endif()
-        set(SPIRV_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/${OUTPUT_DIR}/${FILE_NAME}.cso")
-        set(SPIRV_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/../${Shader}")
-        set(COMMAND_PARAMS "dxc"
-                "${SPIRV_SOURCE}"
-                -T "${SHADER_TYPE}_6_5"
-                -I "${CMAKE_CURRENT_SOURCE_DIR}/../"
-                -D SPIRV
-                -all-resources-bound
-                -pack-optimized
-                -res-may-alias
-                -no-legacy-cbuf-layout
-                -spirv
-                -fspv-target-env=${VK_VERSION}
-                -fvk-use-dx-layout
-                -fvk-use-dx-position-w
-                -flegacy-macro-expansion
-                -Fo ${SPIRV_OUTPUT}
-                -fvk-t-shift 1000 all
-                -fvk-u-shift 2000 all
-                -fvk-s-shift 3000 all
-                #-fspv-extension=KHR
-                -Vd #DISABLE VALIDATION: There is currently a validation bug with raytracing RayTCurrent()!!!
-                )
+function(Generate_Shaders_SPIRV SHADERS_SRC_LIST SHADER_TYPE)
+	foreach (Shader IN LISTS ${SHADERS_SRC_LIST})
+		get_filename_component(FILE_NAME ${Shader} NAME_WLE)
+		message(STATUS "CALCULATING DEPENDENCIES FOR SHADER ${SHADER_TYPE} ${FILE_NAME}")
+		if(${SHADER_TYPE} STREQUAL lib)
+			set(VK_VERSION "vulkan1.2")
+		else()
+			set(VK_VERSION "vulkan1.1")
+		endif()
+		set(SPIRV_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/${SPIRV_OUTPUT_DIR}/${FILE_NAME}.cso")
+		set(SPIRV_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/../${Shader}")
+		set(COMMAND_PARAMS ${DXC_TARGET}
+				"${SPIRV_SOURCE}"
+				-T "${SHADER_TYPE}_6_5"
+				-I "${CMAKE_CURRENT_SOURCE_DIR}/../"
+				-D SPIRV
+				-all-resources-bound
+				#-pack-optimized
+				-res-may-alias
+				-no-legacy-cbuf-layout
+				-spirv
+				-fspv-target-env=${VK_VERSION}
+				-fvk-use-dx-layout
+				-fvk-use-dx-position-w
+				-flegacy-macro-expansion
+				-Fo ${SPIRV_OUTPUT}
+				-fvk-t-shift 1000 all
+				-fvk-u-shift 2000 all
+				-fvk-s-shift 3000 all
+				#-fspv-extension=KHR
+				-Vd #DISABLE VALIDATION: There is currently a validation bug with raytracing RayTCurrent()!!!
+				)
 
-        # Determine include dependencies (recursively)
-        #
-        # This works by compiling the shader with the option -Vi,
-        # which seems to print all inclusion operations done during compilation.
-        # The process is quite slow, it would be nice to have a dedicated option
-        # in dxc to do this properly, like the -MM option in gcc/clang.
-        execute_process(COMMAND ${COMMAND_PARAMS} -Vi
-                ERROR_VARIABLE INCLUDE_DEPENDENCIES
-                OUTPUT_VARIABLE CMD_OUT
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-                ERROR_STRIP_TRAILING_WHITESPACE)
-        if(INCLUDE_DEPENDENCIES)
-            string(REPLACE "\n" ";" INCLUDE_DEPENDENCIES ${INCLUDE_DEPENDENCIES}) # transform lines in cmake list
-            list(FILTER INCLUDE_DEPENDENCIES INCLUDE REGEX "Opening file") # remove non dependencies lines
-            list(LENGTH INCLUDE_DEPENDENCIES INCLUDE_DEPENDENCIES_LENGTH)
-            if(${INCLUDE_DEPENDENCIES_LENGTH} GREATER 0)
-                #filter out [inplace] filename from program output
-                list(TRANSFORM INCLUDE_DEPENDENCIES
-                        REPLACE "Opening file \\[(.+)\\], stack top.*"
-                                "\\1")
-            endif()
-        endif()
+		# Determine include dependencies (recursively)
+		#
+		# This works by compiling the shader with the option -Vi,
+		# which seems to print all inclusion operations done during compilation.
+		# The process is quite slow, it would be nice to have a dedicated option
+		# in dxc to do this properly, like the -MM option in gcc/clang.
+		execute_process(COMMAND ${COMMAND_PARAMS} -Vi
+				ERROR_VARIABLE INCLUDE_DEPENDENCIES
+				OUTPUT_VARIABLE CMD_OUT
+				OUTPUT_STRIP_TRAILING_WHITESPACE
+				ERROR_STRIP_TRAILING_WHITESPACE)
+		if(INCLUDE_DEPENDENCIES)
+			string(REPLACE "\n" ";" INCLUDE_DEPENDENCIES ${INCLUDE_DEPENDENCIES}) # transform lines in cmake list
+			list(FILTER INCLUDE_DEPENDENCIES INCLUDE REGEX "Opening file") # remove non dependencies lines
+			list(LENGTH INCLUDE_DEPENDENCIES INCLUDE_DEPENDENCIES_LENGTH)
+			if(${INCLUDE_DEPENDENCIES_LENGTH} GREATER 0)
+				#filter out [inplace] filename from program output
+				list(TRANSFORM INCLUDE_DEPENDENCIES
+						REPLACE "Opening file \\[(.+)\\], stack top.*"
+								"\\1")
+			endif()
+		endif()
 
-        #DEBUG PRINT
-#        foreach(ELEM ${INCLUDE_DEPENDENCIES})
-#            message(${ELEM})
-#        endforeach()
-
-        add_custom_command(
-                OUTPUT ${SPIRV_OUTPUT}
-                COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_SOURCE_DIR}/spirv/"
-                COMMAND ${COMMAND_PARAMS}
-                DEPENDS ${SPIRV_SOURCE} ${INCLUDE_DEPENDENCIES}
-        )
-        list(APPEND SPIRV_BINARY_FILES ${SPIRV_OUTPUT})
-    endforeach()
-    set(SPIRV_BINARY_FILES ${SPIRV_BINARY_FILES} PARENT_SCOPE)
+		add_custom_command(
+				OUTPUT ${SPIRV_OUTPUT}
+				COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_SOURCE_DIR}/spirv/"
+				COMMAND ${COMMAND_PARAMS}
+				DEPENDS ${SPIRV_SOURCE} ${INCLUDE_DEPENDENCIES}
+		)
+		list(APPEND SPIRV_BINARY_FILES ${SPIRV_OUTPUT})
+	endforeach()
+	set(SPIRV_BINARY_FILES ${SPIRV_BINARY_FILES} PARENT_SCOPE)
 endfunction()
 
 
-Generate_Shaders(SHADERS_VS vs)
-Generate_Shaders(SHADERS_HS hs)
-Generate_Shaders(SHADERS_DS ds)
-Generate_Shaders(SHADERS_GS gs)
-Generate_Shaders(SHADERS_PS ps)
-Generate_Shaders(SHADERS_CS cs)
-Generate_Shaders(SHADERS_LIB lib)
+Generate_Shaders_SPIRV(SHADERS_VS vs)
+Generate_Shaders_SPIRV(SHADERS_HS hs)
+Generate_Shaders_SPIRV(SHADERS_DS ds)
+Generate_Shaders_SPIRV(SHADERS_GS gs)
+Generate_Shaders_SPIRV(SHADERS_PS ps)
+Generate_Shaders_SPIRV(SHADERS_CS cs)
+Generate_Shaders_SPIRV(SHADERS_LIB lib)
 
 add_custom_target(
-        Shaders_SPIRV
-        DEPENDS ${SPIRV_BINARY_FILES}
+		Shaders_SPIRV
+		DEPENDS ${SPIRV_BINARY_FILES}
 )
+
+set_property(TARGET "Shaders_SPIRV" PROPERTY FOLDER "Shaders")
+
+
+if (WIN32)
+	function(Generate_Shaders_DXC SHADERS_SRC_LIST SHADER_TYPE)
+		foreach (Shader IN LISTS ${SHADERS_SRC_LIST})
+			get_filename_component(FILE_NAME ${Shader} NAME_WLE)
+
+			set(DXC_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/${DXC_OUTPUT_DIR}/${FILE_NAME}.cso")
+			set(DXC_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/../${Shader}")
+			set(COMMAND_PARAMS ${DXC_TARGET}
+					"${DXC_SOURCE}"
+					-T "${SHADER_TYPE}_6_5"
+					-I "${CMAKE_CURRENT_SOURCE_DIR}/../"
+					-D HLSL6
+					-all-resources-bound
+					#-pack-optimized
+					-res-may-alias
+					-no-legacy-cbuf-layout
+					-flegacy-macro-expansion
+					-Fo ${DXC_OUTPUT}
+			)
+			
+			add_custom_command(
+					OUTPUT ${DXC_OUTPUT}
+					COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_SOURCE_DIR}/hlsl6/"
+					COMMAND ${COMMAND_PARAMS}
+					DEPENDS ${SPIRV_SOURCE}
+			)
+			list(APPEND DXC_BINARY_FILES ${DXC_OUTPUT})
+		endforeach()
+
+		set(DXC_BINARY_FILES ${DXC_BINARY_FILES} PARENT_SCOPE)
+	endfunction()
+
+	Generate_Shaders_DXC(SHADERS_VS vs)
+	Generate_Shaders_DXC(SHADERS_HS hs)
+	Generate_Shaders_DXC(SHADERS_DS ds)
+	Generate_Shaders_DXC(SHADERS_GS gs)
+	Generate_Shaders_DXC(SHADERS_PS ps)
+	Generate_Shaders_DXC(SHADERS_CS cs)
+	Generate_Shaders_DXC(SHADERS_LIB lib)
+
+	add_custom_target(
+			Shaders_DXC
+			DEPENDS ${DXC_BINARY_FILES}
+	)
+
+	set_property(TARGET "Shaders_DXC" PROPERTY FOLDER "Shaders")
+endif ()


### PR DESCRIPTION
- Cleanup CMake scripts to better support Windows and Linux build
- Shader compilation using dxc.exe for shader model 6.0 or higher (no dx11 shaders ATM)
- Correct build of dependencies
- Correct handle of Win32 entry point and rc compilation