### PR TITLE
Fix compilation for VS2019 Windows 10

### DIFF
--- a/WickedEngine/wiAudio.cpp
+++ b/WickedEngine/wiAudio.cpp
@@ -76,7 +76,7 @@ namespace wiAudio
 			hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
 			assert(SUCCEEDED(hr));
 
-			hr = XAudio2Create(&audioEngine, 0, XAUDIO2_USE_DEFAULT_PROCESSOR);
+			hr = XAudio2Create(&audioEngine, 0, XAUDIO2_DEFAULT_PROCESSOR);
 			assert(SUCCEEDED(hr));
 
 #ifdef _DEBUG


### PR DESCRIPTION
- Use XAUDIO2_DEFAULT_PROCESSOR instead of XAUDIO2_USE_DEFAULT_PROCESSOR