### PR TITLE
Improvements + fixes

### DIFF
--- a/WickedEngine/wiGraphicsDevice.h
+++ b/WickedEngine/wiGraphicsDevice.h
@@ -135,7 +135,7 @@ namespace wiGraphics
 		virtual void BindSampler(const Sampler* sampler, uint32_t slot, CommandList cmd) = 0;
 		virtual void BindConstantBuffer(const GPUBuffer* buffer, uint32_t slot, CommandList cmd, uint64_t offset = 0ull) = 0;
 		virtual void BindVertexBuffers(const GPUBuffer *const* vertexBuffers, uint32_t slot, uint32_t count, const uint32_t* strides, const uint64_t* offsets, CommandList cmd) = 0;
-		virtual void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint32_t offset, CommandList cmd) = 0;
+		virtual void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint64_t offset, CommandList cmd) = 0;
 		virtual void BindStencilRef(uint32_t value, CommandList cmd) = 0;
 		virtual void BindBlendFactor(float r, float g, float b, float a, CommandList cmd) = 0;
 		virtual void BindShadingRate(SHADING_RATE rate, CommandList cmd) {}

--- a/WickedEngine/wiGraphicsDevice_DX12.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX12.cpp
@@ -1578,7 +1578,7 @@ using namespace DX12_Internal;
 		if (cmd.uploadbuffer.desc.Size < staging_size)
 		{
 			GPUBufferDesc uploadBufferDesc;
-			uploadBufferDesc.Size = wiMath::GetNextPowerOfTwo((uint32_t)staging_size);
+			uploadBufferDesc.Size = wiMath::GetNextPowerOfTwo(staging_size);
 			uploadBufferDesc.Usage = USAGE_UPLOAD;
 			bool upload_success = device->CreateBuffer(&uploadBufferDesc, nullptr, &cmd.uploadbuffer);
 			assert(upload_success);
@@ -5792,7 +5792,7 @@ using namespace DX12_Internal;
 		}
 		GetCommandList(cmd)->IASetVertexBuffers(slot, count, res);
 	}
-	void GraphicsDevice_DX12::BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint32_t offset, CommandList cmd)
+	void GraphicsDevice_DX12::BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint64_t offset, CommandList cmd)
 	{
 		D3D12_INDEX_BUFFER_VIEW res = {};
 		if (indexBuffer != nullptr)

--- a/WickedEngine/wiGraphicsDevice_DX12.h
+++ b/WickedEngine/wiGraphicsDevice_DX12.h
@@ -228,7 +228,7 @@ namespace wiGraphics
 		void BindSampler(const Sampler* sampler, uint32_t slot, CommandList cmd) override;
 		void BindConstantBuffer(const GPUBuffer* buffer, uint32_t slot, CommandList cmd, uint64_t offset = 0ull) override;
 		void BindVertexBuffers(const GPUBuffer *const* vertexBuffers, uint32_t slot, uint32_t count, const uint32_t* strides, const uint64_t* offsets, CommandList cmd) override;
-		void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint32_t offset, CommandList cmd) override;
+		void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint64_t offset, CommandList cmd) override;
 		void BindStencilRef(uint32_t value, CommandList cmd) override;
 		void BindBlendFactor(float r, float g, float b, float a, CommandList cmd) override;
 		void BindShadingRate(SHADING_RATE rate, CommandList cmd) override;

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -1050,7 +1050,7 @@ using namespace Vulkan_Internal;
 		if (cmd.uploadbuffer.desc.Size < staging_size)
 		{
 			GPUBufferDesc uploaddesc;
-			uploaddesc.Size = wiMath::GetNextPowerOfTwo((uint32_t)staging_size);
+			uploaddesc.Size = wiMath::GetNextPowerOfTwo(staging_size);
 			uploaddesc.Usage = USAGE_UPLOAD;
 			bool upload_success = device->CreateBuffer(&uploaddesc, nullptr, &cmd.uploadbuffer);
 			assert(upload_success);
@@ -1464,7 +1464,7 @@ using namespace Vulkan_Internal;
 						auto internal_state = to_internal(&buffer);
 						bufferInfos.back().buffer = internal_state->resource;
 						bufferInfos.back().offset = offset;
-						bufferInfos.back().range = (VkDeviceSize)std::min(buffer.desc.Size - offset, (uint64_t)device->properties2.properties.limits.maxUniformBufferRange);
+						bufferInfos.back().range = std::min(buffer.desc.Size - offset, (uint64_t)device->properties2.properties.limits.maxUniformBufferRange);
 					}
 				}
 				break;
@@ -3328,7 +3328,7 @@ using namespace Vulkan_Internal;
 		// Issue data copy on request:
 		if (pInitialData != nullptr)
 		{
-			auto cmd = copyAllocator.allocate((uint32_t)internal_state->allocation->GetSize());
+			auto cmd = copyAllocator.allocate(internal_state->allocation->GetSize());
 
 			std::vector<VkBufferImageCopy> copyRegions;
 
@@ -6103,7 +6103,7 @@ using namespace Vulkan_Internal;
 				vbuffers[i] = internal_state->resource;
 				if (offsets != nullptr)
 				{
-					voffsets[i] = (VkDeviceSize)offsets[i];
+					voffsets[i] = offsets[i];
 				}
 			}
 		}
@@ -6120,12 +6120,12 @@ using namespace Vulkan_Internal;
 			dirty_pso[cmd] = true;
 		}
 	}
-	void GraphicsDevice_Vulkan::BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint32_t offset, CommandList cmd)
+	void GraphicsDevice_Vulkan::BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint64_t offset, CommandList cmd)
 	{
 		if (indexBuffer != nullptr)
 		{
 			auto internal_state = to_internal(indexBuffer);
-			vkCmdBindIndexBuffer(GetCommandList(cmd), internal_state->resource, (VkDeviceSize)offset, format == INDEXFORMAT_16BIT ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32);
+			vkCmdBindIndexBuffer(GetCommandList(cmd), internal_state->resource, offset, format == INDEXFORMAT_16BIT ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32);
 		}
 	}
 	void GraphicsDevice_Vulkan::BindStencilRef(uint32_t value, CommandList cmd)
@@ -6482,7 +6482,7 @@ using namespace Vulkan_Internal;
 			VkBufferCopy copy = {};
 			copy.srcOffset = 0;
 			copy.dstOffset = 0;
-			copy.size = (VkDeviceSize)std::min(src_desc.Size, dst_desc.Size);
+			copy.size = std::min(src_desc.Size, dst_desc.Size);
 
 			vkCmdCopyBuffer(GetCommandList(cmd),
 				internal_state_src->resource,

--- a/WickedEngine/wiGraphicsDevice_Vulkan.h
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.h
@@ -332,7 +332,7 @@ namespace wiGraphics
 		void BindSampler(const Sampler* sampler, uint32_t slot, CommandList cmd) override;
 		void BindConstantBuffer(const GPUBuffer* buffer, uint32_t slot, CommandList cmd, uint64_t offset = 0ull) override;
 		void BindVertexBuffers(const GPUBuffer *const* vertexBuffers, uint32_t slot, uint32_t count, const uint32_t* strides, const uint64_t* offsets, CommandList cmd) override;
-		void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint32_t offset, CommandList cmd) override;
+		void BindIndexBuffer(const GPUBuffer* indexBuffer, const INDEXBUFFER_FORMAT format, uint64_t offset, CommandList cmd) override;
 		void BindStencilRef(uint32_t value, CommandList cmd) override;
 		void BindBlendFactor(float r, float g, float b, float a, CommandList cmd) override;
 		void BindShadingRate(SHADING_RATE rate, CommandList cmd) override;

--- a/WickedEngine/wiMath.h
+++ b/WickedEngine/wiMath.h
@@ -151,6 +151,17 @@ namespace wiMath
 		x |= x >> 16;
 		return ++x;
 	}
+	inline constexpr uint64_t GetNextPowerOfTwo(uint64_t x)
+	{
+		--x;
+		x |= x >> 1;
+		x |= x >> 2;
+		x |= x >> 4;
+		x |= x >> 8;
+		x |= x >> 16;
+		x |= x >> 32u;
+		return ++x;
+	}
 
 	// A, B, C: trangle vertices
 	float TriangleArea(const XMVECTOR& A, const XMVECTOR& B, const XMVECTOR& C);


### PR DESCRIPTION
Add: wiMath::GetNextPowerOfTwo with uint64_t
FIX: Vulkan and D3D12 backends to use uint64_t size and offet during BindIndexBuffer.