### PR TITLE
Included OpenImageDenoise in cmake builds (linux)

### DIFF
--- a/WickedEngine/CMakeLists.txt
+++ b/WickedEngine/CMakeLists.txt
@@ -6,6 +6,12 @@ else ()
 	set(TARGET_NAME WickedEngine)
 	find_package(Vulkan REQUIRED)
 	find_package(SDL2 REQUIRED)
+	find_package(OpenImageDenoise QUIET)
+	if(NOT ${OpenImageDenoise_FOUND})
+		message("OpenImageDenoise not found, it will be disabled.")
+	else()
+		message("OpenImageDenoise Found.")
+	endif()
 
 	if(NOT TARGET SDL2::SDL2)
 		# using old SDL2 cmake, lets create a SDL2 target ourselves
@@ -119,6 +125,7 @@ else ()
 	target_link_libraries(${TARGET_NAME} PUBLIC
 		Vulkan::Vulkan
 		SDL2::SDL2
+		$<$<BOOL:${OpenImageDenoise_FOUND}>:OpenImageDenoise> # links OpenImageDenoise only if it's found
 	)
 
 	target_link_libraries(${TARGET_NAME} PRIVATE dl)


### PR DESCRIPTION
OpenImageDenoise is optional, will build support for the library if found installed.