### PR TITLE
Entity Serializer Refactor

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -696,7 +696,7 @@ void EditorComponent::Load()
 		wi::helper::FileDialog(params, [=](std::string fileName) {
 			wi::eventhandler::Subscribe_Once(wi::eventhandler::EVENT_THREAD_SAFE_POINT, [=](uint64_t userdata) {
 				std::string filename = wi::helper::ReplaceExtension(fileName, params.extensions.front());
-				wi::Archive archive = dump_to_header ? wi::Archive() : wi::Archive(filename, false);
+				wi::ecs::Archive archive = dump_to_header ? wi::ecs::Archive() : wi::ecs::Archive(filename, false);
 				if (archive.IsOpen())
 				{
 					Scene& scene = wi::scene::GetScene();
@@ -1615,7 +1615,7 @@ void EditorComponent::Update(float dt)
 	// Delete
 	if (wi::input::Press(wi::input::KEYBOARD_BUTTON_DELETE))
 	{
-		wi::Archive& archive = AdvanceHistory();
+		wi::ecs::Archive& archive = AdvanceHistory();
 		archive << HISTORYOP_DELETE;
 
 		archive << translator.selected.size();
@@ -2455,7 +2455,7 @@ void EditorComponent::ResetHistory()
 	historyPos = -1;
 	history.clear();
 }
-wi::Archive& EditorComponent::AdvanceHistory()
+wi::ecs::Archive& EditorComponent::AdvanceHistory()
 {
 	historyPos++;
 
@@ -2480,7 +2480,7 @@ void EditorComponent::ConsumeHistoryOperation(bool undo)
 
 		Scene& scene = wi::scene::GetScene();
 
-		wi::Archive& archive = history[historyPos];
+		wi::ecs::Archive& archive = history[historyPos];
 		archive.SetReadModeAndResetPos(true);
 
 		int temp;

--- a/Editor/Editor.h
+++ b/Editor/Editor.h
@@ -156,9 +156,9 @@ public:
 
 
 
-	wi::Archive clipboard;
+	wi::ecs::Archive clipboard;
 
-	wi::vector<wi::Archive> history;
+	wi::vector<wi::ecs::Archive> history;
 	int historyPos = -1;
 	enum HistoryOperationType
 	{
@@ -170,7 +170,7 @@ public:
 	};
 
 	void ResetHistory();
-	wi::Archive& AdvanceHistory();
+	wi::ecs::Archive& AdvanceHistory();
 	void ConsumeHistoryOperation(bool undo);
 };
 

--- a/WickedEngine/wiArchive.h
+++ b/WickedEngine/wiArchive.h
@@ -36,7 +36,7 @@ namespace wi
 		Archive(const std::string& fileName, bool readMode = true);
 		// Creates a memory mapped archive in read mode
 		Archive(const uint8_t* data);
-		~Archive() { Close(); }
+		virtual ~Archive() { Close(); }
 
 		Archive& operator=(const Archive&) = default;
 		Archive& operator=(Archive&&) = default;
@@ -45,19 +45,19 @@ namespace wi
 		constexpr uint64_t GetVersion() const { return version; }
 		constexpr bool IsReadMode() const { return readMode; }
 		// This can set the archive into either read or write mode, and it will reset it's position
-		void SetReadModeAndResetPos(bool isReadMode);
+		virtual void SetReadModeAndResetPos(bool isReadMode);
 		// Check if the archive has any data
 		bool IsOpen() const { return data_ptr != nullptr; };
 		// Close the archive.
 		//	If it was opened from a file in write mode, the file will be written at this point
 		//	The data will be deleted, the archive will be empty after this
-		void Close();
+		virtual void Close();
 		// Write the archive contents to a specific file
 		//	The archive data will be written starting from the beginning, to the current position
-		bool SaveFile(const std::string& fileName);
+		virtual bool SaveFile(const std::string& fileName);
 		// Write the archive contents into a C++ header file
 		//	dataName : it will be the name of the byte data array in the header, that can be memory mapped
-		bool SaveHeaderFile(const std::string& fileName, const std::string& dataName);
+		virtual bool SaveHeaderFile(const std::string& fileName, const std::string& dataName);
 		// If the archive was opened from a file, this will return the file's directory
 		const std::string& GetSourceDirectory() const;
 		// If the archive was opened from a file, this will return the file's name

--- a/WickedEngine/wiECS.h
+++ b/WickedEngine/wiECS.h
@@ -55,6 +55,7 @@ namespace wi::ecs
 		{
 			wi::Archive::SetReadModeAndResetPos(isReadMode);
 			remap.clear();
+			allow_remap = true;
 		}
 
 		// This is the safe way to serialize an entity

--- a/WickedEngine/wiEmittedParticle.cpp
+++ b/WickedEngine/wiEmittedParticle.cpp
@@ -909,13 +909,13 @@ namespace wi
 	}
 
 
-	void EmittedParticleSystem::Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri)
+	void EmittedParticleSystem::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
 			archive >> _flags;
 			archive >> (uint32_t&)shaderType;
-			wi::ecs::SerializeEntity(archive, meshID, seri);
+			archive.SerializeEntity(meshID);
 			archive >> MAX_PARTICLES;
 			archive >> FIXED_TIMESTEP;
 			archive >> size;
@@ -975,7 +975,7 @@ namespace wi
 		{
 			archive << _flags;
 			archive << (uint32_t)shaderType;
-			wi::ecs::SerializeEntity(archive, meshID, seri);
+			archive.SerializeEntity(meshID);
 			archive << MAX_PARTICLES;
 			archive << FIXED_TIMESTEP;
 			archive << size;

--- a/WickedEngine/wiEmittedParticle.h
+++ b/WickedEngine/wiEmittedParticle.h
@@ -147,7 +147,7 @@ namespace wi
 		inline void SetVolumeEnabled(bool value) { if (value) { _flags |= FLAG_HAS_VOLUME; } else { _flags &= ~FLAG_HAS_VOLUME; } }
 		inline void SetFrameBlendingEnabled(bool value) { if (value) { _flags |= FLAG_FRAME_BLENDING; } else { _flags &= ~FLAG_FRAME_BLENDING; } }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 
 		static void Initialize();
 	};

--- a/WickedEngine/wiHairParticle.cpp
+++ b/WickedEngine/wiHairParticle.cpp
@@ -379,12 +379,12 @@ namespace wi
 	}
 
 
-	void HairParticleSystem::Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri)
+	void HairParticleSystem::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
 			archive >> _flags;
-			wi::ecs::SerializeEntity(archive, meshID, seri);
+			archive.SerializeEntity(meshID);
 			archive >> strandCount;
 			archive >> segmentCount;
 			archive >> randomSeed;
@@ -413,7 +413,7 @@ namespace wi
 		else
 		{
 			archive << _flags;
-			wi::ecs::SerializeEntity(archive, meshID, seri);
+			archive.SerializeEntity(meshID);
 			archive << strandCount;
 			archive << segmentCount;
 			archive << randomSeed;

--- a/WickedEngine/wiHairParticle.h
+++ b/WickedEngine/wiHairParticle.h
@@ -83,7 +83,7 @@ namespace wi
 		uint32_t layerMask = ~0u;
 		mutable bool regenerate_frame = true;
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 
 		static void Initialize();
 	};

--- a/WickedEngine/wiJobSystem.cpp
+++ b/WickedEngine/wiJobSystem.cpp
@@ -273,10 +273,13 @@ namespace wi::jobsystem
 
 	void Wait(const context& ctx)
 	{
-		// Wake any threads that might be sleeping:
-		internal_state.worker_state->wakeCondition.notify_all();
+		if (IsBusy(ctx))
+		{
+			// Wake any threads that might be sleeping:
+			internal_state.worker_state->wakeCondition.notify_all();
 
-		// Waiting will also put the current thread to good use by working on an other job if it can:
-		while (IsBusy(ctx)) { work(); }
+			// Waiting will also put the current thread to good use by working on an other job if it can:
+			while (IsBusy(ctx)) { work(); }
+		}
 	}
 }

--- a/WickedEngine/wiPrimitive.cpp
+++ b/WickedEngine/wiPrimitive.cpp
@@ -169,7 +169,7 @@ namespace wi::primitive
 	{
 		return AABB(wi::math::Min(a.getMin(), b.getMin()), wi::math::Max(a.getMax(), b.getMax()));
 	}
-	void AABB::Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri)
+	void AABB::Serialize(wi::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{

--- a/WickedEngine/wiPrimitive.h
+++ b/WickedEngine/wiPrimitive.h
@@ -66,7 +66,7 @@ namespace wi::primitive
 			return XMFLOAT3(0, 0, 0);
 		}
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::Archive& archive);
 	};
 	struct Sphere
 	{

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -1935,7 +1935,7 @@ namespace wi::scene
 		inverse_kinematics.Clear();
 		springs.Clear();
 
-		TLAS = RaytracingAccelerationStructure();
+		TLAS = {};
 		BVH.Clear();
 		waterRipples.clear();
 

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -2029,7 +2029,7 @@ namespace wi::scene
 	}
 	Entity Scene::Entity_Duplicate(Entity entity)
 	{
-		wi::Archive archive;
+		wi::ecs::Archive archive;
 
 		// First write the root entity to staging area:
 		archive.SetReadModeAndResetPos(false);
@@ -4004,7 +4004,7 @@ namespace wi::scene
 
 	Entity LoadModel(Scene& scene, const std::string& fileName, const XMMATRIX& transformMatrix, bool attached)
 	{
-		wi::Archive archive(fileName, true);
+		wi::ecs::Archive archive(fileName, true);
 		if (archive.IsOpen())
 		{
 			// Serialize it from file:

--- a/WickedEngine/wiScene.h
+++ b/WickedEngine/wiScene.h
@@ -20,11 +20,6 @@
 #include <memory>
 #include <limits>
 
-namespace wi
-{
-	class Archive;
-}
-
 namespace wi::scene
 {
 	struct NameComponent
@@ -35,7 +30,7 @@ namespace wi::scene
 		inline void operator=(std::string&& str) { name = std::move(str); }
 		inline bool operator==(const std::string& str) const { return name.compare(str) == 0; }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct LayerComponent
@@ -47,7 +42,7 @@ namespace wi::scene
 
 		inline uint32_t GetLayerMask() const { return layerMask & propagationMask; }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 	
 	struct TransformComponent
@@ -101,7 +96,7 @@ namespace wi::scene
 		void Lerp(const TransformComponent& a, const TransformComponent& b, float t);
 		void CatmullRom(const TransformComponent& a, const TransformComponent& b, const TransformComponent& c, const TransformComponent& d, float t);
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct PreviousFrameTransformComponent
@@ -109,7 +104,7 @@ namespace wi::scene
 		// Non-serialized attributes:
 		XMFLOAT4X4 world_prev;
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct HierarchyComponent
@@ -117,7 +112,7 @@ namespace wi::scene
 		wi::ecs::Entity parentID = wi::ecs::INVALID_ENTITY;
 		uint32_t layerMask_bind; // saved child layermask at the time of binding
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct MaterialComponent
@@ -311,7 +306,7 @@ namespace wi::scene
 		// Create constant buffer and texture resources for GPU
 		void CreateRenderData();
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct MeshComponent
@@ -438,7 +433,7 @@ namespace wi::scene
 		void RecenterToBottom();
 		wi::primitive::Sphere GetBoundingSphere() const;
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 
 
 		struct Vertex_POS
@@ -602,7 +597,7 @@ namespace wi::scene
 		inline void SetDirty(bool value = true) { if (value) { _flags |= DIRTY; } else { _flags &= ~DIRTY; } }
 		inline bool IsDirty() const { return _flags & DIRTY; }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct ObjectComponent
@@ -688,7 +683,7 @@ namespace wi::scene
 		void SaveLightmap();
 		void CompressLightmap();
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct RigidBodyPhysicsComponent
@@ -740,7 +735,7 @@ namespace wi::scene
 		inline bool IsDisableDeactivation() const { return _flags & DISABLE_DEACTIVATION; }
 		inline bool IsKinematic() const { return _flags & KINEMATIC; }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct SoftBodyPhysicsComponent
@@ -776,7 +771,7 @@ namespace wi::scene
 		// Create physics represenation of graphics mesh
 		void CreateFromMesh(const MeshComponent& mesh);
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct ArmatureComponent
@@ -798,7 +793,7 @@ namespace wi::scene
 
 		void CreateRenderData();
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct LightComponent
@@ -860,7 +855,7 @@ namespace wi::scene
 		inline void SetType(LightType val) { type = val; }
 		inline LightType GetType() const { return type; }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct CameraComponent
@@ -929,7 +924,7 @@ namespace wi::scene
 		inline bool IsDirty() const { return _flags & DIRTY; }
 		inline bool IsCustomProjectionEnabled() const { return _flags & CUSTOM_PROJECTION; }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct EnvironmentProbeComponent
@@ -955,7 +950,7 @@ namespace wi::scene
 		inline bool IsDirty() const { return _flags & DIRTY; }
 		inline bool IsRealTime() const { return _flags & REALTIME; }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct ForceFieldComponent
@@ -977,7 +972,7 @@ namespace wi::scene
 
 		inline float GetRange() const { return range_global; }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct DecalComponent
@@ -1001,7 +996,7 @@ namespace wi::scene
 
 		inline float GetOpacity() const { return color.w; }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct AnimationDataComponent
@@ -1015,7 +1010,7 @@ namespace wi::scene
 		wi::vector<float> keyframe_times;
 		wi::vector<float> keyframe_data;
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct AnimationComponent
@@ -1091,7 +1086,7 @@ namespace wi::scene
 		inline void Stop() { Pause(); timer = 0.0f; }
 		inline void SetLooped(bool value = true) { if (value) { _flags |= LOOPED; } else { _flags &= ~LOOPED; } }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct WeatherComponent
@@ -1151,7 +1146,7 @@ namespace wi::scene
 		wi::Resource skyMap;
 		wi::Resource colorGradingMap;
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct SoundComponent
@@ -1179,7 +1174,7 @@ namespace wi::scene
 		inline void SetLooped(bool value = true) { if (value) { _flags |= LOOPED; } else { _flags &= ~LOOPED; } }
 		inline void SetDisable3D(bool value = true) { if (value) { _flags |= DISABLE_3D; } else { _flags &= ~DISABLE_3D; } }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct InverseKinematicsComponent
@@ -1198,7 +1193,7 @@ namespace wi::scene
 		inline void SetDisabled(bool value = true) { if (value) { _flags |= DISABLED; } else { _flags &= ~DISABLED; } }
 		inline bool IsDisabled() const { return _flags & DISABLED; }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct SpringComponent
@@ -1231,7 +1226,7 @@ namespace wi::scene
 		inline bool IsStretchEnabled() const { return _flags & STRETCH_ENABLED; }
 		inline bool IsGravityEnabled() const { return _flags & GRAVITY_ENABLED; }
 
-		void Serialize(wi::Archive& archive, wi::ecs::EntitySerializer& seri);
+		void Serialize(wi::ecs::Archive& archive);
 	};
 
 	struct Scene
@@ -1376,16 +1371,26 @@ namespace wi::scene
 		//	The contents of the other scene will be lost (and moved to this)!
 		void Merge(Scene& other);
 
-		// Removes a specific entity from the scene (if it exists):
+		// Removes (deletes) a specific entity from the scene (if it exists):
 		void Entity_Remove(wi::ecs::Entity entity);
 		// Finds the first entity by the name (if it exists, otherwise returns INVALID_ENTITY):
 		wi::ecs::Entity Entity_FindByName(const std::string& name);
 		// Duplicates all of an entity's components and creates a new entity with them (recursively keeps hierarchy):
 		wi::ecs::Entity Entity_Duplicate(wi::ecs::Entity entity);
+
 		// Serializes entity and all of its components to archive:
-		//	Returns either the new entity that was read, or the original entity that was written
 		//	This serialization is recursive and serializes entity hierarchy as well
-		wi::ecs::Entity Entity_Serialize(wi::Archive& archive, wi::ecs::Entity entity = wi::ecs::INVALID_ENTITY);
+		//
+		//	archive	: the archive that holds the data
+		//	entity	: entity to write (optional, needed when archive is in write mode)
+		//	keep_internal_references_unchanged : if true, entities referenced by components will remain unchanged. In this case those will be only usable in the current application session.
+		//
+		//	Returns	: either the new entity that was read, or the original entity that was written
+		wi::ecs::Entity Entity_Serialize(
+			wi::ecs::Archive& archive,
+			wi::ecs::Entity entity = wi::ecs::INVALID_ENTITY,
+			bool keep_internal_references_unchanged = true
+		);
 
 		wi::ecs::Entity Entity_CreateMaterial(
 			const std::string& name
@@ -1443,7 +1448,7 @@ namespace wi::scene
 		// Detaches all children from an entity (if there are any):
 		void Component_DetachChildren(wi::ecs::Entity parent);
 
-		void Serialize(wi::Archive& archive);
+		void Serialize(wi::ecs::Archive& archive);
 
 		void RunPreviousFrameTransformUpdateSystem(wi::jobsystem::context& ctx);
 		void RunAnimationUpdateSystem(wi::jobsystem::context& ctx);

--- a/WickedEngine/wiScene.h
+++ b/WickedEngine/wiScene.h
@@ -1372,7 +1372,8 @@ namespace wi::scene
 		void Merge(Scene& other);
 
 		// Removes (deletes) a specific entity from the scene (if it exists):
-		void Entity_Remove(wi::ecs::Entity entity);
+		//	recursive : deletes children as well
+		void Entity_Remove(wi::ecs::Entity entity, bool recursive = true);
 		// Finds the first entity by the name (if it exists, otherwise returns INVALID_ENTITY):
 		wi::ecs::Entity Entity_FindByName(const std::string& name);
 		// Duplicates all of an entity's components and creates a new entity with them (recursively keeps hierarchy):
@@ -1389,6 +1390,7 @@ namespace wi::scene
 		wi::ecs::Entity Entity_Serialize(
 			wi::ecs::Archive& archive,
 			wi::ecs::Entity entity = wi::ecs::INVALID_ENTITY,
+			bool recursive = true,
 			bool keep_internal_references_unchanged = true
 		);
 

--- a/WickedEngine/wiScene_Serializers.cpp
+++ b/WickedEngine/wiScene_Serializers.cpp
@@ -12,7 +12,7 @@ using namespace wi::ecs;
 namespace wi::scene
 {
 
-	void NameComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void NameComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -23,7 +23,7 @@ namespace wi::scene
 			archive << name;
 		}
 	}
-	void LayerComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void LayerComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -34,7 +34,7 @@ namespace wi::scene
 			archive << layerMask;
 		}
 	}
-	void TransformComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void TransformComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -54,14 +54,14 @@ namespace wi::scene
 			archive << translation_local;
 		}
 	}
-	void PreviousFrameTransformComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void PreviousFrameTransformComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		// NOTHING! We just need a serialize function for this to be able serialize with ComponentManager!
 		//	This structure has no persistent state!
 	}
-	void HierarchyComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void HierarchyComponent::Serialize(wi::ecs::Archive& archive)
 	{
-		SerializeEntity(archive, parentID, seri);
+		archive.SerializeEntity(parentID);
 
 		if (archive.IsReadMode())
 		{
@@ -77,7 +77,7 @@ namespace wi::scene
 			archive << layerMask_bind;
 		}
 	}
-	void MaterialComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void MaterialComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		const std::string& dir = archive.GetSourceDirectory();
 
@@ -222,7 +222,7 @@ namespace wi::scene
 				}
 			}
 
-			wi::jobsystem::Execute(seri.ctx, [&](wi::jobsystem::JobArgs args) {
+			wi::jobsystem::Execute(archive.ctx, [&](wi::jobsystem::JobArgs args) {
 				CreateRenderData();
 			});
 		}
@@ -341,7 +341,7 @@ namespace wi::scene
 			}
 		}
 	}
-	void MeshComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void MeshComponent::Serialize(wi::ecs::Archive& archive)
 	{
 
 		if (archive.IsReadMode())
@@ -361,13 +361,13 @@ namespace wi::scene
 			subsets.resize(subsetCount);
 			for (size_t i = 0; i < subsetCount; ++i)
 			{
-				SerializeEntity(archive, subsets[i].materialID, seri);
+				archive.SerializeEntity(subsets[i].materialID);
 				archive >> subsets[i].indexOffset;
 				archive >> subsets[i].indexCount;
 			}
 
 			archive >> tessellationFactor;
-			SerializeEntity(archive, armatureID, seri);
+			archive.SerializeEntity(armatureID);
 
 			if (archive.GetVersion() >= 28)
 			{
@@ -376,9 +376,9 @@ namespace wi::scene
 
 			if (archive.GetVersion() >= 41)
 			{
-				SerializeEntity(archive, terrain_material1, seri);
-				SerializeEntity(archive, terrain_material2, seri);
-				SerializeEntity(archive, terrain_material3, seri);
+				archive.SerializeEntity(terrain_material1);
+				archive.SerializeEntity(terrain_material2);
+				archive.SerializeEntity(terrain_material3);
 			}
 
 			if (archive.GetVersion() >= 43)
@@ -404,7 +404,7 @@ namespace wi::scene
 			    }
 			}
 
-			wi::jobsystem::Execute(seri.ctx, [&](wi::jobsystem::JobArgs args) {
+			wi::jobsystem::Execute(archive.ctx, [&](wi::jobsystem::JobArgs args) {
 				CreateRenderData();
 			});
 		}
@@ -423,13 +423,13 @@ namespace wi::scene
 			archive << subsets.size();
 			for (size_t i = 0; i < subsets.size(); ++i)
 			{
-				SerializeEntity(archive, subsets[i].materialID, seri);
+				archive.SerializeEntity(subsets[i].materialID);
 				archive << subsets[i].indexOffset;
 				archive << subsets[i].indexCount;
 			}
 
 			archive << tessellationFactor;
-			SerializeEntity(archive, armatureID, seri);
+			archive.SerializeEntity(armatureID);
 
 			if (archive.GetVersion() >= 28)
 			{
@@ -438,9 +438,9 @@ namespace wi::scene
 
 			if (archive.GetVersion() >= 41)
 			{
-				SerializeEntity(archive, terrain_material1, seri);
-				SerializeEntity(archive, terrain_material2, seri);
-				SerializeEntity(archive, terrain_material3, seri);
+				archive.SerializeEntity(terrain_material1);
+				archive.SerializeEntity(terrain_material2);
+				archive.SerializeEntity(terrain_material3);
 			}
 
 			if (archive.GetVersion() >= 43)
@@ -466,7 +466,7 @@ namespace wi::scene
 
 		}
 	}
-	void ImpostorComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void ImpostorComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -481,12 +481,12 @@ namespace wi::scene
 			archive << swapInDistance;
 		}
 	}
-	void ObjectComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void ObjectComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
 			archive >> _flags;
-			SerializeEntity(archive, meshID, seri);
+			archive.SerializeEntity(meshID);
 			archive >> cascadeMask;
 			archive >> rendertypeMask;
 			archive >> color;
@@ -503,7 +503,7 @@ namespace wi::scene
 					if (expected_datasize != lightmapTextureData.size())
 					{
 						// This means it's from an old version, when lightmap data was stored in raw format, so compress it...
-						wi::jobsystem::Execute(seri.ctx, [this](wi::jobsystem::JobArgs args) {
+						wi::jobsystem::Execute(archive.ctx, [this](wi::jobsystem::JobArgs args) {
 							CompressLightmap();
 							});
 					}
@@ -521,7 +521,7 @@ namespace wi::scene
 		else
 		{
 			archive << _flags;
-			SerializeEntity(archive, meshID, seri);
+			archive.SerializeEntity(meshID);
 			archive << cascadeMask;
 			archive << rendertypeMask;
 			archive << color;
@@ -542,7 +542,7 @@ namespace wi::scene
 			}
 		}
 	}
-	void RigidBodyPhysicsComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void RigidBodyPhysicsComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -596,7 +596,7 @@ namespace wi::scene
 			}
 		}
 	}
-	void SoftBodyPhysicsComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void SoftBodyPhysicsComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -640,7 +640,7 @@ namespace wi::scene
 			}
 		}
 	}
-	void ArmatureComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void ArmatureComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -652,7 +652,7 @@ namespace wi::scene
 			for (size_t i = 0; i < boneCount; ++i)
 			{
 				Entity boneID;
-				SerializeEntity(archive, boneID, seri);
+				archive.SerializeEntity(boneID);
 				boneCollection[i] = boneID;
 			}
 
@@ -666,7 +666,7 @@ namespace wi::scene
 			if (archive.GetVersion() == 26)
 			{
 				Entity rootBoneID;
-				SerializeEntity(archive, rootBoneID, seri);
+				archive.SerializeEntity(rootBoneID);
 			}
 		}
 		else
@@ -677,18 +677,18 @@ namespace wi::scene
 			for (size_t i = 0; i < boneCollection.size(); ++i)
 			{
 				Entity boneID = boneCollection[i];
-				SerializeEntity(archive, boneID, seri);
+				archive.SerializeEntity(boneID);
 			}
 
 			archive << inverseBindMatrices;
 			if (archive.GetVersion() == 26)
 			{
 				Entity rootBoneID;
-				SerializeEntity(archive, rootBoneID, seri);
+				archive.SerializeEntity(rootBoneID);
 			}
 		}
 	}
-	void LightComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void LightComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		const std::string& dir = archive.GetSourceDirectory();
 
@@ -718,7 +718,7 @@ namespace wi::scene
 
 			archive >> lensFlareNames;
 
-			wi::jobsystem::Execute(seri.ctx, [&](wi::jobsystem::JobArgs args) {
+			wi::jobsystem::Execute(archive.ctx, [&](wi::jobsystem::JobArgs args) {
 				lensFlareRimTextures.resize(lensFlareNames.size());
 				for (size_t i = 0; i < lensFlareNames.size(); ++i)
 				{
@@ -761,7 +761,7 @@ namespace wi::scene
 			archive << lensFlareNames;
 		}
 	}
-	void CameraComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void CameraComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -798,7 +798,7 @@ namespace wi::scene
 			}
 		}
 	}
-	void EnvironmentProbeComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void EnvironmentProbeComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -811,7 +811,7 @@ namespace wi::scene
 			archive << _flags;
 		}
 	}
-	void ForceFieldComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void ForceFieldComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -828,7 +828,7 @@ namespace wi::scene
 			archive << range_local;
 		}
 	}
-	void DecalComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void DecalComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -839,7 +839,7 @@ namespace wi::scene
 			archive << _flags;
 		}
 	}
-	void AnimationComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void AnimationComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -864,7 +864,7 @@ namespace wi::scene
 			{
 				archive >> channels[i]._flags;
 				archive >> (uint32_t&)channels[i].path;
-				SerializeEntity(archive, channels[i].target, seri);
+				archive.SerializeEntity(channels[i].target);
 				archive >> channels[i].samplerIndex;
 			}
 
@@ -882,7 +882,7 @@ namespace wi::scene
 				}
 				if (archive.GetVersion() >= 46)
 				{
-					SerializeEntity(archive, samplers[i].data, seri);
+					archive.SerializeEntity(samplers[i].data);
 				}
 			}
 
@@ -908,7 +908,7 @@ namespace wi::scene
 			{
 				archive << channels[i]._flags;
 				archive << (uint32_t&)channels[i].path;
-				SerializeEntity(archive, channels[i].target, seri);
+				archive.SerializeEntity(channels[i].target);
 				archive << channels[i].samplerIndex;
 			}
 
@@ -917,11 +917,11 @@ namespace wi::scene
 			{
 				archive << samplers[i]._flags;
 				archive << samplers[i].mode;
-				SerializeEntity(archive, samplers[i].data, seri);
+				archive.SerializeEntity(samplers[i].data);
 			}
 		}
 	}
-	void AnimationDataComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void AnimationDataComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -936,7 +936,7 @@ namespace wi::scene
 			archive << keyframe_data;
 		}
 	}
-	void WeatherComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void WeatherComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		std::string dir = archive.GetSourceDirectory();
 
@@ -1225,7 +1225,7 @@ namespace wi::scene
 			}
 		}
 	}
-	void SoundComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void SoundComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		const std::string& dir = archive.GetSourceDirectory();
 
@@ -1236,7 +1236,7 @@ namespace wi::scene
 			archive >> volume;
 			archive >> (uint32_t&)soundinstance.type;
 
-			wi::jobsystem::Execute(seri.ctx, [&](wi::jobsystem::JobArgs args) {
+			wi::jobsystem::Execute(archive.ctx, [&](wi::jobsystem::JobArgs args) {
 				if (!filename.empty())
 				{
 					filename = dir + filename;
@@ -1255,9 +1255,9 @@ namespace wi::scene
 			archive << soundinstance.type;
 		}
 	}
-	void InverseKinematicsComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void InverseKinematicsComponent::Serialize(wi::ecs::Archive& archive)
 	{
-		SerializeEntity(archive, target, seri);
+		archive.SerializeEntity(target);
 
 		if (archive.IsReadMode())
 		{
@@ -1272,7 +1272,7 @@ namespace wi::scene
 			archive << iteration_count;
 		}
 	}
-	void SpringComponent::Serialize(wi::Archive& archive, EntitySerializer& seri)
+	void SpringComponent::Serialize(wi::ecs::Archive& archive)
 	{
 		if (archive.IsReadMode())
 		{
@@ -1292,7 +1292,7 @@ namespace wi::scene
 		}
 	}
 
-	void Scene::Serialize(wi::Archive& archive)
+	void Scene::Serialize(wi::ecs::Archive& archive)
 	{
 		wi::Timer timer;
 
@@ -1314,63 +1314,67 @@ namespace wi::scene
 			wi::resourcemanager::Serialize(archive, resource_seri);
 		}
 
-		// With this we will ensure that serialized entities are unique and persistent across the scene:
-		EntitySerializer seri;
-
-		names.Serialize(archive, seri);
-		layers.Serialize(archive, seri);
-		transforms.Serialize(archive, seri);
-		prev_transforms.Serialize(archive, seri);
-		hierarchy.Serialize(archive, seri);
-		materials.Serialize(archive, seri);
-		meshes.Serialize(archive, seri);
-		impostors.Serialize(archive, seri);
-		objects.Serialize(archive, seri);
-		aabb_objects.Serialize(archive, seri);
-		rigidbodies.Serialize(archive, seri);
-		softbodies.Serialize(archive, seri);
-		armatures.Serialize(archive, seri);
-		lights.Serialize(archive, seri);
-		aabb_lights.Serialize(archive, seri);
-		cameras.Serialize(archive, seri);
-		probes.Serialize(archive, seri);
-		aabb_probes.Serialize(archive, seri);
-		forces.Serialize(archive, seri);
-		decals.Serialize(archive, seri);
-		aabb_decals.Serialize(archive, seri);
-		animations.Serialize(archive, seri);
-		emitters.Serialize(archive, seri);
-		hairs.Serialize(archive, seri);
-		weathers.Serialize(archive, seri);
+		names.Serialize(archive);
+		layers.Serialize(archive);
+		transforms.Serialize(archive);
+		prev_transforms.Serialize(archive);
+		hierarchy.Serialize(archive);
+		materials.Serialize(archive);
+		meshes.Serialize(archive);
+		impostors.Serialize(archive);
+		objects.Serialize(archive);
+		aabb_objects.Serialize(archive);
+		rigidbodies.Serialize(archive);
+		softbodies.Serialize(archive);
+		armatures.Serialize(archive);
+		lights.Serialize(archive);
+		aabb_lights.Serialize(archive);
+		cameras.Serialize(archive);
+		probes.Serialize(archive);
+		aabb_probes.Serialize(archive);
+		forces.Serialize(archive);
+		decals.Serialize(archive);
+		aabb_decals.Serialize(archive);
+		animations.Serialize(archive);
+		emitters.Serialize(archive);
+		hairs.Serialize(archive);
+		weathers.Serialize(archive);
 		if (archive.GetVersion() >= 30)
 		{
-			sounds.Serialize(archive, seri);
+			sounds.Serialize(archive);
 		}
 		if (archive.GetVersion() >= 37)
 		{
-			inverse_kinematics.Serialize(archive, seri);
+			inverse_kinematics.Serialize(archive);
 		}
 		if (archive.GetVersion() >= 38)
 		{
-			springs.Serialize(archive, seri);
+			springs.Serialize(archive);
 		}
 		if (archive.GetVersion() >= 46)
 		{
-			animation_datas.Serialize(archive, seri);
+			animation_datas.Serialize(archive);
 		}
 
+		archive.Wait();
 		wi::backlog::post("Scene serialize took " + std::to_string(timer.elapsed_seconds()) + " sec");
 	}
 
-	Entity Scene::Entity_Serialize(wi::Archive& archive, Entity entity)
+	Entity Scene::Entity_Serialize(
+		wi::ecs::Archive& archive,
+		Entity entity,
+		bool keep_internal_references_unchanged
+	)
 	{
-		EntitySerializer seri;
+		archive.allow_remap = true;
+		archive.SerializeEntity(entity);
 
-		SerializeEntity(archive, entity, seri);
-
-		// From this point, we will not remap the entities, 
-		//	to retain internal entity references inside components:
-		seri.allow_remap = false;
+		if (keep_internal_references_unchanged)
+		{
+			// From this point, we will not remap the entities, 
+			//	to retain internal entity references inside components:
+			archive.allow_remap = false;
+		}
 
 		if (archive.IsReadMode())
 		{
@@ -1381,7 +1385,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = names.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1390,7 +1394,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = layers.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1399,7 +1403,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = transforms.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1408,7 +1412,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = prev_transforms.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1417,7 +1421,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = hierarchy.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1426,7 +1430,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = materials.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1435,7 +1439,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = meshes.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1444,7 +1448,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = impostors.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1453,7 +1457,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = objects.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1462,7 +1466,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = aabb_objects.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1471,7 +1475,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = rigidbodies.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1480,7 +1484,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = softbodies.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1489,7 +1493,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = armatures.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1498,7 +1502,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = lights.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1507,7 +1511,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = aabb_lights.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1516,7 +1520,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = cameras.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1525,7 +1529,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = probes.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1534,7 +1538,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = aabb_probes.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1543,7 +1547,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = forces.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1552,7 +1556,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = decals.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1561,7 +1565,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = aabb_decals.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1570,7 +1574,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = animations.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1579,7 +1583,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = emitters.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1588,7 +1592,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = hairs.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			{
@@ -1597,7 +1601,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = weathers.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			if (archive.GetVersion() >= 30)
@@ -1607,7 +1611,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = sounds.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			if (archive.GetVersion() >= 37)
@@ -1617,7 +1621,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = inverse_kinematics.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			if (archive.GetVersion() >= 38)
@@ -1627,7 +1631,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = springs.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 			if (archive.GetVersion() >= 46)
@@ -1637,7 +1641,7 @@ namespace wi::scene
 				if (component_exists)
 				{
 					auto& component = animation_datas.Create(entity);
-					component.Serialize(archive, seri);
+					component.Serialize(archive);
 				}
 			}
 
@@ -1648,7 +1652,7 @@ namespace wi::scene
 				archive >> childCount;
 				for (size_t i = 0; i < childCount; ++i)
 				{
-					Entity child = Entity_Serialize(archive);
+					Entity child = Entity_Serialize(archive, entity, keep_internal_references_unchanged);
 					if (child != INVALID_ENTITY)
 					{
 						HierarchyComponent* hier = hierarchy.GetComponent(child);
@@ -1668,7 +1672,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1680,7 +1684,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1692,7 +1696,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1704,7 +1708,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1716,7 +1720,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1728,7 +1732,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1740,7 +1744,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1752,7 +1756,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1764,7 +1768,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1776,7 +1780,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1788,7 +1792,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1800,7 +1804,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1812,7 +1816,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1824,7 +1828,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1836,7 +1840,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1848,7 +1852,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1860,7 +1864,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1872,7 +1876,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1884,7 +1888,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1896,7 +1900,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1908,7 +1912,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1920,7 +1924,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1932,7 +1936,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1944,7 +1948,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1956,7 +1960,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1969,7 +1973,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1982,7 +1986,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -1995,7 +1999,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -2008,7 +2012,7 @@ namespace wi::scene
 				if (component != nullptr)
 				{
 					archive << true;
-					component->Serialize(archive, seri);
+					component->Serialize(archive);
 				}
 				else
 				{
@@ -2032,11 +2036,12 @@ namespace wi::scene
 				archive << children.size();
 				for (Entity child : children)
 				{
-					Entity_Serialize(archive, child);
+					Entity_Serialize(archive, child, keep_internal_references_unchanged);
 				}
 			}
 		}
 
+		archive.Wait();
 		return entity;
 	}
 

--- a/WickedEngine/wiScene_Serializers.cpp
+++ b/WickedEngine/wiScene_Serializers.cpp
@@ -7,8 +7,6 @@
 #include "wiTimer.h"
 #include "wiVector.h"
 
-using namespace wi::ecs;
-
 namespace wi::scene
 {
 
@@ -651,7 +649,7 @@ namespace wi::scene
 			boneCollection.resize(boneCount);
 			for (size_t i = 0; i < boneCount; ++i)
 			{
-				Entity boneID;
+				wi::ecs::Entity boneID;
 				archive.SerializeEntity(boneID);
 				boneCollection[i] = boneID;
 			}
@@ -665,7 +663,7 @@ namespace wi::scene
 			}
 			if (archive.GetVersion() == 26)
 			{
-				Entity rootBoneID;
+				wi::ecs::Entity rootBoneID;
 				archive.SerializeEntity(rootBoneID);
 			}
 		}
@@ -676,14 +674,14 @@ namespace wi::scene
 			archive << boneCollection.size();
 			for (size_t i = 0; i < boneCollection.size(); ++i)
 			{
-				Entity boneID = boneCollection[i];
+				wi::ecs::Entity boneID = boneCollection[i];
 				archive.SerializeEntity(boneID);
 			}
 
 			archive << inverseBindMatrices;
 			if (archive.GetVersion() == 26)
 			{
-				Entity rootBoneID;
+				wi::ecs::Entity rootBoneID;
 				archive.SerializeEntity(rootBoneID);
 			}
 		}
@@ -1360,9 +1358,9 @@ namespace wi::scene
 		wi::backlog::post("Scene serialize took " + std::to_string(timer.elapsed_seconds()) + " sec");
 	}
 
-	Entity Scene::Entity_Serialize(
+	wi::ecs::Entity Scene::Entity_Serialize(
 		wi::ecs::Archive& archive,
-		Entity entity,
+		wi::ecs::Entity entity,
 		bool keep_internal_references_unchanged
 	)
 	{
@@ -1652,8 +1650,8 @@ namespace wi::scene
 				archive >> childCount;
 				for (size_t i = 0; i < childCount; ++i)
 				{
-					Entity child = Entity_Serialize(archive, entity, keep_internal_references_unchanged);
-					if (child != INVALID_ENTITY)
+					wi::ecs::Entity child = Entity_Serialize(archive, entity, keep_internal_references_unchanged);
+					if (child != wi::ecs::INVALID_ENTITY)
 					{
 						HierarchyComponent* hier = hierarchy.GetComponent(child);
 						if (hier != nullptr)
@@ -2023,18 +2021,18 @@ namespace wi::scene
 			if (archive.GetVersion() >= 72)
 			{
 				// Recursive serialization for all children:
-				wi::vector<Entity> children;
+				wi::vector<wi::ecs::Entity> children;
 				for (size_t i = 0; i < hierarchy.GetCount(); ++i)
 				{
 					const HierarchyComponent& hier = hierarchy[i];
 					if (hier.parentID == entity)
 					{
-						Entity child = hierarchy.GetEntity(i);
+						wi::ecs::Entity child = hierarchy.GetEntity(i);
 						children.push_back(child);
 					}
 				}
 				archive << children.size();
-				for (Entity child : children)
+				for (wi::ecs::Entity child : children)
 				{
 					Entity_Serialize(archive, child, keep_internal_references_unchanged);
 				}

--- a/WickedEngine/wiScene_Serializers.cpp
+++ b/WickedEngine/wiScene_Serializers.cpp
@@ -2041,6 +2041,7 @@ namespace wi::scene
 			}
 		}
 
+		archive.allow_remap = true;
 		archive.Wait();
 		return entity;
 	}

--- a/WickedEngine/wiVersion.cpp
+++ b/WickedEngine/wiVersion.cpp
@@ -9,7 +9,7 @@ namespace wi::version
 	// minor features, major updates, breaking compatibility changes
 	const int minor = 60;
 	// minor bug fixes, alterations, refactors, updates
-	const int revision = 25;
+	const int revision = 26;
 
 	const std::string version_string = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(revision);
 


### PR DESCRIPTION
- Removed EntitySerializer
- Added `wi::ecs::Archive` that adds entity serializing functionality to `wi::Archive`
- `Scene::Entity_Serialize` supports persistent serialization (`keep_internal_references_unchanged`)