### PR TITLE
Fixed crash on wayland exit

### DIFF
--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -929,7 +929,7 @@ namespace Vulkan_Internal
 			// If so we would delete the swapchain twice, causing a crash on wayland.
 			if (SDL_WasInit(SDL_INIT_VIDEO))
 			#endif
-            {
+			{
 				vkDestroySwapchainKHR(allocationhandler->device, swapChain, nullptr);
 				vkDestroySurfaceKHR(allocationhandler->instance, surface, nullptr);
 			}

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -924,8 +924,15 @@ namespace Vulkan_Internal
 				vkDestroyFramebuffer(allocationhandler->device, swapChainFramebuffers[i], nullptr);
 				vkDestroyImageView(allocationhandler->device, swapChainImageViews[i], nullptr);
 			}
-			vkDestroySwapchainKHR(allocationhandler->device, swapChain, nullptr);
-			vkDestroySurfaceKHR(allocationhandler->instance, surface, nullptr);
+			#ifdef SDL2
+			// Checks if the SDL VIDEO System was already destroyed.
+			// If so we would delete the swapchain twice, causing a crash on wayland.
+			if (SDL_WasInit(SDL_INIT_VIDEO))
+			#endif
+            {
+				vkDestroySwapchainKHR(allocationhandler->device, swapChain, nullptr);
+				vkDestroySurfaceKHR(allocationhandler->instance, surface, nullptr);
+			}
 			vkDestroySemaphore(allocationhandler->device, swapchainAcquireSemaphore, nullptr);
 			vkDestroySemaphore(allocationhandler->device, swapchainReleaseSemaphore, nullptr);
 


### PR DESCRIPTION
The engine would crash on exit because SDL handles the deletion of the swapchain on his own, making the engine delete the swapchain twice, which would result in a crash on wayland.
This fix checks if the Video Subsystem is not running any more, if not it will assume there is no need to destroy the swap chains any more.

If there is a better way to test if the swapchain is already destroyed, even better :)