### PR TITLE
GUI Sort Fix

### DIFF
--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -44,9 +44,11 @@ void wiGUI::Update(const wiCanvas& canvas, float dt)
 		}
 	}
 
-	std::sort(widgets.begin(), widgets.end(), [](const wiWidget* a, const wiWidget* b) {
-		return a->priority < b->priority;
-		});
+	if(priority > 0) //Sort only if there are priority changes
+		//Use std::stable_sort instead of std::sort to preserve UI element order with equal priorities
+		std::stable_sort(widgets.begin(), widgets.end(), [](const wiWidget* a, const wiWidget* b) {
+			return a->priority < b->priority;
+			});
 }
 
 void wiGUI::Render(const wiCanvas& canvas, CommandList cmd) const

--- a/WickedEngine/wiWidget.cpp
+++ b/WickedEngine/wiWidget.cpp
@@ -1727,9 +1727,11 @@ void wiWindow::Update(const wiCanvas& canvas, float dt)
 		}
 	}
 
-	std::sort(widgets.begin(), widgets.end(), [](const wiWidget* a, const wiWidget* b) {
-		return a->priority < b->priority;
-		});
+	if(priority > 0) //Sort only if there are priority changes
+		//Use std::stable_sort instead of std::sort to preserve UI element order with equal priorities
+		std::stable_sort(widgets.begin(), widgets.end(), [](const wiWidget* a, const wiWidget* b) {
+			return a->priority < b->priority;
+			});
 
 	if (IsMinimized())
 	{


### PR DESCRIPTION
Had problems with GUI sorting on my machine, my solution is to change the sorting method from std::sort to std::stable_sort
also added changes to execution of sorting to only sort when there are priority changes.