### PR TITLE
(Linux) File dialog glob pattern fix

### DIFF
--- a/WickedEngine/wiHelper.cpp
+++ b/WickedEngine/wiHelper.cpp
@@ -953,9 +953,14 @@ namespace wi::helper
 		}
 
 		std::vector<std::string> extensions = {params.description, ""};
+		int extcount = 0;
 		for (auto& x : params.extensions)
 		{
-			extensions[1] += "*." + x + " ";
+			extensions[1] += "*." + x;
+			if(extcount < params.extensions.size()-1){
+				extensions[1] += " ";
+			}
+			extcount++;
 		}
 
 		switch (params.type) {


### PR DESCRIPTION
This one is for Flatpak applications, since the Flatpak uses portals for dialogs the requirements is a lot more stricter for file dialog list, seems like it does not tolerate empty string after the list (the space at the end of the list is detected as a file with an empty glob would also be accepted, which in this case is illegal)