### PR TITLE
Async Compute

### DIFF
--- a/Content/Documentation/WickedEngine-Documentation.md
+++ b/Content/Documentation/WickedEngine-Documentation.md
@@ -49,6 +49,7 @@ This is a reference for the C++ features of Wicked Engine
 			2. [Creating resources](#creating-resources)
 			3. [Destroying resources](#destroying-resources)
 			4. [Work submission](#work-submission)
+			4. [Async compute](#async-compute)
 			5. [Presenting to the screen](#presenting-to-the-screen)
 			6. [Resource binding](#resource-binding)
 			6. [Bindless resources](#bindless-resources)
@@ -460,6 +461,22 @@ device->SubmitCommandLists(cmd_present); // CPU submits work for GPU
 When submitting command lists with `SubmitCommandLists()`, the CPU thread can be blocked in cases when there is too much GPU work submitted already that didn't finish. It's not appropriate to start recording new command lists until `SubmitCommandLists()` finished.
 
 Furthermore, the `BeginCommandList()` is thread safe, so the user can call it from worker threads if ordering between command lists is not a requirement (such as when they are producing workloads that are independent of each other).
+
+##### Async compute
+Async workload can be performed on the compute queue with `CommandList` granularity. The `BeginCommandList()` function has an optional `QUEUE_TYPE` parameter, which can be specified to execute the command list on the specified queue. By default, if no such parameter is specified, the work will be executed on the main graphics queue (`QUEUE_GRAPHICS`), serially to other such graphics work. In case the graphics device or API doesn't support async compute (such as DX11), then the `QUEUE_GRAPHICS` will be assumed. The main graphics queue can execute both graphics and compute work, but the `QUEUE_COMPUTE` can only execute compute work. Two queues can also be synchronized with `CommandList` granularity, with the `WaitCommandList()` function. This function inserts a dependency barrier before the first parameter command list, that synchronizes with the second parameter command list. For example:
+
+```cpp
+CommandList cmd0 = device->BeginCommandList(QUEUE_GRAPHICS);
+CommandList cmd1 = device->BeginCommandList(QUEUE_COMPUTE);
+device->WaitCommandList(cmd1, cmd0); // cmd1 waits for cmd0 to finish
+CommandList cmd2 = device->BeginCommandList(QUEUE_GRAPHICS); // cmd2 doesn't wait, it runs async with cmd1
+CommandList cmd3 = device->BeginCommandList(QUEUE_GRAPHICS);
+device->WaitCommandList(cmd3, cmd1); // cmd3 waits for cmd1 to finish
+
+device->SubmitCommandLists(); // execute all of the above
+```
+
+The `WaitCommandList()` function is a GPU wait operation, so it will not block CPU execution. Furthermore, it is not required to use this between two `CommandList`s that are on the same queue, because the synchronization between those is implicit.
 
 ##### Presenting to the screen
 To present to the screen (an operating system window), first create a SwapChain with the `CreateSwapChain()` function that will be associated with a window. The SwapChain acts as a special kind of [RenderPass](#render-passes), so there is a `BeginRenderPass()` function with an overload that accepts a SwapChain parameter instead of a RenderPass. Simply use this `BeginRenderPass()` and `EndRenderPass()` to draw to the SwapChain. The final presentation will happen when calling `SubmitCommandLists()`.

--- a/Content/Documentation/WickedEngine-Documentation.md
+++ b/Content/Documentation/WickedEngine-Documentation.md
@@ -478,6 +478,8 @@ device->SubmitCommandLists(); // execute all of the above
 
 The `WaitCommandList()` function is a GPU wait operation, so it will not block CPU execution. Furthermore, it is not required to use this between two `CommandList`s that are on the same queue, because the synchronization between those is implicit.
 
+Important: The `IMAGE_LAYOUT_SHADER_RESOURCE` and `BUFFER_STATE_SHADER_RESOURCE` states cannot be used on the compute queue. The device could convert these to `IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE` and `BUFFER_STATE_SHADER_RESOURCE_COMPUTE` respectively while issuing `Barrier()` commands. However, the starting resource state must be correctly specified, because those cannot be converted. Consider always choosing a `_SHADER_RESOURCE_COMPUTE` starting resource state if the resource is goig to be used in a compute queue, and transition them to regular `SHADER_RESOURCE` only before the resource is going to be used in a pixel shader. The graphics queue with compute commands doesn't have this limitation however.
+
 ##### Presenting to the screen
 To present to the screen (an operating system window), first create a SwapChain with the `CreateSwapChain()` function that will be associated with a window. The SwapChain acts as a special kind of [RenderPass](#render-passes), so there is a `BeginRenderPass()` function with an overload that accepts a SwapChain parameter instead of a RenderPass. Simply use this `BeginRenderPass()` and `EndRenderPass()` to draw to the SwapChain. The final presentation will happen when calling `SubmitCommandLists()`.
 

--- a/Content/Documentation/WickedEngine-Documentation.md
+++ b/Content/Documentation/WickedEngine-Documentation.md
@@ -49,7 +49,7 @@ This is a reference for the C++ features of Wicked Engine
 			2. [Creating resources](#creating-resources)
 			3. [Destroying resources](#destroying-resources)
 			4. [Work submission](#work-submission)
-			4. [Async compute](#async-compute)
+				1. [Async compute](#async-compute)
 			5. [Presenting to the screen](#presenting-to-the-screen)
 			6. [Resource binding](#resource-binding)
 			6. [Bindless resources](#bindless-resources)
@@ -462,7 +462,7 @@ When submitting command lists with `SubmitCommandLists()`, the CPU thread can be
 
 Furthermore, the `BeginCommandList()` is thread safe, so the user can call it from worker threads if ordering between command lists is not a requirement (such as when they are producing workloads that are independent of each other).
 
-##### Async compute
+###### Async compute
 Async workload can be performed on the compute queue with `CommandList` granularity. The `BeginCommandList()` function has an optional `QUEUE_TYPE` parameter, which can be specified to execute the command list on the specified queue. By default, if no such parameter is specified, the work will be executed on the main graphics queue (`QUEUE_GRAPHICS`), serially to other such graphics work. In case the graphics device or API doesn't support async compute (such as DX11), then the `QUEUE_GRAPHICS` will be assumed. The main graphics queue can execute both graphics and compute work, but the `QUEUE_COMPUTE` can only execute compute work. Two queues can also be synchronized with `CommandList` granularity, with the `WaitCommandList()` function. This function inserts a dependency barrier before the first parameter command list, that synchronizes with the second parameter command list. For example:
 
 ```cpp

--- a/WickedEngine/RenderPath3D.cpp
+++ b/WickedEngine/RenderPath3D.cpp
@@ -158,6 +158,7 @@ void RenderPath3D::ResizeBuffers()
 		desc.Format = FORMAT_R32G32B32A32_UINT;
 		desc.Width = internalResolution.x;
 		desc.Height = internalResolution.y;
+		desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE;
 		device->CreateTexture(&desc, nullptr, &rtShadow);
 		device->SetName(&rtShadow, "rtShadow");
 	}

--- a/WickedEngine/RenderPath3D.cpp
+++ b/WickedEngine/RenderPath3D.cpp
@@ -148,6 +148,7 @@ void RenderPath3D::ResizeBuffers()
 		desc.Format = FORMAT_R8_UNORM;
 		desc.Width = internalResolution.x;
 		desc.Height = internalResolution.y;
+		desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE;
 		device->CreateTexture(&desc, nullptr, &rtAO);
 		device->SetName(&rtAO, "rtAO");
 	}
@@ -267,7 +268,7 @@ void RenderPath3D::ResizeBuffers()
 		device->CreateTexture(&desc, nullptr, &depthBuffer_Main);
 		device->SetName(&depthBuffer_Main, "depthBuffer_Main");
 
-		desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE;
+		desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE;
 		desc.Format = FORMAT_R32_FLOAT;
 		desc.BindFlags = BIND_SHADER_RESOURCE | BIND_UNORDERED_ACCESS;
 		desc.SampleCount = 1;
@@ -307,6 +308,7 @@ void RenderPath3D::ResizeBuffers()
 		desc.Width = internalResolution.x;
 		desc.Height = internalResolution.y;
 		desc.MipLevels = 6;
+		desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE;
 		device->CreateTexture(&desc, nullptr, &rtLinearDepth);
 		device->SetName(&rtLinearDepth, "rtLinearDepth");
 

--- a/WickedEngine/wiGraphics.h
+++ b/WickedEngine/wiGraphics.h
@@ -290,6 +290,7 @@ namespace wiGraphics
 		IMAGE_LAYOUT_DEPTHSTENCIL,				// depth stencil, write enabled
 		IMAGE_LAYOUT_DEPTHSTENCIL_READONLY,		// depth stencil, read only
 		IMAGE_LAYOUT_SHADER_RESOURCE,			// shader resource, read only
+		IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE,	// shader resource, read only, non-pixel shader
 		IMAGE_LAYOUT_UNORDERED_ACCESS,			// shader resource, write enabled
 		IMAGE_LAYOUT_COPY_SRC,					// copy from
 		IMAGE_LAYOUT_COPY_DST,					// copy to
@@ -303,6 +304,7 @@ namespace wiGraphics
 		BUFFER_STATE_CONSTANT_BUFFER,			// constant buffer, read only
 		BUFFER_STATE_INDIRECT_ARGUMENT,			// argument buffer to DrawIndirect() or DispatchIndirect()
 		BUFFER_STATE_SHADER_RESOURCE,			// shader resource, read only
+		BUFFER_STATE_SHADER_RESOURCE_COMPUTE,	// shader resource, read only, non-pixel shader
 		BUFFER_STATE_UNORDERED_ACCESS,			// shader resource, write enabled
 		BUFFER_STATE_COPY_SRC,					// copy from
 		BUFFER_STATE_COPY_DST,					// copy to

--- a/WickedEngine/wiGraphicsDevice.h
+++ b/WickedEngine/wiGraphicsDevice.h
@@ -9,6 +9,14 @@ namespace wiGraphics
 	static const CommandList COMMANDLIST_COUNT = 32;
 	static const CommandList INVALID_COMMANDLIST = COMMANDLIST_COUNT;
 
+	enum QUEUE_TYPE
+	{
+		QUEUE_GRAPHICS,
+		QUEUE_COMPUTE,
+
+		QUEUE_COUNT,
+	};
+
 	class GraphicsDevice
 	{
 	protected:
@@ -55,7 +63,7 @@ namespace wiGraphics
 
 		// Begin a new command list for GPU command recording.
 		//	This will be valid until SubmitCommandLists() is called.
-		virtual CommandList BeginCommandList() = 0;
+		virtual CommandList BeginCommandList(QUEUE_TYPE queue = QUEUE_GRAPHICS) = 0;
 		// Submit all command list that were used with BeginCommandList before this call.
 		//	This will make every command list to be in "available" state and restarts them
 		virtual void SubmitCommandLists() = 0;
@@ -63,7 +71,7 @@ namespace wiGraphics
 		virtual void WaitForGPU() const = 0;
 		virtual void ClearPipelineStateCache() {};
 
-		inline uint64_t GetFrameCount() const { return FRAMECOUNT; }
+		constexpr uint64_t GetFrameCount() const { return FRAMECOUNT; }
 
 		inline bool CheckCapability(GRAPHICSDEVICE_CAPABILITY capability) const { return capabilities & capability; }
 
@@ -74,12 +82,12 @@ namespace wiGraphics
 
 		static constexpr uint32_t GetBufferCount() { return BUFFERCOUNT; }
 
-		inline bool IsDebugDevice() const { return DEBUGDEVICE; }
+		constexpr bool IsDebugDevice() const { return DEBUGDEVICE; }
 
-		inline size_t GetShaderIdentifierSize() const { return SHADER_IDENTIFIER_SIZE; }
-		inline size_t GetTopLevelAccelerationStructureInstanceSize() const { return TOPLEVEL_ACCELERATION_STRUCTURE_INSTANCE_SIZE; }
-		inline uint32_t GetVariableRateShadingTileSize() const { return VARIABLE_RATE_SHADING_TILE_SIZE; }
-		inline uint64_t GetTimestampFrequency() const { return TIMESTAMP_FREQUENCY; }
+		constexpr size_t GetShaderIdentifierSize() const { return SHADER_IDENTIFIER_SIZE; }
+		constexpr size_t GetTopLevelAccelerationStructureInstanceSize() const { return TOPLEVEL_ACCELERATION_STRUCTURE_INSTANCE_SIZE; }
+		constexpr uint32_t GetVariableRateShadingTileSize() const { return VARIABLE_RATE_SHADING_TILE_SIZE; }
+		constexpr uint64_t GetTimestampFrequency() const { return TIMESTAMP_FREQUENCY; }
 
 		virtual SHADERFORMAT GetShaderFormat() const { return SHADERFORMAT_NONE; }
 
@@ -87,6 +95,7 @@ namespace wiGraphics
 
 		///////////////Thread-sensitive////////////////////////
 
+		virtual void WaitCommandList(CommandList cmd, CommandList wait_for) {}
 		virtual void RenderPassBegin(const SwapChain* swapchain, CommandList cmd) = 0;
 		virtual void RenderPassBegin(const RenderPass* renderpass, CommandList cmd) = 0;
 		virtual void RenderPassEnd(CommandList cmd) = 0;

--- a/WickedEngine/wiGraphicsDevice_DX11.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX11.cpp
@@ -2595,7 +2595,7 @@ void GraphicsDevice_DX11::SetName(GPUResource* pResource, const char* name)
 	internal_state->resource->SetPrivateData(WKPDID_D3DDebugObjectName, (UINT)strlen(name), name);
 }
 
-CommandList GraphicsDevice_DX11::BeginCommandList()
+CommandList GraphicsDevice_DX11::BeginCommandList(QUEUE_TYPE queue)
 {
 	CommandList cmd = cmd_count.fetch_add(1);
 	assert(cmd < COMMANDLIST_COUNT);

--- a/WickedEngine/wiGraphicsDevice_DX11.h
+++ b/WickedEngine/wiGraphicsDevice_DX11.h
@@ -105,7 +105,7 @@ namespace wiGraphics
 
 		void WaitForGPU() const override;
 
-		CommandList BeginCommandList() override;
+		CommandList BeginCommandList(QUEUE_TYPE queue = QUEUE_GRAPHICS) override;
 		void SubmitCommandLists() override;
 
 		SHADERFORMAT GetShaderFormat() const override { return SHADERFORMAT_HLSL5; }

--- a/WickedEngine/wiGraphicsDevice_DX12.h
+++ b/WickedEngine/wiGraphicsDevice_DX12.h
@@ -31,14 +31,6 @@ namespace wiGraphics
 		Microsoft::WRL::ComPtr<ID3D12Device5> device;
 		Microsoft::WRL::ComPtr<IDXGIAdapter4> adapter;
 		Microsoft::WRL::ComPtr<IDXGIFactory6> factory;
-		struct CommandQueue
-		{
-			D3D12_COMMAND_QUEUE_DESC desc = {};
-			Microsoft::WRL::ComPtr<ID3D12CommandQueue> queue;
-			Microsoft::WRL::ComPtr<ID3D12Fence> fence;
-			ID3D12CommandList* submit_cmds[COMMANDLIST_COUNT] = {};
-			uint32_t submit_count = 0;
-		} queues[QUEUE_COUNT];
 
 		Microsoft::WRL::ComPtr<ID3D12CommandSignature> dispatchIndirectCommandSignature;
 		Microsoft::WRL::ComPtr<ID3D12CommandSignature> drawInstancedIndirectCommandSignature;
@@ -74,6 +66,15 @@ namespace wiGraphics
 		D3D12_CPU_DESCRIPTOR_HANDLE nullUAV_texture3d = {};
 
 		std::vector<D3D12_STATIC_SAMPLER_DESC> common_samplers;
+
+		struct CommandQueue
+		{
+			D3D12_COMMAND_QUEUE_DESC desc = {};
+			Microsoft::WRL::ComPtr<ID3D12CommandQueue> queue;
+			Microsoft::WRL::ComPtr<ID3D12Fence> fence;
+			ID3D12CommandList* submit_cmds[COMMANDLIST_COUNT] = {};
+			uint32_t submit_count = 0;
+		} queues[QUEUE_COUNT];
 
 		struct CopyAllocator
 		{

--- a/WickedEngine/wiGraphicsDevice_DX12.h
+++ b/WickedEngine/wiGraphicsDevice_DX12.h
@@ -31,7 +31,14 @@ namespace wiGraphics
 		Microsoft::WRL::ComPtr<ID3D12Device5> device;
 		Microsoft::WRL::ComPtr<IDXGIAdapter4> adapter;
 		Microsoft::WRL::ComPtr<IDXGIFactory6> factory;
-		Microsoft::WRL::ComPtr<ID3D12CommandQueue> graphicsQueue;
+		struct CommandQueue
+		{
+			D3D12_COMMAND_QUEUE_DESC desc = {};
+			Microsoft::WRL::ComPtr<ID3D12CommandQueue> queue;
+			Microsoft::WRL::ComPtr<ID3D12Fence> fence;
+			ID3D12CommandList* submit_cmds[COMMANDLIST_COUNT] = {};
+			uint32_t submit_count = 0;
+		} queues[QUEUE_COUNT];
 
 		Microsoft::WRL::ComPtr<ID3D12CommandSignature> dispatchIndirectCommandSignature;
 		Microsoft::WRL::ComPtr<ID3D12CommandSignature> drawInstancedIndirectCommandSignature;
@@ -199,9 +206,9 @@ namespace wiGraphics
 
 		struct FrameResources
 		{
-			Microsoft::WRL::ComPtr<ID3D12Fence> fence;
-			Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocators[COMMANDLIST_COUNT];
-			Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList4> commandLists[COMMANDLIST_COUNT];
+			Microsoft::WRL::ComPtr<ID3D12Fence> fence[QUEUE_COUNT];
+			Microsoft::WRL::ComPtr<ID3D12CommandAllocator> commandAllocators[COMMANDLIST_COUNT][QUEUE_COUNT];
+			Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList4> commandLists[COMMANDLIST_COUNT][QUEUE_COUNT];
 
 			struct ResourceFrameAllocator
 			{
@@ -221,7 +228,17 @@ namespace wiGraphics
 		};
 		FrameResources frames[BUFFERCOUNT];
 		FrameResources& GetFrameResources() { return frames[GetFrameCount() % BUFFERCOUNT]; }
-		inline ID3D12GraphicsCommandList6* GetCommandList(CommandList cmd) { return (ID3D12GraphicsCommandList6*)GetFrameResources().commandLists[cmd].Get(); }
+
+		struct CommandListMetadata
+		{
+			QUEUE_TYPE queue = {};
+			std::vector<CommandList> waits;
+		} cmd_meta[COMMANDLIST_COUNT];
+
+		inline ID3D12GraphicsCommandList6* GetCommandList(CommandList cmd)
+		{
+			return (ID3D12GraphicsCommandList6*)GetFrameResources().commandLists[cmd][cmd_meta[cmd].queue].Get();
+		}
 
 		struct DescriptorBinder
 		{
@@ -332,7 +349,7 @@ namespace wiGraphics
 
 		void SetName(GPUResource* pResource, const char* name) override;
 
-		CommandList BeginCommandList() override;
+		CommandList BeginCommandList(QUEUE_TYPE queue = QUEUE_GRAPHICS) override;
 		void SubmitCommandLists() override;
 
 		void WaitForGPU() const override;
@@ -344,6 +361,7 @@ namespace wiGraphics
 
 		///////////////Thread-sensitive////////////////////////
 
+		void WaitCommandList(CommandList cmd, CommandList wait_for) override;
 		void RenderPassBegin(const SwapChain* swapchain, CommandList cmd) override;
 		void RenderPassBegin(const RenderPass* renderpass, CommandList cmd) override;
 		void RenderPassEnd(CommandList cmd) override;

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -435,6 +435,7 @@ namespace Vulkan_Internal
 		case wiGraphics::IMAGE_LAYOUT_DEPTHSTENCIL_READONLY:
 			return VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
 		case wiGraphics::IMAGE_LAYOUT_SHADER_RESOURCE:
+		case wiGraphics::IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE:
 			return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 		case wiGraphics::IMAGE_LAYOUT_UNORDERED_ACCESS:
 			return VK_IMAGE_LAYOUT_GENERAL;
@@ -491,6 +492,7 @@ namespace Vulkan_Internal
 			flags |= VK_ACCESS_SHADER_READ_BIT;
 			break;
 		case wiGraphics::IMAGE_LAYOUT_SHADER_RESOURCE:
+		case wiGraphics::IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE:
 			flags |= VK_ACCESS_SHADER_READ_BIT;
 			break;
 		case wiGraphics::IMAGE_LAYOUT_UNORDERED_ACCESS:
@@ -532,6 +534,7 @@ namespace Vulkan_Internal
 			flags |= VK_ACCESS_INDIRECT_COMMAND_READ_BIT;
 			break;
 		case wiGraphics::BUFFER_STATE_SHADER_RESOURCE:
+		case wiGraphics::BUFFER_STATE_SHADER_RESOURCE_COMPUTE:
 			flags |= VK_ACCESS_SHADER_READ_BIT;
 			flags |= VK_ACCESS_UNIFORM_READ_BIT;
 			break;

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -5596,7 +5596,7 @@ using namespace Vulkan_Internal;
 		}
 	}
 
-	CommandList GraphicsDevice_Vulkan::BeginCommandList()
+	CommandList GraphicsDevice_Vulkan::BeginCommandList(QUEUE_TYPE queue)
 	{
 		VkResult res;
 

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -2246,6 +2246,7 @@ using namespace Vulkan_Internal;
 				queueCreateInfo.queueCount = 1;
 				queueCreateInfo.pQueuePriorities = &queuePriority;
 				queueCreateInfos.push_back(queueCreateInfo);
+				families.push_back((uint32_t)queueFamily);
 			}
 
 			VkDeviceCreateInfo createInfo = {};
@@ -2955,7 +2956,16 @@ using namespace Vulkan_Internal;
 
 		bufferInfo.flags = 0;
 
-		bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+		if (families.size() > 1)
+		{
+			bufferInfo.sharingMode = VK_SHARING_MODE_CONCURRENT;
+			bufferInfo.queueFamilyIndexCount = (uint32_t)families.size();
+			bufferInfo.pQueueFamilyIndices = families.data();
+		}
+		else
+		{
+			bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+		}
 
 
 
@@ -3178,7 +3188,16 @@ using namespace Vulkan_Internal;
 			imageInfo.flags |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
 		}
 
-		imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+		if (families.size() > 1)
+		{
+			imageInfo.sharingMode = VK_SHARING_MODE_CONCURRENT;
+			imageInfo.queueFamilyIndexCount = (uint32_t)families.size();
+			imageInfo.pQueueFamilyIndices = families.data();
+		}
+		else
+		{
+			imageInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+		}
 
 		switch (pTexture->desc.type)
 		{

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -2191,72 +2191,33 @@ using namespace Vulkan_Internal;
 			vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, queueFamilies.data());
 
 			// Query base queue families:
+			const uint32_t familyMask = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT;
 			int familyIndex = 0;
 			for (const auto& queueFamily : queueFamilies)
 			{
-				if (graphicsFamily < 0 && queueFamily.queueCount > 0 && queueFamily.queueFlags & VK_QUEUE_GRAPHICS_BIT)
+				if ((queueFamily.queueFlags & familyMask) && queueFamily.queueCount >= 3)
 				{
-					graphicsFamily = familyIndex;
-				}
-
-				if (copyFamily < 0 && queueFamily.queueCount > 0 && queueFamily.queueFlags & VK_QUEUE_TRANSFER_BIT)
-				{
-					copyFamily = familyIndex;
-				}
-
-				if (computeFamily < 0 && queueFamily.queueCount > 0 && queueFamily.queueFlags & VK_QUEUE_COMPUTE_BIT)
-				{
-					computeFamily = familyIndex;
+					family = familyIndex;
+					break;
 				}
 
 				familyIndex++;
 			}
+			assert(family >= 0);
 
-			// Now try to find dedicated compute and transfer queues:
-			familyIndex = 0;
-			for (const auto& queueFamily : queueFamilies)
-			{
-				if (queueFamily.queueCount > 0 &&
-					queueFamily.queueFlags & VK_QUEUE_TRANSFER_BIT &&
-					!(queueFamily.queueFlags & VK_QUEUE_GRAPHICS_BIT) &&
-					!(queueFamily.queueFlags & VK_QUEUE_COMPUTE_BIT)
-					) {
-					copyFamily = familyIndex;
-				}
-
-				if (queueFamily.queueCount > 0 &&
-					queueFamily.queueFlags & VK_QUEUE_COMPUTE_BIT &&
-					!(queueFamily.queueFlags & VK_QUEUE_GRAPHICS_BIT)
-					) {
-					computeFamily = familyIndex;
-				}
-
-				familyIndex++;
-			}
-
-			std::vector<VkDeviceQueueCreateInfo> queueCreateInfos;
-			std::set<int> uniqueQueueFamilies = { graphicsFamily, copyFamily, computeFamily };
-
-			float queuePriority = 1.0f;
-			for (int queueFamily : uniqueQueueFamilies)
-			{
-				VkDeviceQueueCreateInfo queueCreateInfo = {};
-				queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
-				queueCreateInfo.queueFamilyIndex = queueFamily;
-				queueCreateInfo.queueCount = 1;
-				queueCreateInfo.pQueuePriorities = &queuePriority;
-				queueCreateInfos.push_back(queueCreateInfo);
-			}
+			float priorities[] = { 1,1,1 };
+			VkDeviceQueueCreateInfo queueCreateInfo = {};
+			queueCreateInfo.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+			queueCreateInfo.queueFamilyIndex = family;
+			queueCreateInfo.queueCount = arraysize(priorities);
+			queueCreateInfo.pQueuePriorities = priorities;
 
 			VkDeviceCreateInfo createInfo = {};
 			createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
-
-			createInfo.queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfos.size());
-			createInfo.pQueueCreateInfos = queueCreateInfos.data();
-
+			createInfo.queueCreateInfoCount = 1;
+			createInfo.pQueueCreateInfos = &queueCreateInfo;
 			createInfo.pEnabledFeatures = nullptr;
 			createInfo.pNext = &features2;
-
 			createInfo.enabledExtensionCount = static_cast<uint32_t>(enabled_deviceExtensions.size());
 			createInfo.ppEnabledExtensionNames = enabled_deviceExtensions.data();
 
@@ -2275,10 +2236,33 @@ using namespace Vulkan_Internal;
 
 			volkLoadDevice(device);
 
-			vkGetDeviceQueue(device, graphicsFamily, 0, &graphicsQueue);
-			vkGetDeviceQueue(device, copyFamily, 0, &copyQueue);
-			vkGetDeviceQueue(device, computeFamily, 0, &computeQueue);
+			vkGetDeviceQueue(device, family, 0, &graphicsQueue);
+			vkGetDeviceQueue(device, family, 1, &computeQueue);
+			vkGetDeviceQueue(device, family, 2, &copyQueue);
 		}
+
+		// queues:
+		{
+			queues[QUEUE_GRAPHICS].queue = graphicsQueue;
+			queues[QUEUE_COMPUTE].queue = computeQueue;
+
+			VkSemaphoreTypeCreateInfo timelineCreateInfo = {};
+			timelineCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO;
+			timelineCreateInfo.pNext = nullptr;
+			timelineCreateInfo.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+			timelineCreateInfo.initialValue = 0;
+
+			VkSemaphoreCreateInfo createInfo = {};
+			createInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+			createInfo.pNext = &timelineCreateInfo;
+			createInfo.flags = 0;
+
+			res = vkCreateSemaphore(device, &createInfo, nullptr, &queues[QUEUE_GRAPHICS].semaphore);
+			assert(res == VK_SUCCESS);
+			res = vkCreateSemaphore(device, &createInfo, nullptr, &queues[QUEUE_COMPUTE].semaphore);
+			assert(res == VK_SUCCESS);
+		}
+
 
 		allocationhandler = std::make_shared<AllocationHandler>();
 		allocationhandler->device = device;
@@ -2296,17 +2280,17 @@ using namespace Vulkan_Internal;
 		res = vmaCreateAllocator(&allocatorInfo, &allocationhandler->allocator);
 		assert(res == VK_SUCCESS);
 
-		copyAllocator.Create(device, copyQueue, copyFamily);
+		copyAllocator.Create(device, copyQueue, family);
 
 		// Create frame resources:
 		for (uint32_t fr = 0; fr < BUFFERCOUNT; ++fr)
 		{
-			// Fence:
+			for (int queue = 0; queue < QUEUE_COUNT; ++queue)
 			{
 				VkFenceCreateInfo fenceInfo = {};
 				fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
 				//fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-				VkResult res = vkCreateFence(device, &fenceInfo, nullptr, &frames[fr].fence);
+				VkResult res = vkCreateFence(device, &fenceInfo, nullptr, &frames[fr].fence[queue]);
 				assert(res == VK_SUCCESS);
 			}
 
@@ -2314,7 +2298,7 @@ using namespace Vulkan_Internal;
 			{
 				VkCommandPoolCreateInfo poolInfo = {};
 				poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-				poolInfo.queueFamilyIndex = graphicsFamily;
+				poolInfo.queueFamilyIndex = family;
 				poolInfo.flags = 0; // Optional
 
 				res = vkCreateCommandPool(device, &poolInfo, nullptr, &frames[fr].transitionCommandPool);
@@ -2514,13 +2498,25 @@ using namespace Vulkan_Internal;
 	{
 		VkResult res = vkQueueWaitIdle(graphicsQueue);
 		assert(res == VK_SUCCESS);
+		res = vkQueueWaitIdle(computeQueue);
+		assert(res == VK_SUCCESS);
+		res = vkQueueWaitIdle(copyQueue);
+		assert(res == VK_SUCCESS);
+
+		for (auto& queue : queues)
+		{
+			vkDestroySemaphore(device, queue.semaphore, nullptr);
+		}
 
 		for (auto& frame : frames)
 		{
-			vkDestroyFence(device, frame.fence, nullptr);
-			for (auto& commandPool : frame.commandPools)
+			for (int queue = 0; queue < QUEUE_COUNT; ++queue)
 			{
-				vkDestroyCommandPool(device, commandPool, nullptr);
+				vkDestroyFence(device, frame.fence[queue], nullptr);
+				for (int cmd = 0; cmd < COMMANDLIST_COUNT; ++cmd)
+				{
+					vkDestroyCommandPool(device, frame.commandPools[cmd][queue], nullptr);
+				}
 			}
 			vkDestroyCommandPool(device, frame.transitionCommandPool, nullptr);
 
@@ -2679,21 +2675,9 @@ using namespace Vulkan_Internal;
 		createInfo.imageExtent = internal_state->swapChainExtent;
 		createInfo.imageArrayLayers = 1;
 		createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-
-		uint32_t queueFamilyIndices[] = { (uint32_t)graphicsFamily, (uint32_t)presentFamily };
-
-		if (graphicsFamily != presentFamily)
-		{
-			createInfo.imageSharingMode = VK_SHARING_MODE_CONCURRENT;
-			createInfo.queueFamilyIndexCount = 2;
-			createInfo.pQueueFamilyIndices = queueFamilyIndices;
-		}
-		else
-		{
-			createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
-			createInfo.queueFamilyIndexCount = 0; // Optional
-			createInfo.pQueueFamilyIndices = nullptr; // Optional
-		}
+		createInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+		createInfo.queueFamilyIndexCount = family; // Optional
+		createInfo.pQueueFamilyIndices = nullptr; // Optional
 
 		createInfo.preTransform = internal_state->swapchain_capabilities.currentTransform;
 		createInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
@@ -3059,10 +3043,6 @@ using namespace Vulkan_Internal;
 				{
 					barrier.dstAccessMask |= VK_ACCESS_SHADER_WRITE_BIT;
 				}
-
-				// transfer queue-ownership from copy to graphics:
-				barrier.srcQueueFamilyIndex = copyFamily;
-				barrier.dstQueueFamilyIndex = graphicsFamily;
 
 				vkCmdPipelineBarrier(
 					cmd.commandBuffer,
@@ -5605,6 +5585,8 @@ using namespace Vulkan_Internal;
 
 		CommandList cmd = cmd_count.fetch_add(1);
 		assert(cmd < COMMANDLIST_COUNT);
+		cmd_meta[cmd].queue = queue;
+		cmd_meta[cmd].waits.clear();
 
 		if (GetCommandList(cmd) == VK_NULL_HANDLE)
 		{
@@ -5614,19 +5596,19 @@ using namespace Vulkan_Internal;
 			{
 				VkCommandPoolCreateInfo poolInfo = {};
 				poolInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
-				poolInfo.queueFamilyIndex = graphicsFamily;
+				poolInfo.queueFamilyIndex = family;
 				poolInfo.flags = 0; // Optional
 
-				res = vkCreateCommandPool(device, &poolInfo, nullptr, &frame.commandPools[cmd]);
+				res = vkCreateCommandPool(device, &poolInfo, nullptr, &frame.commandPools[cmd][queue]);
 				assert(res == VK_SUCCESS);
 
 				VkCommandBufferAllocateInfo commandBufferInfo = {};
 				commandBufferInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
 				commandBufferInfo.commandBufferCount = 1;
-				commandBufferInfo.commandPool = frame.commandPools[cmd];
+				commandBufferInfo.commandPool = frame.commandPools[cmd][queue];
 				commandBufferInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
 
-				res = vkAllocateCommandBuffers(device, &commandBufferInfo, &frame.commandBuffers[cmd]);
+				res = vkAllocateCommandBuffers(device, &commandBufferInfo, &frame.commandBuffers[cmd][queue]);
 				assert(res == VK_SUCCESS);
 
 				frame.resourceBuffer[cmd].init(this, 1024 * 1024); // 1 MB starting size
@@ -5634,7 +5616,7 @@ using namespace Vulkan_Internal;
 			}
 		}
 
-		res = vkResetCommandPool(device, GetFrameResources().commandPools[cmd], 0);
+		res = vkResetCommandPool(device, GetFrameResources().commandPools[cmd][queue], 0);
 		assert(res == VK_SUCCESS);
 
 		VkCommandBufferBeginInfo beginInfo = {};
@@ -5642,7 +5624,7 @@ using namespace Vulkan_Internal;
 		beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 		beginInfo.pInheritanceInfo = nullptr; // Optional
 
-		res = vkBeginCommandBuffer(GetFrameResources().commandBuffers[cmd], &beginInfo);
+		res = vkBeginCommandBuffer(GetFrameResources().commandBuffers[cmd][queue], &beginInfo);
 		assert(res == VK_SUCCESS);
 
 		// reset descriptor allocators:
@@ -5651,18 +5633,21 @@ using namespace Vulkan_Internal;
 		// reset immediate resource allocators:
 		GetFrameResources().resourceBuffer[cmd].clear();
 
-		VkRect2D scissors[8];
-		for (int i = 0; i < arraysize(scissors); ++i)
+		if (queue == QUEUE_GRAPHICS)
 		{
-			scissors[i].offset.x = 0;
-			scissors[i].offset.y = 0;
-			scissors[i].extent.width = 65535;
-			scissors[i].extent.height = 65535;
-		}
-		vkCmdSetScissor(GetCommandList(cmd), 0, arraysize(scissors), scissors);
+			VkRect2D scissors[8];
+			for (int i = 0; i < arraysize(scissors); ++i)
+			{
+				scissors[i].offset.x = 0;
+				scissors[i].offset.y = 0;
+				scissors[i].extent.width = 65535;
+				scissors[i].extent.height = 65535;
+			}
+			vkCmdSetScissor(GetCommandList(cmd), 0, arraysize(scissors), scissors);
 
-		float blendConstants[] = { 1,1,1,1 };
-		vkCmdSetBlendConstants(GetCommandList(cmd), blendConstants);
+			float blendConstants[] = { 1,1,1,1 };
+			vkCmdSetBlendConstants(GetCommandList(cmd), blendConstants);
+		}
 
 		prev_pipeline_hash[cmd] = 0;
 		active_pso[cmd] = nullptr;
@@ -5683,16 +5668,18 @@ using namespace Vulkan_Internal;
 	}
 	void GraphicsDevice_Vulkan::SubmitCommandLists()
 	{
+		transitionLocker.lock();
 		VkResult res;
 
 		// Submit current frame:
 		{
 			auto& frame = GetFrameResources();
-			VkCommandBuffer cmdLists[COMMANDLIST_COUNT + 1]; // +1 : space for transition command buffer
-			uint32_t counter = 0;
+
+			QUEUE_TYPE submit_queue = QUEUE_COUNT;
 
 			// Transitions:
-			transitionLocker.lock();
+			bool submit_transitions = false;
+			if(!transitions.empty())
 			{
 				vkCmdPipelineBarrier(
 					frame.transitionCommandBuffer,
@@ -5709,47 +5696,71 @@ using namespace Vulkan_Internal;
 				res = vkEndCommandBuffer(frame.transitionCommandBuffer);
 				assert(res == VK_SUCCESS);
 
-				cmdLists[counter++] = frame.transitionCommandBuffer;
+				submit_transitions = true;
 			}
-			transitionLocker.unlock();
-
-			submit_swapchains.clear();
-			submit_swapChainImageIndices.clear();
-			submit_waitStages.clear();
-			submit_waitSemaphores.clear();
-			submit_waitValues.clear();
-			submit_signalSemaphores.clear();
 
 			uint64_t copy_sync = copyAllocator.flush();
-			if (copy_sync > 0)
-			{
-				submit_waitStages.push_back(VK_PIPELINE_STAGE_TRANSFER_BIT);
-				submit_waitSemaphores.push_back(copyAllocator.semaphore);
-				submit_waitValues.push_back(copy_sync);
-			}
 
 			CommandList cmd_last = cmd_count.load();
 			cmd_count.store(0);
 			for (CommandList cmd = 0; cmd < cmd_last; ++cmd)
 			{
-				for (auto& swapchain : prev_swapchains[cmd])
-				{
-					auto internal_state = to_internal(swapchain);
-
-					submit_swapchains.push_back(internal_state->swapChain);
-					submit_swapChainImageIndices.push_back(internal_state->swapChainImageIndex);
-					submit_waitStages.push_back(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-					submit_waitSemaphores.push_back(internal_state->swapchainAcquireSemaphore);
-					submit_waitValues.push_back(0); // not a timeline semaphore
-					submit_signalSemaphores.push_back(internal_state->swapchainReleaseSemaphore);
-				}
-
 				barrier_flush(cmd);
 
 				res = vkEndCommandBuffer(GetCommandList(cmd));
 				assert(res == VK_SUCCESS);
 
-				cmdLists[counter++] = GetCommandList(cmd);
+				const CommandListMetadata& meta = cmd_meta[cmd];
+				if (submit_queue == QUEUE_COUNT) // start first batch
+				{
+					submit_queue = meta.queue;
+				}
+				if (submit_queue != meta.queue || !meta.waits.empty()) // new queue type or wait breaks submit batch
+				{
+					// New batch signals its last cmd:
+					queues[submit_queue].submit_signalSemaphores.push_back(queues[submit_queue].semaphore);
+					queues[submit_queue].submit_signalValues.push_back(FRAMECOUNT * COMMANDLIST_COUNT + (uint64_t)cmd);
+					queues[submit_queue].submit(VK_NULL_HANDLE);
+					submit_queue = meta.queue;
+
+					for (auto& wait : meta.waits)
+					{
+						// record wait for signal on a previous submit:
+						const CommandListMetadata& wait_meta = cmd_meta[wait];
+						queues[submit_queue].submit_waitStages.push_back(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+						queues[submit_queue].submit_waitSemaphores.push_back(queues[wait_meta.queue].semaphore);
+						queues[submit_queue].submit_waitValues.push_back(FRAMECOUNT * COMMANDLIST_COUNT + (uint64_t)wait);
+					}
+				}
+
+				if (copy_sync > 0)
+				{
+					queues[submit_queue].submit_waitStages.push_back(VK_PIPELINE_STAGE_TRANSFER_BIT);
+					queues[submit_queue].submit_waitSemaphores.push_back(copyAllocator.semaphore);
+					queues[submit_queue].submit_waitValues.push_back(copy_sync);
+					copy_sync = 0;
+				}
+
+				if (submit_transitions)
+				{
+					queues[submit_queue].submit_cmds.push_back(frame.transitionCommandBuffer);
+					submit_transitions = false;
+				}
+
+				for (auto& swapchain : prev_swapchains[cmd])
+				{
+					auto internal_state = to_internal(swapchain);
+
+					queues[submit_queue].submit_swapchains.push_back(internal_state->swapChain);
+					queues[submit_queue].submit_swapChainImageIndices.push_back(internal_state->swapChainImageIndex);
+					queues[submit_queue].submit_waitStages.push_back(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+					queues[submit_queue].submit_waitSemaphores.push_back(internal_state->swapchainAcquireSemaphore);
+					queues[submit_queue].submit_waitValues.push_back(0); // not a timeline semaphore
+					queues[submit_queue].submit_signalSemaphores.push_back(internal_state->swapchainReleaseSemaphore);
+					queues[submit_queue].submit_signalValues.push_back(0); // not a timeline semaphore
+				}
+
+				queues[submit_queue].submit_cmds.push_back(GetCommandList(cmd));
 
 				for (auto& x : pipelines_worker[cmd])
 				{
@@ -5767,40 +5778,11 @@ using namespace Vulkan_Internal;
 				pipelines_worker[cmd].clear();
 			}
 
-			VkSubmitInfo submitInfo = {};
-			submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-			submitInfo.commandBufferCount = counter;
-			submitInfo.pCommandBuffers = cmdLists;
-
-			submitInfo.waitSemaphoreCount = (uint32_t)submit_waitSemaphores.size();
-			submitInfo.pWaitSemaphores = submit_waitSemaphores.data();
-			submitInfo.pWaitDstStageMask = submit_waitStages.data();
-
-			submitInfo.signalSemaphoreCount = (uint32_t)submit_signalSemaphores.size();
-			submitInfo.pSignalSemaphores = submit_signalSemaphores.data();
-
-			VkTimelineSemaphoreSubmitInfo timelineInfo = {};
-			timelineInfo.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
-			timelineInfo.pNext = nullptr;
-			timelineInfo.waitSemaphoreValueCount = (uint32_t)submit_waitValues.size();
-			timelineInfo.pWaitSemaphoreValues = submit_waitValues.data();
-			timelineInfo.signalSemaphoreValueCount = 0;
-			timelineInfo.pSignalSemaphoreValues = nullptr;
-
-			submitInfo.pNext = &timelineInfo;
-
-			res = vkQueueSubmit(graphicsQueue, 1, &submitInfo, frame.fence);
-			assert(res == VK_SUCCESS);
-
-			VkPresentInfoKHR presentInfo = {};
-			presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-			presentInfo.waitSemaphoreCount = (uint32_t)submit_signalSemaphores.size();
-			presentInfo.pWaitSemaphores = submit_signalSemaphores.data();
-			presentInfo.swapchainCount = (uint32_t)submit_swapchains.size();
-			presentInfo.pSwapchains = submit_swapchains.data();
-			presentInfo.pImageIndices = submit_swapChainImageIndices.data();
-			res = vkQueuePresentKHR(graphicsQueue, &presentInfo);
-			assert(res == VK_SUCCESS);
+			// final submits with fences:
+			for (int queue = 0; queue < QUEUE_COUNT; ++queue)
+			{
+				queues[queue].submit(frame.fence[queue]);
+			}
 		}
 
 		// From here, we begin a new frame, this affects GetFrameResources()!
@@ -5813,11 +5795,14 @@ using namespace Vulkan_Internal;
 			// Initiate stalling CPU when GPU is not yet finished with next frame:
 			if (FRAMECOUNT >= BUFFERCOUNT)
 			{
-				res = vkWaitForFences(device, 1, &frame.fence, true, 0xFFFFFFFFFFFFFFFF);
-				assert(res == VK_SUCCESS);
+				for (int queue = 0; queue < QUEUE_COUNT; ++queue)
+				{
+					res = vkWaitForFences(device, 1, &frame.fence[queue], true, 0xFFFFFFFFFFFFFFFF);
+					assert(res == VK_SUCCESS);
 
-				res = vkResetFences(device, 1, &frame.fence);
-				assert(res == VK_SUCCESS);
+					res = vkResetFences(device, 1, &frame.fence[queue]);
+					assert(res == VK_SUCCESS);
+				}
 			}
 
 			allocationhandler->Update(FRAMECOUNT, BUFFERCOUNT);
@@ -5836,6 +5821,7 @@ using namespace Vulkan_Internal;
 				assert(res == VK_SUCCESS);
 			}
 		}
+		transitionLocker.unlock();
 	}
 
 	void GraphicsDevice_Vulkan::WaitForGPU() const
@@ -5891,6 +5877,12 @@ using namespace Vulkan_Internal;
 	}
 
 
+	void GraphicsDevice_Vulkan::WaitCommandList(CommandList cmd, CommandList wait_for)
+	{
+		CommandListMetadata& wait_meta = cmd_meta[wait_for];
+		assert(wait_for < cmd); // command list cannot wait for future command list!
+		cmd_meta[cmd].waits.push_back(wait_for);
+	}
 	void GraphicsDevice_Vulkan::RenderPassBegin(const SwapChain* swapchain, CommandList cmd)
 	{
 		auto internal_state = to_internal(swapchain);

--- a/WickedEngine/wiGraphicsDevice_Vulkan.h
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.h
@@ -405,7 +405,7 @@ namespace wiGraphics
 
 		void SetName(GPUResource* pResource, const char* name) override;
 
-		CommandList BeginCommandList() override;
+		CommandList BeginCommandList(QUEUE_TYPE queue = QUEUE_GRAPHICS) override;
 		void SubmitCommandLists() override;
 
 		void WaitForGPU() const override;

--- a/WickedEngine/wiGraphicsDevice_Vulkan.h
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.h
@@ -35,11 +35,51 @@ namespace wiGraphics
 	    VkDebugUtilsMessengerEXT debugUtilsMessenger = VK_NULL_HANDLE;
 		VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
 		VkDevice device = VK_NULL_HANDLE;
-		int family = -1;
+		std::vector<VkQueueFamilyProperties> queueFamilies;
+		int graphicsFamily = -1;
+		int computeFamily = -1;
+		int copyFamily = -1;
 		VkQueue graphicsQueue = VK_NULL_HANDLE;
 		VkQueue computeQueue = VK_NULL_HANDLE;
 		VkQueue copyQueue = VK_NULL_HANDLE;
-		std::vector<VkQueueFamilyProperties> queueFamilies;
+
+		VkPhysicalDeviceProperties2 properties2 = {};
+		VkPhysicalDeviceVulkan11Properties properties_1_1 = {};
+		VkPhysicalDeviceVulkan12Properties properties_1_2 = {};
+		VkPhysicalDeviceAccelerationStructurePropertiesKHR acceleration_structure_properties = {};
+		VkPhysicalDeviceRayTracingPipelinePropertiesKHR raytracing_properties = {};
+		VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_properties = {};
+		VkPhysicalDeviceMeshShaderPropertiesNV mesh_shader_properties = {};
+
+		VkPhysicalDeviceFeatures2 features2 = {};
+		VkPhysicalDeviceVulkan11Features features_1_1 = {};
+		VkPhysicalDeviceVulkan12Features features_1_2 = {};
+		VkPhysicalDeviceAccelerationStructureFeaturesKHR acceleration_structure_features = {};
+		VkPhysicalDeviceRayTracingPipelineFeaturesKHR raytracing_features = {};
+		VkPhysicalDeviceRayQueryFeaturesKHR raytracing_query_features = {};
+		VkPhysicalDeviceFragmentShadingRateFeaturesKHR fragment_shading_rate_features = {};
+		VkPhysicalDeviceMeshShaderFeaturesNV mesh_shader_features = {};
+
+		std::vector<VkDynamicState> pso_dynamicStates;
+		VkPipelineDynamicStateCreateInfo dynamicStateInfo = {};
+
+		VkBuffer		nullBuffer = VK_NULL_HANDLE;
+		VmaAllocation	nullBufferAllocation = VK_NULL_HANDLE;
+		VkBufferView	nullBufferView = VK_NULL_HANDLE;
+		VkSampler		nullSampler = VK_NULL_HANDLE;
+		VmaAllocation	nullImageAllocation1D = VK_NULL_HANDLE;
+		VmaAllocation	nullImageAllocation2D = VK_NULL_HANDLE;
+		VmaAllocation	nullImageAllocation3D = VK_NULL_HANDLE;
+		VkImage			nullImage1D = VK_NULL_HANDLE;
+		VkImage			nullImage2D = VK_NULL_HANDLE;
+		VkImage			nullImage3D = VK_NULL_HANDLE;
+		VkImageView		nullImageView1D = VK_NULL_HANDLE;
+		VkImageView		nullImageView1DArray = VK_NULL_HANDLE;
+		VkImageView		nullImageView2D = VK_NULL_HANDLE;
+		VkImageView		nullImageView2DArray = VK_NULL_HANDLE;
+		VkImageView		nullImageViewCube = VK_NULL_HANDLE;
+		VkImageView		nullImageViewCubeArray = VK_NULL_HANDLE;
+		VkImageView		nullImageView3D = VK_NULL_HANDLE;
 
 		struct CommandQueue
 		{
@@ -105,44 +145,6 @@ namespace wiGraphics
 			}
 
 		} queues[QUEUE_COUNT];
-
-		VkPhysicalDeviceProperties2 properties2 = {};
-		VkPhysicalDeviceVulkan11Properties properties_1_1 = {};
-		VkPhysicalDeviceVulkan12Properties properties_1_2 = {};
-		VkPhysicalDeviceAccelerationStructurePropertiesKHR acceleration_structure_properties = {};
-		VkPhysicalDeviceRayTracingPipelinePropertiesKHR raytracing_properties = {};
-		VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_properties = {};
-		VkPhysicalDeviceMeshShaderPropertiesNV mesh_shader_properties = {};
-
-		VkPhysicalDeviceFeatures2 features2 = {};
-		VkPhysicalDeviceVulkan11Features features_1_1 = {};
-		VkPhysicalDeviceVulkan12Features features_1_2 = {};
-		VkPhysicalDeviceAccelerationStructureFeaturesKHR acceleration_structure_features = {};
-		VkPhysicalDeviceRayTracingPipelineFeaturesKHR raytracing_features = {};
-		VkPhysicalDeviceRayQueryFeaturesKHR raytracing_query_features = {};
-		VkPhysicalDeviceFragmentShadingRateFeaturesKHR fragment_shading_rate_features = {};
-		VkPhysicalDeviceMeshShaderFeaturesNV mesh_shader_features = {};
-
-		std::vector<VkDynamicState> pso_dynamicStates;
-		VkPipelineDynamicStateCreateInfo dynamicStateInfo = {};
-
-		VkBuffer		nullBuffer = VK_NULL_HANDLE;
-		VmaAllocation	nullBufferAllocation = VK_NULL_HANDLE;
-		VkBufferView	nullBufferView = VK_NULL_HANDLE;
-		VkSampler		nullSampler = VK_NULL_HANDLE;
-		VmaAllocation	nullImageAllocation1D = VK_NULL_HANDLE;
-		VmaAllocation	nullImageAllocation2D = VK_NULL_HANDLE;
-		VmaAllocation	nullImageAllocation3D = VK_NULL_HANDLE;
-		VkImage			nullImage1D = VK_NULL_HANDLE;
-		VkImage			nullImage2D = VK_NULL_HANDLE;
-		VkImage			nullImage3D = VK_NULL_HANDLE;
-		VkImageView		nullImageView1D = VK_NULL_HANDLE;
-		VkImageView		nullImageView1DArray = VK_NULL_HANDLE;
-		VkImageView		nullImageView2D = VK_NULL_HANDLE;
-		VkImageView		nullImageView2DArray = VK_NULL_HANDLE;
-		VkImageView		nullImageViewCube = VK_NULL_HANDLE;
-		VkImageView		nullImageViewCubeArray = VK_NULL_HANDLE;
-		VkImageView		nullImageView3D = VK_NULL_HANDLE;
 
 		struct CopyAllocator
 		{

--- a/WickedEngine/wiGraphicsDevice_Vulkan.h
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.h
@@ -39,6 +39,7 @@ namespace wiGraphics
 		int graphicsFamily = -1;
 		int computeFamily = -1;
 		int copyFamily = -1;
+		std::vector<uint32_t> families;
 		VkQueue graphicsQueue = VK_NULL_HANDLE;
 		VkQueue computeQueue = VK_NULL_HANDLE;
 		VkQueue copyQueue = VK_NULL_HANDLE;

--- a/WickedEngine/wiGraphicsDevice_Vulkan.h
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.h
@@ -35,13 +35,76 @@ namespace wiGraphics
 	    VkDebugUtilsMessengerEXT debugUtilsMessenger = VK_NULL_HANDLE;
 		VkPhysicalDevice physicalDevice = VK_NULL_HANDLE;
 		VkDevice device = VK_NULL_HANDLE;
-		int graphicsFamily = -1;
-		int copyFamily = -1;
-		int computeFamily = -1;
+		int family = -1;
 		VkQueue graphicsQueue = VK_NULL_HANDLE;
 		VkQueue computeQueue = VK_NULL_HANDLE;
 		VkQueue copyQueue = VK_NULL_HANDLE;
 		std::vector<VkQueueFamilyProperties> queueFamilies;
+
+		struct CommandQueue
+		{
+			VkQueue queue = VK_NULL_HANDLE;
+			VkSemaphore semaphore = VK_NULL_HANDLE;
+			std::vector<VkSwapchainKHR> submit_swapchains;
+			std::vector<uint32_t> submit_swapChainImageIndices;
+			std::vector<VkPipelineStageFlags> submit_waitStages;
+			std::vector<VkSemaphore> submit_waitSemaphores;
+			std::vector<uint64_t> submit_waitValues;
+			std::vector<VkSemaphore> submit_signalSemaphores;
+			std::vector<uint64_t> submit_signalValues;
+			std::vector<VkCommandBuffer> submit_cmds;
+
+			void submit(VkFence fence)
+			{
+				VkSubmitInfo submitInfo = {};
+				submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+				submitInfo.commandBufferCount = (uint32_t)submit_cmds.size();
+				submitInfo.pCommandBuffers = submit_cmds.data();
+
+				submitInfo.waitSemaphoreCount = (uint32_t)submit_waitSemaphores.size();
+				submitInfo.pWaitSemaphores = submit_waitSemaphores.data();
+				submitInfo.pWaitDstStageMask = submit_waitStages.data();
+
+				submitInfo.signalSemaphoreCount = (uint32_t)submit_signalSemaphores.size();
+				submitInfo.pSignalSemaphores = submit_signalSemaphores.data();
+
+				VkTimelineSemaphoreSubmitInfo timelineInfo = {};
+				timelineInfo.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
+				timelineInfo.pNext = nullptr;
+				timelineInfo.waitSemaphoreValueCount = (uint32_t)submit_waitValues.size();
+				timelineInfo.pWaitSemaphoreValues = submit_waitValues.data();
+				timelineInfo.signalSemaphoreValueCount = (uint32_t)submit_signalValues.size();
+				timelineInfo.pSignalSemaphoreValues = submit_signalValues.data();
+
+				submitInfo.pNext = &timelineInfo;
+
+				VkResult res = vkQueueSubmit(queue, 1, &submitInfo, fence);
+				assert(res == VK_SUCCESS);
+
+				if (!submit_swapchains.empty())
+				{
+					VkPresentInfoKHR presentInfo = {};
+					presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+					presentInfo.waitSemaphoreCount = (uint32_t)submit_signalSemaphores.size();
+					presentInfo.pWaitSemaphores = submit_signalSemaphores.data();
+					presentInfo.swapchainCount = (uint32_t)submit_swapchains.size();
+					presentInfo.pSwapchains = submit_swapchains.data();
+					presentInfo.pImageIndices = submit_swapChainImageIndices.data();
+					res = vkQueuePresentKHR(queue, &presentInfo);
+					assert(res == VK_SUCCESS);
+				}
+
+				submit_swapchains.clear();
+				submit_swapChainImageIndices.clear();
+				submit_waitStages.clear();
+				submit_waitSemaphores.clear();
+				submit_waitValues.clear();
+				submit_signalSemaphores.clear();
+				submit_signalValues.clear();
+				submit_cmds.clear();
+			}
+
+		} queues[QUEUE_COUNT];
 
 		VkPhysicalDeviceProperties2 properties2 = {};
 		VkPhysicalDeviceVulkan11Properties properties_1_1 = {};
@@ -119,7 +182,8 @@ namespace wiGraphics
 				createInfo.pNext = &timelineCreateInfo;
 				createInfo.flags = 0;
 
-				vkCreateSemaphore(device, &createInfo, nullptr, &semaphore);
+				VkResult res = vkCreateSemaphore(device, &createInfo, nullptr, &semaphore);
+				assert(res == VK_SUCCESS);
 			}
 			void Destroy()
 			{
@@ -263,9 +327,9 @@ namespace wiGraphics
 
 		struct FrameResources
 		{
-			VkFence fence = VK_NULL_HANDLE;
-			VkCommandPool commandPools[COMMANDLIST_COUNT] = {};
-			VkCommandBuffer commandBuffers[COMMANDLIST_COUNT] = {};
+			VkFence fence[QUEUE_COUNT] = {};
+			VkCommandPool commandPools[COMMANDLIST_COUNT][QUEUE_COUNT] = {};
+			VkCommandBuffer commandBuffers[COMMANDLIST_COUNT][QUEUE_COUNT] = {};
 
 			VkCommandPool transitionCommandPool = VK_NULL_HANDLE;
 			VkCommandBuffer transitionCommandBuffer = VK_NULL_HANDLE;
@@ -318,7 +382,17 @@ namespace wiGraphics
 		FrameResources frames[BUFFERCOUNT];
 		const FrameResources& GetFrameResources() const { return frames[GetFrameCount() % BUFFERCOUNT]; }
 		FrameResources& GetFrameResources() { return frames[GetFrameCount() % BUFFERCOUNT]; }
-		inline VkCommandBuffer GetCommandList(CommandList cmd) { return GetFrameResources().commandBuffers[cmd]; }
+
+		struct CommandListMetadata
+		{
+			QUEUE_TYPE queue = {};
+			std::vector<CommandList> waits;
+		} cmd_meta[COMMANDLIST_COUNT];
+
+		inline VkCommandBuffer GetCommandList(CommandList cmd)
+		{
+			return GetFrameResources().commandBuffers[cmd][cmd_meta[cmd].queue];
+		}
 
 		std::vector<VkMemoryBarrier> frame_memoryBarriers[COMMANDLIST_COUNT];
 		std::vector<VkImageMemoryBarrier> frame_imageBarriers[COMMANDLIST_COUNT];
@@ -365,13 +439,6 @@ namespace wiGraphics
 
 		std::vector<StaticSampler> common_samplers;
 
-		std::vector<VkSwapchainKHR> submit_swapchains;
-		std::vector<uint32_t> submit_swapChainImageIndices;
-		std::vector<VkPipelineStageFlags> submit_waitStages;
-		std::vector<VkSemaphore> submit_waitSemaphores;
-		std::vector<uint64_t> submit_waitValues;
-		std::vector<VkSemaphore> submit_signalSemaphores;
-
 	public:
 		GraphicsDevice_Vulkan(wiPlatform::window_type window, bool debuglayer = false);
 		virtual ~GraphicsDevice_Vulkan();
@@ -417,6 +484,7 @@ namespace wiGraphics
 
 		///////////////Thread-sensitive////////////////////////
 
+		void WaitCommandList(CommandList cmd, CommandList wait_for) override;
 		void RenderPassBegin(const SwapChain* swapchain, CommandList cmd) override;
 		void RenderPassBegin(const RenderPass* renderpass, CommandList cmd) override;
 		void RenderPassEnd(CommandList cmd) override;

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -8440,6 +8440,7 @@ void CreateSSAOResources(SSAOResources& res, XMUINT2 resolution)
 	desc.Width = (resolution.x + 1) / 2;
 	desc.Height = (resolution.y + 1) / 2;
 	desc.BindFlags = BIND_UNORDERED_ACCESS | BIND_SHADER_RESOURCE;
+	desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE;
 	device->CreateTexture(&desc, nullptr, &res.temp0);
 	device->CreateTexture(&desc, nullptr, &res.temp1);
 }
@@ -8640,7 +8641,7 @@ void CreateMSAOResources(MSAOResources& res, XMUINT2 resolution)
 	saved_desc.Width = resolution.x;
 	saved_desc.Height = resolution.y;
 	saved_desc.BindFlags = BIND_SHADER_RESOURCE | BIND_UNORDERED_ACCESS;
-	saved_desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE;
+	saved_desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE;
 
 	const uint32_t bufferWidth = saved_desc.Width;
 	const uint32_t bufferWidth1 = (bufferWidth + 1) / 2;
@@ -9122,6 +9123,7 @@ void CreateRTAOResources(RTAOResources& res, XMUINT2 resolution)
 	desc.Width = (resolution.x + 1) / 2;
 	desc.Height = (resolution.y + 1) / 2;
 	desc.BindFlags = BIND_SHADER_RESOURCE | BIND_UNORDERED_ACCESS;
+	desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE;
 	device->CreateTexture(&desc, nullptr, &res.temp);
 	device->SetName(&res.temp, "rtao_temp");
 
@@ -9613,6 +9615,7 @@ void CreateSSRResources(SSRResources& res, XMUINT2 resolution)
 	cast_desc.Height = (resolution.y + 1) / 2;
 	cast_desc.Format = FORMAT_R16G16B16A16_FLOAT;
 	cast_desc.BindFlags = BIND_SHADER_RESOURCE | BIND_UNORDERED_ACCESS;
+	cast_desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE;
 	device->CreateTexture(&cast_desc, nullptr, &res.texture_raytrace);
 
 	TextureDesc buffer_desc;
@@ -9621,6 +9624,7 @@ void CreateSSRResources(SSRResources& res, XMUINT2 resolution)
 	buffer_desc.Height = resolution.y;
 	buffer_desc.Format = FORMAT_R16G16B16A16_FLOAT;
 	buffer_desc.BindFlags = BIND_SHADER_RESOURCE | BIND_UNORDERED_ACCESS;
+	buffer_desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE;
 	device->CreateTexture(&buffer_desc, nullptr, &res.texture_resolve);
 	device->CreateTexture(&buffer_desc, nullptr, &res.texture_temporal[0]);
 	device->CreateTexture(&buffer_desc, nullptr, &res.texture_temporal[1]);
@@ -9843,6 +9847,7 @@ void CreateRTShadowResources(RTShadowResources& res, XMUINT2 resolution)
 	desc.Height = (resolution.y + 1) / 2;
 	desc.Format = FORMAT_R32G32B32A32_UINT;
 	desc.BindFlags = BIND_SHADER_RESOURCE | BIND_UNORDERED_ACCESS;
+	desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE;
 	device->CreateTexture(&desc, nullptr, &res.temp);
 	device->SetName(&res.temp, "rtshadow_temp");
 
@@ -10027,6 +10032,7 @@ void CreateScreenSpaceShadowResources(ScreenSpaceShadowResources& res, XMUINT2 r
 	desc.Height = (resolution.y + 1) / 2;
 	desc.Format = FORMAT_R32G32B32A32_UINT;
 	desc.BindFlags = BIND_SHADER_RESOURCE | BIND_UNORDERED_ACCESS;
+	desc.layout = IMAGE_LAYOUT_SHADER_RESOURCE_COMPUTE;
 	device->CreateTexture(&desc, nullptr, &res.temp);
 	device->SetName(&res.temp, "screenspaceshadow_temp");
 }

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -2069,11 +2069,6 @@ void LoadBuffers()
 	device->CreateBuffer(&bd, nullptr, &constantBuffers[CBTYPE_FRAME]);
 	device->SetName(&constantBuffers[CBTYPE_FRAME], "FrameCB");
 
-	bd.ByteWidth = sizeof(CameraCB);
-	bd.BindFlags = BIND_CONSTANT_BUFFER;
-	device->CreateBuffer(&bd, nullptr, &constantBuffers[CBTYPE_CAMERA]);
-	device->SetName(&constantBuffers[CBTYPE_CAMERA], "CameraCB");
-
 
 	bd.ByteWidth = sizeof(ShaderEntity) * SHADER_ENTITY_COUNT;
 	bd.BindFlags = BIND_SHADER_RESOURCE;
@@ -2095,6 +2090,10 @@ void LoadBuffers()
 	bd.CPUAccessFlags = CPU_ACCESS_WRITE;
 	bd.MiscFlags = 0;
 	bd.BindFlags = BIND_CONSTANT_BUFFER;
+
+	bd.ByteWidth = sizeof(CameraCB);
+	device->CreateBuffer(&bd, nullptr, &constantBuffers[CBTYPE_CAMERA]);
+	device->SetName(&constantBuffers[CBTYPE_CAMERA], "CameraCB");
 
 	bd.ByteWidth = sizeof(MiscCB);
 	device->CreateBuffer(&bd, nullptr, &constantBuffers[CBTYPE_MISC]);

--- a/WickedEngine/wiVersion.cpp
+++ b/WickedEngine/wiVersion.cpp
@@ -9,7 +9,7 @@ namespace wiVersion
 	// minor features, major updates, breaking compatibility changes
 	const int minor = 56;
 	// minor bug fixes, alterations, refactors, updates
-	const int revision = 3;
+	const int revision = 4;
 
 	const std::string version_string = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(revision);
 


### PR DESCRIPTION
Exposing async compute functionality in the GraphicsDevice in a simple way:
- BeginCommandList() now accepts a paramter like `QUEUE_COMPUTE` to indicate the used queue for the workload
- WaitCommandList(cmd, wait_cmd) is providing functionality to synchronize executin between two command lists that are on separate queues

RenderPath3D uses async compute for raytraced acceleration structure building, ambient occlusion, raytraced shadow, etc, async with shadow map generation and other unrelated gfx passes. 

TODO:
- Vulkan implementation