### PR TITLE
D3D12 improvements

### DIFF
--- a/WickedEngine/wiGraphicsDevice_DX12.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX12.cpp
@@ -2405,13 +2405,17 @@ using namespace DX12_Internal;
 			auto D3D12GetDebugInterface = (PFN_D3D12_GET_DEBUG_INTERFACE)GetProcAddress(dx12, "D3D12GetDebugInterface");
 			if (D3D12GetDebugInterface)
 			{
-				ComPtr<ID3D12Debug1> d3dDebug;
+				ComPtr<ID3D12Debug> d3dDebug;
 				if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&d3dDebug))))
 				{
 					d3dDebug->EnableDebugLayer();
 					if (gpuvalidation)
 					{
-						d3dDebug->SetEnableGPUBasedValidation(TRUE);
+						ComPtr<ID3D12Debug1> d3dDebug1;
+						if (SUCCEEDED(d3dDebug.As(&d3dDebug1)))
+						{
+							d3dDebug1->SetEnableGPUBasedValidation(TRUE);
+						}
 					}
 				}
 			}
@@ -2420,7 +2424,6 @@ using namespace DX12_Internal;
 			ComPtr<IDXGIInfoQueue> dxgiInfoQueue;
 			if (SUCCEEDED(DXGIGetDebugInterface1(0, IID_PPV_ARGS(dxgiInfoQueue.GetAddressOf()))))
 			{
-
 				dxgiInfoQueue->SetBreakOnSeverity(DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE_SEVERITY_ERROR, true);
 				dxgiInfoQueue->SetBreakOnSeverity(DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE_SEVERITY_CORRUPTION, true);
 

--- a/WickedEngine/wiGraphicsDevice_DX12.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX12.cpp
@@ -2420,7 +2420,6 @@ using namespace DX12_Internal;
 			ComPtr<IDXGIInfoQueue> dxgiInfoQueue;
 			if (SUCCEEDED(DXGIGetDebugInterface1(0, IID_PPV_ARGS(dxgiInfoQueue.GetAddressOf()))))
 			{
-				dxgiFactoryFlags = DXGI_CREATE_FACTORY_DEBUG;
 
 				dxgiInfoQueue->SetBreakOnSeverity(DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE_SEVERITY_ERROR, true);
 				dxgiInfoQueue->SetBreakOnSeverity(DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE_SEVERITY_CORRUPTION, true);
@@ -2438,7 +2437,7 @@ using namespace DX12_Internal;
 		}
 #endif
 
-		hr = CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&dxgiFactory));
+		hr = CreateDXGIFactory2(debuglayer ? DXGI_CREATE_FACTORY_DEBUG : 0u, IID_PPV_ARGS(&dxgiFactory));
 		if (FAILED(hr))
 		{
 			std::stringstream ss("");

--- a/WickedEngine/wiGraphicsDevice_DX12.h
+++ b/WickedEngine/wiGraphicsDevice_DX12.h
@@ -30,7 +30,8 @@ namespace wiGraphics
 	{
 	protected:
 		DWORD dxgiFactoryFlags = 0;
-		Microsoft::WRL::ComPtr<IDXGIFactory6> factory;
+		Microsoft::WRL::ComPtr<IDXGIFactory4> dxgiFactory;
+		bool tearingSupported = false;
 		Microsoft::WRL::ComPtr<IDXGIAdapter4> adapter;
 		Microsoft::WRL::ComPtr<ID3D12Device5> device;
 

--- a/WickedEngine/wiGraphicsDevice_DX12.h
+++ b/WickedEngine/wiGraphicsDevice_DX12.h
@@ -29,9 +29,10 @@ namespace wiGraphics
 	class GraphicsDevice_DX12 : public GraphicsDevice
 	{
 	protected:
-		Microsoft::WRL::ComPtr<ID3D12Device5> device;
-		Microsoft::WRL::ComPtr<IDXGIAdapter4> adapter;
+		DWORD dxgiFactoryFlags = 0;
 		Microsoft::WRL::ComPtr<IDXGIFactory6> factory;
+		Microsoft::WRL::ComPtr<IDXGIAdapter4> adapter;
+		Microsoft::WRL::ComPtr<ID3D12Device5> device;
 
 		Microsoft::WRL::ComPtr<ID3D12CommandSignature> dispatchIndirectCommandSignature;
 		Microsoft::WRL::ComPtr<ID3D12CommandSignature> drawInstancedIndirectCommandSignature;

--- a/WickedEngine/wiGraphicsDevice_DX12.h
+++ b/WickedEngine/wiGraphicsDevice_DX12.h
@@ -31,7 +31,6 @@ namespace wiGraphics
 	protected:
 		Microsoft::WRL::ComPtr<IDXGIFactory4> dxgiFactory;
 		bool tearingSupported = false;
-		Microsoft::WRL::ComPtr<IDXGIAdapter4> adapter;
 		Microsoft::WRL::ComPtr<ID3D12Device5> device;
 
 		Microsoft::WRL::ComPtr<ID3D12CommandSignature> dispatchIndirectCommandSignature;

--- a/WickedEngine/wiGraphicsDevice_DX12.h
+++ b/WickedEngine/wiGraphicsDevice_DX12.h
@@ -29,7 +29,6 @@ namespace wiGraphics
 	class GraphicsDevice_DX12 : public GraphicsDevice
 	{
 	protected:
-		DWORD dxgiFactoryFlags = 0;
 		Microsoft::WRL::ComPtr<IDXGIFactory4> dxgiFactory;
 		bool tearingSupported = false;
 		Microsoft::WRL::ComPtr<IDXGIAdapter4> adapter;


### PR DESCRIPTION
This time is D3D12:
- Enable DXGI debug only in debug mode (DXGIGetDebugInterface1 is not supported in UWP) and improve ID3D12InfoQueue logic.
- Use IDXGIFactory4 and check for variable refresh rate display support (tearing) and improve adapter detection.
- Improve SwapChain creation, handle supported formats and correctly create RTV with wanted format.