### PR TITLE
HiDPI support on SDL2

### DIFF
--- a/Editor/main_SDL2.cpp
+++ b/Editor/main_SDL2.cpp
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
             "Wicked Engine Editor",
             SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
             w, h,
-            SDL_WINDOW_SHOWN | SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE);
+            SDL_WINDOW_SHOWN | SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     if (!window) {
         throw sdl2::SDLError("Error creating window");
     }

--- a/Tests/main_SDL2.cpp
+++ b/Tests/main_SDL2.cpp
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
             "Wicked Engine Tests",
             SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
             1280, 800,
-            SDL_WINDOW_SHOWN | SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE);
+            SDL_WINDOW_SHOWN | SDL_WINDOW_VULKAN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
     if (!window) {
         throw sdl2::SDLError("Error creating window");
     }

--- a/WickedEngine/wiPlatform.h
+++ b/WickedEngine/wiPlatform.h
@@ -95,10 +95,10 @@ namespace wiPlatform
 #endif // PLATFORM_UWP
 
 #ifdef PLATFORM_LINUX
-        int window_width, window_height;
+		int window_width, window_height;
 		SDL_GetWindowSize(window, &window_width, &window_height);
 		SDL_Vulkan_GetDrawableSize(window, &dest->width, &dest->height);
-        dest->dpi = ((float) dest->width / (float) window_width) * 96.0;
+		dest->dpi = ((float) dest->width / (float) window_width) * 96.0;
 #endif // PLATFORM_LINUX
 	}
 }

--- a/WickedEngine/wiPlatform.h
+++ b/WickedEngine/wiPlatform.h
@@ -94,8 +94,10 @@ namespace wiPlatform
 #endif // PLATFORM_UWP
 
 #ifdef PLATFORM_LINUX
-		dest->dpi = 96; // todo
-		SDL_GetWindowSize(window, &dest->width, &dest->height);
+        int window_width, window_height;
+		SDL_GetWindowSize(window, &window_width, &window_height);
+        SDL_GL_GetDrawableSize(window, &dest->width, &dest->height);
+        dest->dpi = ((float) dest->width / (float) window_width) * 96.0;
 #endif // PLATFORM_LINUX
 	}
 }

--- a/WickedEngine/wiPlatform.h
+++ b/WickedEngine/wiPlatform.h
@@ -38,6 +38,7 @@ typedef void* HMODULE;
 
 #ifdef SDL2
 #include <SDL2/SDL.h>
+#include <SDL_vulkan.h>
 #include "sdl2.h"
 #endif
 
@@ -96,7 +97,7 @@ namespace wiPlatform
 #ifdef PLATFORM_LINUX
         int window_width, window_height;
 		SDL_GetWindowSize(window, &window_width, &window_height);
-        SDL_GL_GetDrawableSize(window, &dest->width, &dest->height);
+		SDL_Vulkan_GetDrawableSize(window, &dest->width, &dest->height);
         dest->dpi = ((float) dest->width / (float) window_width) * 96.0;
 #endif // PLATFORM_LINUX
 	}


### PR DESCRIPTION
It dinamically changes the resolution of the window when moved to a screen with different DPI.

linux: works only with wayland backend, can be used with `SDL_VIDEODRIVER=wayland` enviroment variable set.
macos: when available it should just work.
windows: I guess it works here as well, if someone wants to try the SDL backend on windows.