### PR TITLE
Samplers: Correctly implement BorderColor

### DIFF
--- a/WickedEngine/wiFont.cpp
+++ b/WickedEngine/wiFont.cpp
@@ -331,10 +331,7 @@ void Initialize()
 	samplerDesc.MipLODBias = 0.0f;
 	samplerDesc.MaxAnisotropy = 0;
 	samplerDesc.ComparisonFunc = COMPARISON_NEVER;
-	samplerDesc.BorderColor[0] = 0;
-	samplerDesc.BorderColor[1] = 0;
-	samplerDesc.BorderColor[2] = 0;
-	samplerDesc.BorderColor[3] = 0;
+	samplerDesc.BorderColor = SAMPLER_BORDER_COLOR_TRANSPARENT_BLACK;
 	samplerDesc.MinLOD = 0;
 	samplerDesc.MaxLOD = FLT_MAX;
 	device->CreateSampler(&samplerDesc, &sampler);

--- a/WickedEngine/wiGraphics.h
+++ b/WickedEngine/wiGraphics.h
@@ -187,6 +187,12 @@ namespace wiGraphics
 		FILTER_MAXIMUM_MIN_MAG_MIP_LINEAR,
 		FILTER_MAXIMUM_ANISOTROPIC,
 	};
+	enum SAMPLER_BORDER_COLOR
+	{
+		SAMPLER_BORDER_COLOR_TRANSPARENT_BLACK,
+		SAMPLER_BORDER_COLOR_OPAQUE_BLACK,
+		SAMPLER_BORDER_COLOR_OPAQUE_WHITE,
+	};
 	enum FORMAT
 	{
 		FORMAT_UNKNOWN,
@@ -440,7 +446,7 @@ namespace wiGraphics
 		float MipLODBias = 0.0f;
 		uint32_t MaxAnisotropy = 0;
 		COMPARISON_FUNC ComparisonFunc = COMPARISON_NEVER;
-		float BorderColor[4] = { 0.0f,0.0f,0.0f,0.0f };
+		SAMPLER_BORDER_COLOR BorderColor = SAMPLER_BORDER_COLOR_TRANSPARENT_BLACK;
 		float MinLOD = 0.0f;
 		float MaxLOD = FLT_MAX;
 	};

--- a/WickedEngine/wiGraphicsDevice_DX11.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX11.cpp
@@ -1781,10 +1781,29 @@ bool GraphicsDevice_DX11::CreateSampler(const SamplerDesc *pSamplerDesc, Sampler
 	desc.MipLODBias = pSamplerDesc->MipLODBias;
 	desc.MaxAnisotropy = pSamplerDesc->MaxAnisotropy;
 	desc.ComparisonFunc = _ConvertComparisonFunc(pSamplerDesc->ComparisonFunc);
-	desc.BorderColor[0] = pSamplerDesc->BorderColor[0];
-	desc.BorderColor[1] = pSamplerDesc->BorderColor[1];
-	desc.BorderColor[2] = pSamplerDesc->BorderColor[2];
-	desc.BorderColor[3] = pSamplerDesc->BorderColor[3];
+	switch (pSamplerDesc->BorderColor)
+	{
+	case SAMPLER_BORDER_COLOR_OPAQUE_BLACK:
+		desc.BorderColor[0] = 0.0f;
+		desc.BorderColor[1] = 0.0f;
+		desc.BorderColor[2] = 0.0f;
+		desc.BorderColor[3] = 1.0f;
+		break;
+
+	case SAMPLER_BORDER_COLOR_OPAQUE_WHITE:
+		desc.BorderColor[0] = 1.0f;
+		desc.BorderColor[1] = 1.0f;
+		desc.BorderColor[2] = 1.0f;
+		desc.BorderColor[3] = 1.0f;
+		break;
+
+	default:
+		desc.BorderColor[0] = 0.0f;
+		desc.BorderColor[1] = 0.0f;
+		desc.BorderColor[2] = 0.0f;
+		desc.BorderColor[3] = 0.0f;
+		break;
+	}
 	desc.MinLOD = pSamplerDesc->MinLOD;
 	desc.MaxLOD = pSamplerDesc->MaxLOD;
 

--- a/WickedEngine/wiGraphicsDevice_DX12.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX12.cpp
@@ -222,6 +222,20 @@ namespace DX12_Internal
 		}
 		return D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 	}
+	constexpr D3D12_STATIC_BORDER_COLOR _ConvertSamplerBorderColor(SAMPLER_BORDER_COLOR value)
+	{
+		switch (value)
+		{
+		case SAMPLER_BORDER_COLOR_TRANSPARENT_BLACK:
+			return D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+		case SAMPLER_BORDER_COLOR_OPAQUE_BLACK:
+			return D3D12_STATIC_BORDER_COLOR_OPAQUE_BLACK;
+		case SAMPLER_BORDER_COLOR_OPAQUE_WHITE:
+			return D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE;
+		default:
+			return D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+		}
+	}
 	constexpr D3D12_COMPARISON_FUNC _ConvertComparisonFunc(COMPARISON_FUNC value)
 	{
 		switch (value)
@@ -404,38 +418,28 @@ namespace DX12_Internal
 		{
 		case BLEND_OP_ADD:
 			return D3D12_BLEND_OP_ADD;
-			break;
 		case BLEND_OP_SUBTRACT:
 			return D3D12_BLEND_OP_SUBTRACT;
-			break;
 		case BLEND_OP_REV_SUBTRACT:
 			return D3D12_BLEND_OP_REV_SUBTRACT;
-			break;
 		case BLEND_OP_MIN:
 			return D3D12_BLEND_OP_MIN;
-			break;
 		case BLEND_OP_MAX:
 			return D3D12_BLEND_OP_MAX;
-			break;
 		default:
-			break;
+			return D3D12_BLEND_OP_ADD;
 		}
-		return D3D12_BLEND_OP_ADD;
 	}
 	constexpr D3D12_INPUT_CLASSIFICATION _ConvertInputClassification(INPUT_CLASSIFICATION value)
 	{
 		switch (value)
 		{
-		case INPUT_PER_VERTEX_DATA:
-			return D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
-			break;
 		case INPUT_PER_INSTANCE_DATA:
 			return D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA;
 			break;
 		default:
-			break;
+			return D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
 		}
-		return D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
 	}
 	constexpr DXGI_FORMAT _ConvertFormat(FORMAT value)
 	{
@@ -786,7 +790,7 @@ namespace DX12_Internal
 		desc.MipLODBias = x.sampler.desc.MipLODBias;
 		desc.MaxAnisotropy = x.sampler.desc.MaxAnisotropy;
 		desc.ComparisonFunc = _ConvertComparisonFunc(x.sampler.desc.ComparisonFunc);
-		desc.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+		desc.BorderColor = _ConvertSamplerBorderColor(x.sampler.desc.BorderColor);
 		desc.MinLOD = x.sampler.desc.MinLOD;
 		desc.MaxLOD = x.sampler.desc.MaxLOD;
 		desc.ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
@@ -3890,10 +3894,29 @@ using namespace DX12_Internal;
 		desc.MipLODBias = pSamplerDesc->MipLODBias;
 		desc.MaxAnisotropy = pSamplerDesc->MaxAnisotropy;
 		desc.ComparisonFunc = _ConvertComparisonFunc(pSamplerDesc->ComparisonFunc);
-		desc.BorderColor[0] = pSamplerDesc->BorderColor[0];
-		desc.BorderColor[1] = pSamplerDesc->BorderColor[1];
-		desc.BorderColor[2] = pSamplerDesc->BorderColor[2];
-		desc.BorderColor[3] = pSamplerDesc->BorderColor[3];
+		switch (pSamplerDesc->BorderColor)
+		{
+		case SAMPLER_BORDER_COLOR_OPAQUE_BLACK:
+			desc.BorderColor[0] = 0.0f;
+			desc.BorderColor[1] = 0.0f;
+			desc.BorderColor[2] = 0.0f;
+			desc.BorderColor[3] = 1.0f;
+			break;
+
+		case SAMPLER_BORDER_COLOR_OPAQUE_WHITE:
+			desc.BorderColor[0] = 1.0f;
+			desc.BorderColor[1] = 1.0f;
+			desc.BorderColor[2] = 1.0f;
+			desc.BorderColor[3] = 1.0f;
+			break;
+
+		default:
+			desc.BorderColor[0] = 0.0f;
+			desc.BorderColor[1] = 0.0f;
+			desc.BorderColor[2] = 0.0f;
+			desc.BorderColor[3] = 0.0f;
+			break;
+		}
 		desc.MinLOD = pSamplerDesc->MinLOD;
 		desc.MaxLOD = pSamplerDesc->MaxLOD;
 

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -257,32 +257,23 @@ namespace Vulkan_Internal
 		{
 		case COMPARISON_NEVER:
 			return VK_COMPARE_OP_NEVER;
-			break;
 		case COMPARISON_LESS:
 			return VK_COMPARE_OP_LESS;
-			break;
 		case COMPARISON_EQUAL:
 			return VK_COMPARE_OP_EQUAL;
-			break;
 		case COMPARISON_LESS_EQUAL:
 			return VK_COMPARE_OP_LESS_OR_EQUAL;
-			break;
 		case COMPARISON_GREATER:
 			return VK_COMPARE_OP_GREATER;
-			break;
 		case COMPARISON_NOT_EQUAL:
 			return VK_COMPARE_OP_NOT_EQUAL;
-			break;
 		case COMPARISON_GREATER_EQUAL:
 			return VK_COMPARE_OP_GREATER_OR_EQUAL;
-			break;
 		case COMPARISON_ALWAYS:
 			return VK_COMPARE_OP_ALWAYS;
-			break;
 		default:
-			break;
+			return VK_COMPARE_OP_NEVER;
 		}
-		return VK_COMPARE_OP_NEVER;
 	}
 	constexpr VkBlendFactor _ConvertBlend(BLEND value)
 	{
@@ -351,20 +342,29 @@ namespace Vulkan_Internal
 		{
 		case TEXTURE_ADDRESS_WRAP:
 			return VK_SAMPLER_ADDRESS_MODE_REPEAT;
-			break;
 		case TEXTURE_ADDRESS_MIRROR:
 			return VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-			break;
 		case TEXTURE_ADDRESS_CLAMP:
 			return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-			break;
 		case TEXTURE_ADDRESS_BORDER:
 			return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-			break;
 		default:
-			break;
+			return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
 		}
-		return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+	}
+	constexpr VkBorderColor _ConvertSamplerBorderColor(SAMPLER_BORDER_COLOR value)
+	{
+		switch (value)
+		{
+		case SAMPLER_BORDER_COLOR_TRANSPARENT_BLACK:
+			return VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+		case SAMPLER_BORDER_COLOR_OPAQUE_BLACK:
+			return VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
+		case SAMPLER_BORDER_COLOR_OPAQUE_WHITE:
+			return VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
+		default:
+			return VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+		}
 	}
 	constexpr VkStencilOp _ConvertStencilOp(STENCIL_OP value)
 	{
@@ -4172,7 +4172,7 @@ using namespace Vulkan_Internal;
 		createInfo.minLod = pSamplerDesc->MinLOD;
 		createInfo.maxLod = pSamplerDesc->MaxLOD;
 		createInfo.mipLodBias = pSamplerDesc->MipLODBias;
-		createInfo.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+		createInfo.borderColor = _ConvertSamplerBorderColor(pSamplerDesc->BorderColor);
 		createInfo.unnormalizedCoordinates = VK_FALSE;
 
 		VkResult res = vkCreateSampler(device, &createInfo, nullptr, &internal_state->resource);

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -153,10 +153,7 @@ void SetDevice(std::shared_ptr<GraphicsDevice> newDevice)
 	samplerDesc.MipLODBias = 0.0f;
 	samplerDesc.MaxAnisotropy = 0;
 	samplerDesc.ComparisonFunc = COMPARISON_NEVER;
-	samplerDesc.BorderColor[0] = 0;
-	samplerDesc.BorderColor[1] = 0;
-	samplerDesc.BorderColor[2] = 0;
-	samplerDesc.BorderColor[3] = 0;
+	samplerDesc.BorderColor = SAMPLER_BORDER_COLOR_TRANSPARENT_BLACK;
 	samplerDesc.MinLOD = 0;
 	samplerDesc.MaxLOD = FLT_MAX;
 	device->CreateSampler(&samplerDesc, &samplers[SSLOT_LINEAR_MIRROR]);


### PR DESCRIPTION
- Add new SAMPLER_BORDER_COLOR
- Correctly implement under D3D11
- Correctly implement under D3D12 and handle static samplers as well
- Correctly map to VkBorderColor
