### PR TITLE
Add SetDepthBounds.

### DIFF
--- a/WickedEngine/wiApplication.cpp
+++ b/WickedEngine/wiApplication.cpp
@@ -72,7 +72,6 @@ namespace wi
 
 	void Application::Run()
 	{
-
 		if (!initialized)
 		{
 			// Initialize in a lazy way, so the user application doesn't have to call this explicitly

--- a/WickedEngine/wiGraphics.h
+++ b/WickedEngine/wiGraphics.h
@@ -354,6 +354,7 @@ namespace wi::graphics
 		RAYTRACING = 1 << 9,
 		PREDICATION = 1 << 10,
 		SAMPLER_MINMAX = 1 << 11,
+		DEPTH_BOUNDS_TEST = 1 << 12,
 	};
 
 	enum class ResourceState

--- a/WickedEngine/wiGraphics.h
+++ b/WickedEngine/wiGraphics.h
@@ -496,6 +496,7 @@ namespace wi::graphics
 		};
 		DepthStencilOp front_face;
 		DepthStencilOp back_face;
+		bool depth_bounds_test_enable = false;
 	};
 
 	struct BlendState

--- a/WickedEngine/wiGraphicsDevice.h
+++ b/WickedEngine/wiGraphicsDevice.h
@@ -175,6 +175,7 @@ namespace wi::graphics
 		virtual void BindShadingRate(ShadingRate rate, CommandList cmd) {}
 		virtual void BindPipelineState(const PipelineState* pso, CommandList cmd) = 0;
 		virtual void BindComputeShader(const Shader* cs, CommandList cmd) = 0;
+		virtual void SetDepthBounds(float min_bounds, float max_bounds, CommandList cmd) = 0;
 		virtual void Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd) = 0;
 		virtual void DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, int32_t baseVertexLocation, CommandList cmd) = 0;
 		virtual void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd) = 0;

--- a/WickedEngine/wiGraphicsDevice.h
+++ b/WickedEngine/wiGraphicsDevice.h
@@ -175,7 +175,7 @@ namespace wi::graphics
 		virtual void BindShadingRate(ShadingRate rate, CommandList cmd) {}
 		virtual void BindPipelineState(const PipelineState* pso, CommandList cmd) = 0;
 		virtual void BindComputeShader(const Shader* cs, CommandList cmd) = 0;
-		virtual void SetDepthBounds(float min_bounds, float max_bounds, CommandList cmd) = 0;
+		virtual void BindDepthBounds(float min_bounds, float max_bounds, CommandList cmd) = 0;
 		virtual void Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd) = 0;
 		virtual void DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, int32_t baseVertexLocation, CommandList cmd) = 0;
 		virtual void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd) = 0;

--- a/WickedEngine/wiGraphicsDevice_DX12.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX12.cpp
@@ -2584,6 +2584,11 @@ using namespace dx12_internal;
 			capabilities |= GraphicsDeviceCapability::MESH_SHADER;
 		}
 
+		if (features.DepthBoundsTestSupported() == TRUE)
+		{
+			capabilities |= GraphicsDeviceCapability::DEPTH_BOUNDS_TEST;
+		}
+
 		if (features.HighestRootSignatureVersion() < D3D_ROOT_SIGNATURE_VERSION_1_1)
 		{
 			assert(0);
@@ -4399,7 +4404,14 @@ using namespace dx12_internal;
 		dss.BackFace.StencilFailOp = _ConvertStencilOp(pDepthStencilStateDesc.back_face.stencil_fail_op);
 		dss.BackFace.StencilFunc = _ConvertComparisonFunc(pDepthStencilStateDesc.back_face.stencil_func);
 		dss.BackFace.StencilPassOp = _ConvertStencilOp(pDepthStencilStateDesc.back_face.stencil_pass_op);
-		dss.DepthBoundsTestEnable = pDepthStencilStateDesc.depth_bounds_test_enable;
+		if (CheckCapability(GraphicsDeviceCapability::DEPTH_BOUNDS_TEST))
+		{
+			dss.DepthBoundsTestEnable = pDepthStencilStateDesc.depth_bounds_test_enable;
+		}
+		else
+		{
+			dss.DepthBoundsTestEnable = FALSE;
+		}
 		stream.stream1.DSS = dss;
 
 		BlendState pBlendStateDesc = pso->desc.bs != nullptr ? *pso->desc.bs : BlendState();
@@ -6182,7 +6194,10 @@ using namespace dx12_internal;
 	}
 	void GraphicsDevice_DX12::BindDepthBounds(float min_bounds, float max_bounds, CommandList cmd)
 	{
-		GetCommandList(cmd)->OMSetDepthBounds(min_bounds, max_bounds);
+		if (CheckCapability(GraphicsDeviceCapability::DEPTH_BOUNDS_TEST))
+		{
+			GetCommandList(cmd)->OMSetDepthBounds(min_bounds, max_bounds);
+		}
 	}
 	void GraphicsDevice_DX12::Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd)
 	{

--- a/WickedEngine/wiGraphicsDevice_DX12.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX12.cpp
@@ -6179,6 +6179,10 @@ using namespace dx12_internal;
 
 		}
 	}
+	void GraphicsDevice_DX12::SetDepthBounds(float min_bounds, float max_bounds, CommandList cmd)
+	{
+		GetCommandList(cmd)->OMSetDepthBounds(min_bounds, max_bounds);
+	}
 	void GraphicsDevice_DX12::Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd)
 	{
 		predraw(cmd);

--- a/WickedEngine/wiGraphicsDevice_DX12.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX12.cpp
@@ -1340,7 +1340,7 @@ namespace dx12_internal
 				CD3DX12_PIPELINE_STATE_STREAM_GS GS;
 				CD3DX12_PIPELINE_STATE_STREAM_PS PS;
 				CD3DX12_PIPELINE_STATE_STREAM_RASTERIZER RS;
-				CD3DX12_PIPELINE_STATE_STREAM_DEPTH_STENCIL DSS;
+				CD3DX12_PIPELINE_STATE_STREAM_DEPTH_STENCIL1 DSS;
 				CD3DX12_PIPELINE_STATE_STREAM_BLEND_DESC BD;
 				CD3DX12_PIPELINE_STATE_STREAM_PRIMITIVE_TOPOLOGY PT;
 				CD3DX12_PIPELINE_STATE_STREAM_INPUT_LAYOUT IL;
@@ -4384,7 +4384,7 @@ using namespace dx12_internal;
 		stream.stream1.RS = rs;
 
 		DepthStencilState pDepthStencilStateDesc = pso->desc.dss != nullptr ? *pso->desc.dss : DepthStencilState();
-		CD3DX12_DEPTH_STENCIL_DESC dss = {};
+		CD3DX12_DEPTH_STENCIL_DESC1 dss = {};
 		dss.DepthEnable = pDepthStencilStateDesc.depth_enable;
 		dss.DepthWriteMask = _ConvertDepthWriteMask(pDepthStencilStateDesc.depth_write_mask);
 		dss.DepthFunc = _ConvertComparisonFunc(pDepthStencilStateDesc.depth_func);
@@ -4399,6 +4399,7 @@ using namespace dx12_internal;
 		dss.BackFace.StencilFailOp = _ConvertStencilOp(pDepthStencilStateDesc.back_face.stencil_fail_op);
 		dss.BackFace.StencilFunc = _ConvertComparisonFunc(pDepthStencilStateDesc.back_face.stencil_func);
 		dss.BackFace.StencilPassOp = _ConvertStencilOp(pDepthStencilStateDesc.back_face.stencil_pass_op);
+		dss.DepthBoundsTestEnable = pDepthStencilStateDesc.depth_bounds_test_enable;
 		stream.stream1.DSS = dss;
 
 		BlendState pBlendStateDesc = pso->desc.bs != nullptr ? *pso->desc.bs : BlendState();
@@ -6179,7 +6180,7 @@ using namespace dx12_internal;
 
 		}
 	}
-	void GraphicsDevice_DX12::SetDepthBounds(float min_bounds, float max_bounds, CommandList cmd)
+	void GraphicsDevice_DX12::BindDepthBounds(float min_bounds, float max_bounds, CommandList cmd)
 	{
 		GetCommandList(cmd)->OMSetDepthBounds(min_bounds, max_bounds);
 	}

--- a/WickedEngine/wiGraphicsDevice_DX12.h
+++ b/WickedEngine/wiGraphicsDevice_DX12.h
@@ -236,7 +236,7 @@ namespace wi::graphics
 		void BindShadingRate(ShadingRate rate, CommandList cmd) override;
 		void BindPipelineState(const PipelineState* pso, CommandList cmd) override;
 		void BindComputeShader(const Shader* cs, CommandList cmd) override;
-		void SetDepthBounds(float min_bounds, float max_bounds, CommandList cmd) override;
+		void BindDepthBounds(float min_bounds, float max_bounds, CommandList cmd) override;
 		void Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd) override;
 		void DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, int32_t baseVertexLocation, CommandList cmd) override;
 		void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd) override;

--- a/WickedEngine/wiGraphicsDevice_DX12.h
+++ b/WickedEngine/wiGraphicsDevice_DX12.h
@@ -236,6 +236,7 @@ namespace wi::graphics
 		void BindShadingRate(ShadingRate rate, CommandList cmd) override;
 		void BindPipelineState(const PipelineState* pso, CommandList cmd) override;
 		void BindComputeShader(const Shader* cs, CommandList cmd) override;
+		void SetDepthBounds(float min_bounds, float max_bounds, CommandList cmd) override;
 		void Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd) override;
 		void DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, int32_t baseVertexLocation, CommandList cmd) override;
 		void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd) override;

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -2949,6 +2949,7 @@ using namespace vulkan_internal;
 		pso_dynamicStates.push_back(VK_DYNAMIC_STATE_SCISSOR);
 		pso_dynamicStates.push_back(VK_DYNAMIC_STATE_STENCIL_REFERENCE);
 		pso_dynamicStates.push_back(VK_DYNAMIC_STATE_BLEND_CONSTANTS);
+		pso_dynamicStates.push_back(VK_DYNAMIC_STATE_DEPTH_BOUNDS);
 		if (CheckCapability(GraphicsDeviceCapability::VARIABLE_RATE_SHADING))
 		{
 			pso_dynamicStates.push_back(VK_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR);
@@ -5989,6 +5990,7 @@ using namespace vulkan_internal;
 
 			float blendConstants[] = { 1,1,1,1 };
 			vkCmdSetBlendConstants(GetCommandList(cmd), blendConstants);
+			vkCmdSetDepthBounds(GetCommandList(cmd), 0.0f, 1.0f);
 		}
 
 		prev_pipeline_hash[cmd] = 0;
@@ -6643,6 +6645,10 @@ using namespace vulkan_internal;
 				}
 			}
 		}
+	}
+	void GraphicsDevice_Vulkan::SetDepthBounds(float min_bounds, float max_bounds, CommandList cmd)
+	{
+		vkCmdSetDepthBounds(GetCommandList(cmd), min_bounds, max_bounds);
 	}
 	void GraphicsDevice_Vulkan::Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd)
 	{

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -4749,7 +4749,7 @@ using namespace vulkan_internal;
 			depthstencil.back.failOp = _ConvertStencilOp(pso->desc.dss->back_face.stencil_fail_op);
 			depthstencil.back.depthFailOp = _ConvertStencilOp(pso->desc.dss->back_face.stencil_depth_fail_op);
 
-			depthstencil.depthBoundsTestEnable = VK_FALSE;
+			depthstencil.depthBoundsTestEnable = pso->desc.dss->depth_bounds_test_enable ? VK_TRUE : VK_FALSE;
 		}
 
 		pipelineInfo.pDepthStencilState = &depthstencil;
@@ -6646,7 +6646,7 @@ using namespace vulkan_internal;
 			}
 		}
 	}
-	void GraphicsDevice_Vulkan::SetDepthBounds(float min_bounds, float max_bounds, CommandList cmd)
+	void GraphicsDevice_Vulkan::BindDepthBounds(float min_bounds, float max_bounds, CommandList cmd)
 	{
 		vkCmdSetDepthBounds(GetCommandList(cmd), min_bounds, max_bounds);
 	}

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -2571,6 +2571,11 @@ using namespace vulkan_internal;
 				capabilities |= GraphicsDeviceCapability::SAMPLER_MINMAX;
 			}
 
+			if (features2.features.depthBounds == VK_TRUE)
+			{
+				capabilities |= GraphicsDeviceCapability::DEPTH_BOUNDS_TEST;
+			}
+
 			// Find queue families:
 			uint32_t queueFamilyCount = 0;
 			vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamilyCount, nullptr);
@@ -2949,7 +2954,10 @@ using namespace vulkan_internal;
 		pso_dynamicStates.push_back(VK_DYNAMIC_STATE_SCISSOR);
 		pso_dynamicStates.push_back(VK_DYNAMIC_STATE_STENCIL_REFERENCE);
 		pso_dynamicStates.push_back(VK_DYNAMIC_STATE_BLEND_CONSTANTS);
-		pso_dynamicStates.push_back(VK_DYNAMIC_STATE_DEPTH_BOUNDS);
+		if (CheckCapability(GraphicsDeviceCapability::DEPTH_BOUNDS_TEST))
+		{
+			pso_dynamicStates.push_back(VK_DYNAMIC_STATE_DEPTH_BOUNDS);
+		}
 		if (CheckCapability(GraphicsDeviceCapability::VARIABLE_RATE_SHADING))
 		{
 			pso_dynamicStates.push_back(VK_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR);
@@ -4749,7 +4757,14 @@ using namespace vulkan_internal;
 			depthstencil.back.failOp = _ConvertStencilOp(pso->desc.dss->back_face.stencil_fail_op);
 			depthstencil.back.depthFailOp = _ConvertStencilOp(pso->desc.dss->back_face.stencil_depth_fail_op);
 
-			depthstencil.depthBoundsTestEnable = pso->desc.dss->depth_bounds_test_enable ? VK_TRUE : VK_FALSE;
+			if (CheckCapability(GraphicsDeviceCapability::DEPTH_BOUNDS_TEST))
+			{
+				depthstencil.depthBoundsTestEnable = pso->desc.dss->depth_bounds_test_enable ? VK_TRUE : VK_FALSE;
+			}
+			else
+			{
+				depthstencil.depthBoundsTestEnable = VK_FALSE;
+			}
 		}
 
 		pipelineInfo.pDepthStencilState = &depthstencil;
@@ -6648,7 +6663,10 @@ using namespace vulkan_internal;
 	}
 	void GraphicsDevice_Vulkan::BindDepthBounds(float min_bounds, float max_bounds, CommandList cmd)
 	{
-		vkCmdSetDepthBounds(GetCommandList(cmd), min_bounds, max_bounds);
+		if (features2.features.depthBounds == VK_TRUE)
+		{
+			vkCmdSetDepthBounds(GetCommandList(cmd), min_bounds, max_bounds);
+		}
 	}
 	void GraphicsDevice_Vulkan::Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd)
 	{

--- a/WickedEngine/wiGraphicsDevice_Vulkan.h
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.h
@@ -297,6 +297,7 @@ namespace wi::graphics
 		void BindShadingRate(ShadingRate rate, CommandList cmd) override;
 		void BindPipelineState(const PipelineState* pso, CommandList cmd) override;
 		void BindComputeShader(const Shader* cs, CommandList cmd) override;
+		void SetDepthBounds(float min_bounds, float max_bounds, CommandList cmd) override;
 		void Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd) override;
 		void DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, int32_t baseVertexLocation, CommandList cmd) override;
 		void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd) override;

--- a/WickedEngine/wiGraphicsDevice_Vulkan.h
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.h
@@ -297,7 +297,7 @@ namespace wi::graphics
 		void BindShadingRate(ShadingRate rate, CommandList cmd) override;
 		void BindPipelineState(const PipelineState* pso, CommandList cmd) override;
 		void BindComputeShader(const Shader* cs, CommandList cmd) override;
-		void SetDepthBounds(float min_bounds, float max_bounds, CommandList cmd) override;
+		void BindDepthBounds(float min_bounds, float max_bounds, CommandList cmd) override;
 		void Draw(uint32_t vertexCount, uint32_t startVertexLocation, CommandList cmd) override;
 		void DrawIndexed(uint32_t indexCount, uint32_t startIndexLocation, int32_t baseVertexLocation, CommandList cmd) override;
 		void DrawInstanced(uint32_t vertexCount, uint32_t instanceCount, uint32_t startVertexLocation, uint32_t startInstanceLocation, CommandList cmd) override;


### PR DESCRIPTION
- Add BindDepthBounds, this binds to OMSetDepthBounds in D3D12 and vkCmdSetDepthBounds with VK_DYNAMIC_STATE_DEPTH_BOUNDS on Pipeline.
- Add DEPTH_BOUNDS_TEST capability
- Add depth_bounds_test_enable to DepthStencilState 