### PR TITLE
Vulkan fix - use the destroy lock in DescriptorBinder::destroy() 

### DIFF
--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -1124,8 +1124,10 @@ using namespace Vulkan_Internal;
 	{
 		if (descriptorPool != VK_NULL_HANDLE)
 		{
+			device->allocationhandler->destroylocker.lock();
 			device->allocationhandler->destroyer_descriptorPools.push_back(std::make_pair(descriptorPool, device->FRAMECOUNT));
 			descriptorPool = VK_NULL_HANDLE;
+			device->allocationhandler->destroylocker.unlock();
 		}
 	}
 	void GraphicsDevice_Vulkan::FrameResources::DescriptorBinder::reset()

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -6143,6 +6143,10 @@ using namespace Vulkan_Internal;
 				}
 			}
 		}
+		for (int i = count; i < arraysize(vb_strides[cmd]); ++i)
+		{
+			vb_strides[cmd][i] = 0;
+		}
 
 		vkCmdBindVertexBuffers(GetDirectCommandList(cmd), static_cast<uint32_t>(slot), static_cast<uint32_t>(count), vbuffers, voffsets);
 


### PR DESCRIPTION
Uuse the destroy lock in DescriptorBinder::destroy() as it can be called from multiple threads via pool growth in DescriptorBinder::validate().