### PR TITLE
Changed the Wicked Engine launcher shebang

### DIFF
--- a/Editor/Linux/Installer/Distribution/wicked-engine.sh
+++ b/Editor/Linux/Installer/Distribution/wicked-engine.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Starting Wicked Engine"
 

--- a/Editor/Linux/Installer/Distribution/wicked-engine.template.sh
+++ b/Editor/Linux/Installer/Distribution/wicked-engine.template.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Starting Wicked Engine Editor"
 


### PR DESCRIPTION
The Wicked Engine launcher script on GNU/Linux has been altered to use `sh` rather than `bash`, making it *almost* universal.