### PR TITLE
GUI scrollbar updates

### DIFF
--- a/Editor/AnimationWindow.cpp
+++ b/Editor/AnimationWindow.cpp
@@ -11,14 +11,14 @@ void AnimationWindow::Create(EditorComponent* editor)
 	SetSize(XMFLOAT2(520, 140));
 
 	float x = 140;
-	float y = 10;
+	float y = 0;
 	float hei = 18;
 	float step = hei + 2;
 
 
 	animationsComboBox.Create("Animation: ");
 	animationsComboBox.SetSize(XMFLOAT2(300, hei));
-	animationsComboBox.SetPos(XMFLOAT2(x, y += step));
+	animationsComboBox.SetPos(XMFLOAT2(x, y));
 	animationsComboBox.SetEnabled(false);
 	animationsComboBox.OnSelect([&](wi::gui::EventArgs args) {
 		entity = wi::scene::GetScene().animations.GetEntity(args.iValue);

--- a/Editor/CameraWindow.cpp
+++ b/Editor/CameraWindow.cpp
@@ -37,14 +37,14 @@ void CameraWindow::Create(EditorComponent* editor)
 	SetSize(XMFLOAT2(380, 360));
 
 	float x = 200;
-	float y = 10;
+	float y = 0;
 	float hei = 18;
 	float step = hei + 2;
 
 	farPlaneSlider.Create(100, 10000, 5000, 100000, "Far Plane: ");
 	farPlaneSlider.SetTooltip("Controls the camera's far clip plane, geometry farther than this will be clipped.");
 	farPlaneSlider.SetSize(XMFLOAT2(100, hei));
-	farPlaneSlider.SetPos(XMFLOAT2(x, y += step));
+	farPlaneSlider.SetPos(XMFLOAT2(x, y));
 	farPlaneSlider.SetValue(wi::scene::GetCamera().zFarP);
 	farPlaneSlider.OnSlide([&](wi::gui::EventArgs args) {
 		Scene& scene = wi::scene::GetScene();

--- a/Editor/DecalWindow.cpp
+++ b/Editor/DecalWindow.cpp
@@ -9,15 +9,15 @@ using namespace wi::scene;
 void DecalWindow::Create(EditorComponent* editor)
 {
 	wi::gui::Window::Create("Decal Window");
-	SetSize(XMFLOAT2(400, 200));
+	SetSize(XMFLOAT2(420, 200));
 
 	float x = 200;
-	float y = 5;
+	float y = 0;
 	float hei = 18;
 	float step = hei + 2;
 
 	placementCheckBox.Create("Decal Placement Enabled: ");
-	placementCheckBox.SetPos(XMFLOAT2(x, y += step));
+	placementCheckBox.SetPos(XMFLOAT2(x, y));
 	placementCheckBox.SetSize(XMFLOAT2(hei, hei));
 	placementCheckBox.SetCheck(false);
 	placementCheckBox.SetTooltip("Enable decal placement. Use the left mouse button to place decals to the scene.");

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -1021,7 +1021,6 @@ void EditorComponent::Load()
 		RecordSelection(archive);
 
 		});
-	sceneGraphView.SetColor(wi::Color(100, 100, 100, 100), wi::gui::IDLE);
 	GetGUI().AddWidget(&sceneGraphView);
 
 

--- a/Editor/EmitterWindow.cpp
+++ b/Editor/EmitterWindow.cpp
@@ -10,16 +10,16 @@ using namespace wi::scene;
 void EmitterWindow::Create(EditorComponent* editor)
 {
 	wi::gui::Window::Create("Emitter Window");
-	SetSize(XMFLOAT2(680, 720));
+	SetSize(XMFLOAT2(680, 420));
 
 	float x = 200;
-	float y = 5;
+	float y = 0;
 	float itemheight = 18;
 	float step = itemheight + 2;
 
 
 	emitterNameField.Create("EmitterName");
-	emitterNameField.SetPos(XMFLOAT2(x, y += step));
+	emitterNameField.SetPos(XMFLOAT2(x, y));
 	emitterNameField.SetSize(XMFLOAT2(300, itemheight));
 	emitterNameField.OnInputAccepted([=](wi::gui::EventArgs args) {
 		NameComponent* name = wi::scene::GetScene().names.GetComponent(entity);

--- a/Editor/EnvProbeWindow.cpp
+++ b/Editor/EnvProbeWindow.cpp
@@ -10,10 +10,10 @@ void EnvProbeWindow::Create(EditorComponent* editor)
 	wi::gui::Window::Create("Environment Probe Window");
 	SetSize(XMFLOAT2(300, 200));
 
-	float x = 100, y = 5, step = 35;
+	float x = 100, y = 0, step = 35;
 
 	realTimeCheckBox.Create("RealTime: ");
-	realTimeCheckBox.SetPos(XMFLOAT2(x, y += step));
+	realTimeCheckBox.SetPos(XMFLOAT2(x, y));
 	realTimeCheckBox.SetEnabled(false);
 	realTimeCheckBox.OnClick([&](wi::gui::EventArgs args) {
 		EnvironmentProbeComponent* probe = wi::scene::GetScene().probes.GetComponent(entity);

--- a/Editor/ForceFieldWindow.cpp
+++ b/Editor/ForceFieldWindow.cpp
@@ -12,13 +12,13 @@ void ForceFieldWindow::Create(EditorComponent* editor)
 	SetSize(XMFLOAT2(420, 120));
 
 	float x = 150;
-	float y = 10;
+	float y = 0;
 	float hei = 18;
 	float step = hei + 2;
 
 	addButton.Create("Add Force Field");
 	addButton.SetSize(XMFLOAT2(150, hei));
-	addButton.SetPos(XMFLOAT2(x, y += step));
+	addButton.SetPos(XMFLOAT2(x, y));
 	addButton.OnClick([=](wi::gui::EventArgs args) {
 		Entity entity = wi::scene::GetScene().Entity_CreateForce("editorForce");
 		ForceFieldComponent* force = wi::scene::GetScene().forces.GetComponent(entity);

--- a/Editor/HairParticleWindow.cpp
+++ b/Editor/HairParticleWindow.cpp
@@ -11,13 +11,13 @@ void HairParticleWindow::Create(EditorComponent* editor)
 	SetSize(XMFLOAT2(600, 260));
 
 	float x = 160;
-	float y = 10;
+	float y = 0;
 	float hei = 18;
 	float step = hei + 2;
 
 
 	addButton.Create("Add Hair Particle System");
-	addButton.SetPos(XMFLOAT2(x, y += step));
+	addButton.SetPos(XMFLOAT2(x, y));
 	addButton.SetSize(XMFLOAT2(200, hei));
 	addButton.OnClick([=](wi::gui::EventArgs args) {
 		Scene& scene = wi::scene::GetScene();

--- a/Editor/IKWindow.cpp
+++ b/Editor/IKWindow.cpp
@@ -12,14 +12,14 @@ void IKWindow::Create(EditorComponent* editor)
 	SetSize(XMFLOAT2(400, 150));
 
 	float x = 120;
-	float y = 10;
+	float y = 0;
 	float siz = 200;
 	float hei = 18;
 	float step = hei + 2;
 
 	createButton.Create("Create");
 	createButton.SetTooltip("Create/Remove IK Component to selected entity");
-	createButton.SetPos(XMFLOAT2(x, y += step));
+	createButton.SetPos(XMFLOAT2(x, y));
 	createButton.SetSize(XMFLOAT2(siz, hei));
 	AddWidget(&createButton);
 

--- a/Editor/LayerWindow.cpp
+++ b/Editor/LayerWindow.cpp
@@ -9,10 +9,10 @@ using namespace wi::scene;
 void LayerWindow::Create(EditorComponent* editor)
 {
 	wi::gui::Window::Create("Layer Window");
-	SetSize(XMFLOAT2(410, 290));
+	SetSize(XMFLOAT2(420, 290));
 
 	float x = 30;
-	float y = 25;
+	float y = 0;
 	float step = 25;
 	float siz = 20;
 

--- a/Editor/LightWindow.cpp
+++ b/Editor/LightWindow.cpp
@@ -12,16 +12,16 @@ using namespace wi::scene;
 void LightWindow::Create(EditorComponent* editor)
 {
 	wi::gui::Window::Create("Light Window");
-	SetSize(XMFLOAT2(650, 500));
+	SetSize(XMFLOAT2(650, 300));
 
 	float x = 450;
-	float y = 20;
+	float y = 0;
 	float hei = 18;
 	float step = hei + 2;
 
 	energySlider.Create(0.1f, 64, 0, 100000, "Energy: ");
 	energySlider.SetSize(XMFLOAT2(100, hei));
-	energySlider.SetPos(XMFLOAT2(x, y += step));
+	energySlider.SetPos(XMFLOAT2(x, y));
 	energySlider.OnSlide([&](wi::gui::EventArgs args) {
 		LightComponent* light = wi::scene::GetScene().lights.GetComponent(entity);
 		if (light != nullptr)

--- a/Editor/MaterialWindow.cpp
+++ b/Editor/MaterialWindow.cpp
@@ -11,13 +11,13 @@ void MaterialWindow::Create(EditorComponent* editor)
 	wi::gui::Window::Create("Material Window");
 	SetSize(XMFLOAT2(730, 620));
 
-	float x = 670, y = 0;
 	float hei = 18;
 	float step = hei + 2;
+	float x = 670, y = 0;
 
 	shadowReceiveCheckBox.Create("Receive Shadow: ");
 	shadowReceiveCheckBox.SetTooltip("Receives shadow or not?");
-	shadowReceiveCheckBox.SetPos(XMFLOAT2(540, y += step));
+	shadowReceiveCheckBox.SetPos(XMFLOAT2(540, y));
 	shadowReceiveCheckBox.SetSize(XMFLOAT2(hei, hei));
 	shadowReceiveCheckBox.OnClick([&](wi::gui::EventArgs args) {
 		MaterialComponent* material = wi::scene::GetScene().materials.GetComponent(entity);
@@ -426,14 +426,14 @@ void MaterialWindow::Create(EditorComponent* editor)
 
 
 	// 
-	x = 10;
-	y = 0;
 	hei = 20;
 	step = hei + 2;
+	x = 10;
+	y = 0;
 
 	materialNameField.Create("MaterialName");
 	materialNameField.SetTooltip("Set a name for the material...");
-	materialNameField.SetPos(XMFLOAT2(10, y += step));
+	materialNameField.SetPos(XMFLOAT2(10, y));
 	materialNameField.SetSize(XMFLOAT2(300, hei));
 	materialNameField.OnInputAccepted([=](wi::gui::EventArgs args) {
 		NameComponent* name = wi::scene::GetScene().names.GetComponent(entity);

--- a/Editor/MaterialWindow.cpp
+++ b/Editor/MaterialWindow.cpp
@@ -9,7 +9,7 @@ using namespace wi::scene;
 void MaterialWindow::Create(EditorComponent* editor)
 {
 	wi::gui::Window::Create("Material Window");
-	SetSize(XMFLOAT2(720, 620));
+	SetSize(XMFLOAT2(730, 620));
 
 	float x = 670, y = 0;
 	float hei = 18;

--- a/Editor/MeshWindow.cpp
+++ b/Editor/MeshWindow.cpp
@@ -14,7 +14,7 @@ using namespace wi::scene;
 void MeshWindow::Create(EditorComponent* editor)
 {
 	wi::gui::Window::Create("Mesh Window");
-	SetSize(XMFLOAT2(580, 580));
+	SetSize(XMFLOAT2(580, 380));
 
 	float x = 150;
 	float y = 0;
@@ -23,17 +23,17 @@ void MeshWindow::Create(EditorComponent* editor)
 
 	float infolabel_height = 190;
 	meshInfoLabel.Create("Mesh Info");
-	meshInfoLabel.SetPos(XMFLOAT2(x - 50, y += step));
+	meshInfoLabel.SetPos(XMFLOAT2(x - 50, y));
 	meshInfoLabel.SetSize(XMFLOAT2(450, infolabel_height));
 	meshInfoLabel.SetColor(wi::Color::Transparent());
 	AddWidget(&meshInfoLabel);
 
 	// Left side:
-	y = infolabel_height + 10;
+	y = infolabel_height + 5;
 
 	subsetComboBox.Create("Selected subset: ");
 	subsetComboBox.SetSize(XMFLOAT2(40, hei));
-	subsetComboBox.SetPos(XMFLOAT2(x, y += step));
+	subsetComboBox.SetPos(XMFLOAT2(x, y));
 	subsetComboBox.SetEnabled(false);
 	subsetComboBox.OnSelect([=](wi::gui::EventArgs args) {
 		Scene& scene = wi::scene::GetScene();
@@ -474,11 +474,11 @@ void MeshWindow::Create(EditorComponent* editor)
 
 	// Right side:
 	x = 150;
-	y = infolabel_height + 10;
+	y = infolabel_height + 5;
 
 	subsetMaterialComboBox.Create("Subset Material: ");
 	subsetMaterialComboBox.SetSize(XMFLOAT2(200, hei));
-	subsetMaterialComboBox.SetPos(XMFLOAT2(x + 180, y += step));
+	subsetMaterialComboBox.SetPos(XMFLOAT2(x + 180, y));
 	subsetMaterialComboBox.SetEnabled(false);
 	subsetMaterialComboBox.OnSelect([&](wi::gui::EventArgs args) {
 		Scene& scene = wi::scene::GetScene();

--- a/Editor/NameWindow.cpp
+++ b/Editor/NameWindow.cpp
@@ -19,7 +19,7 @@ void NameWindow::Create(EditorComponent* editor)
 
 	nameInput.Create("");
 	nameInput.SetDescription("Name: ");
-	nameInput.SetPos(XMFLOAT2(x, y += step));
+	nameInput.SetPos(XMFLOAT2(x, y));
 	nameInput.SetSize(XMFLOAT2(siz, hei));
 	nameInput.OnInputAccepted([=](wi::gui::EventArgs args) {
 		NameComponent* name = wi::scene::GetScene().names.GetComponent(entity);

--- a/Editor/ObjectWindow.cpp
+++ b/Editor/ObjectWindow.cpp
@@ -261,7 +261,7 @@ void ObjectWindow::Create(EditorComponent* editor)
 	this->editor = editor;
 
 	wi::gui::Window::Create("Object Window");
-	SetSize(XMFLOAT2(660, 520));
+	SetSize(XMFLOAT2(670, 320));
 
 	float x = 200;
 	float y = 0;
@@ -270,7 +270,7 @@ void ObjectWindow::Create(EditorComponent* editor)
 
 	nameLabel.Create("NAMELABEL");
 	nameLabel.SetText("");
-	nameLabel.SetPos(XMFLOAT2(x - 30, y += step));
+	nameLabel.SetPos(XMFLOAT2(x - 30, y));
 	nameLabel.SetSize(XMFLOAT2(150, hei));
 	AddWidget(&nameLabel);
 

--- a/Editor/PaintToolWindow.cpp
+++ b/Editor/PaintToolWindow.cpp
@@ -14,16 +14,16 @@ void PaintToolWindow::Create(EditorComponent* editor)
 	this->editor = editor;
 
 	wi::gui::Window::Create("Paint Tool Window");
-	SetSize(XMFLOAT2(400, 600));
+	SetSize(XMFLOAT2(410, 610));
 
 	float x = 100;
-	float y = 5;
+	float y = 0;
 	float hei = 20;
 	float step = hei + 4;
 
 	modeComboBox.Create("Mode: ");
 	modeComboBox.SetTooltip("Choose paint tool mode");
-	modeComboBox.SetPos(XMFLOAT2(x, y += step));
+	modeComboBox.SetPos(XMFLOAT2(x, y));
 	modeComboBox.SetSize(XMFLOAT2(200, hei));
 	modeComboBox.AddItem("Disabled");
 	modeComboBox.AddItem("Texture");

--- a/Editor/PostprocessWindow.cpp
+++ b/Editor/PostprocessWindow.cpp
@@ -9,10 +9,10 @@ using namespace wi::graphics;
 void PostprocessWindow::Create(EditorComponent* editor)
 {
 	wi::gui::Window::Create("PostProcess Window");
-	SetSize(XMFLOAT2(420, 500));
+	SetSize(XMFLOAT2(420, 400));
 
 	float x = 150;
-	float y = 10;
+	float y = 0;
 	float hei = 18;
 	float step = hei + 2;
 
@@ -20,7 +20,7 @@ void PostprocessWindow::Create(EditorComponent* editor)
 	exposureSlider.SetTooltip("Set the tonemap exposure value");
 	exposureSlider.SetScriptTip("RenderPath3D::SetExposure(float value)");
 	exposureSlider.SetSize(XMFLOAT2(100, hei));
-	exposureSlider.SetPos(XMFLOAT2(x, y += step));
+	exposureSlider.SetPos(XMFLOAT2(x, y));
 	exposureSlider.SetValue(editor->renderPath->getExposure());
 	exposureSlider.OnSlide([=](wi::gui::EventArgs args) {
 		editor->renderPath->setExposure(args.fValue);

--- a/Editor/RendererWindow.cpp
+++ b/Editor/RendererWindow.cpp
@@ -11,7 +11,7 @@ void RendererWindow::Create(EditorComponent* editor)
 	wi::renderer::SetToDrawGridHelper(true);
 	wi::renderer::SetToDrawDebugCameras(true);
 
-	SetSize(XMFLOAT2(580, 600));
+	SetSize(XMFLOAT2(580, 300));
 
 	float x = 220, y = 5, step = 20, itemheight = 18;
 

--- a/Editor/RendererWindow.cpp
+++ b/Editor/RendererWindow.cpp
@@ -11,14 +11,15 @@ void RendererWindow::Create(EditorComponent* editor)
 	wi::renderer::SetToDrawGridHelper(true);
 	wi::renderer::SetToDrawDebugCameras(true);
 
-	SetSize(XMFLOAT2(580, 300));
+	SetSize(XMFLOAT2(580, 400));
 
-	float x = 220, y = 5, step = 20, itemheight = 18;
+	float step = 20, itemheight = 18;
+	float x = 220, y = 0;
 
 	vsyncCheckBox.Create("VSync: ");
 	vsyncCheckBox.SetTooltip("Toggle vertical sync");
 	vsyncCheckBox.SetScriptTip("SetVSyncEnabled(opt bool enabled)");
-	vsyncCheckBox.SetPos(XMFLOAT2(x, y += step));
+	vsyncCheckBox.SetPos(XMFLOAT2(x, y));
 	vsyncCheckBox.SetSize(XMFLOAT2(itemheight, itemheight));
 	vsyncCheckBox.SetCheck(editor->main->swapChain.desc.vsync);
 	vsyncCheckBox.OnClick([=](wi::gui::EventArgs args) {
@@ -529,11 +530,11 @@ void RendererWindow::Create(EditorComponent* editor)
 
 
 	// Visualizer toggles:
-	x = 540, y = 5;
+	x = 540, y = 0;
 
 	physicsDebugCheckBox.Create("Physics visualizer: ");
 	physicsDebugCheckBox.SetTooltip("Visualize the physics world");
-	physicsDebugCheckBox.SetPos(XMFLOAT2(x, y += step));
+	physicsDebugCheckBox.SetPos(XMFLOAT2(x, y));
 	physicsDebugCheckBox.SetSize(XMFLOAT2(itemheight, itemheight));
 	physicsDebugCheckBox.OnClick([](wi::gui::EventArgs args) {
 		wi::physics::SetDebugDrawEnabled(args.bValue);

--- a/Editor/SoundWindow.cpp
+++ b/Editor/SoundWindow.cpp
@@ -13,12 +13,12 @@ void SoundWindow::Create(EditorComponent* editor)
 	SetSize(XMFLOAT2(440, 220));
 
 	float x = 20;
-	float y = 10;
+	float y = 0;
 	float hei = 18;
 	float step = hei + 2;
 
 	reverbComboBox.Create("Reverb: ");
-	reverbComboBox.SetPos(XMFLOAT2(x + 80, y += step));
+	reverbComboBox.SetPos(XMFLOAT2(x + 80, y));
 	reverbComboBox.SetSize(XMFLOAT2(180, hei));
 	reverbComboBox.OnSelect([&](wi::gui::EventArgs args) {
 		wi::audio::SetReverb((wi::audio::REVERB_PRESET)args.iValue);

--- a/Editor/SpringWindow.cpp
+++ b/Editor/SpringWindow.cpp
@@ -12,14 +12,14 @@ void SpringWindow::Create(EditorComponent* editor)
 	SetSize(XMFLOAT2(460, 200));
 
 	float x = 150;
-	float y = 10;
+	float y = 0;
 	float siz = 200;
 	float hei = 18;
 	float step = hei + 2;
 
 	createButton.Create("Create");
 	createButton.SetTooltip("Create/Remove Spring Component to selected entity");
-	createButton.SetPos(XMFLOAT2(x, y += step));
+	createButton.SetPos(XMFLOAT2(x, y));
 	createButton.SetSize(XMFLOAT2(siz, hei));
 	AddWidget(&createButton);
 

--- a/Editor/TerrainGenerator.cpp
+++ b/Editor/TerrainGenerator.cpp
@@ -172,7 +172,7 @@ void TerrainGenerator::init()
 	centerToCamCheckBox.Create("Center to Cam: ");
 	centerToCamCheckBox.SetTooltip("Automatically generate chunks around camera. This sets the center chunk to camera position.");
 	centerToCamCheckBox.SetSize(XMFLOAT2(hei, hei));
-	centerToCamCheckBox.SetPos(XMFLOAT2(x, y += step));
+	centerToCamCheckBox.SetPos(XMFLOAT2(x, y));
 	centerToCamCheckBox.SetCheck(true);
 	AddWidget(&centerToCamCheckBox);
 

--- a/Editor/TransformWindow.cpp
+++ b/Editor/TransformWindow.cpp
@@ -9,7 +9,7 @@ using namespace wi::scene;
 void TransformWindow::Create(EditorComponent* editor)
 {
 	wi::gui::Window::Create("Transform Window");
-	SetSize(XMFLOAT2(460, 180));
+	SetSize(XMFLOAT2(480, 200));
 
 	float x = 100;
 	float y = 0;
@@ -19,7 +19,7 @@ void TransformWindow::Create(EditorComponent* editor)
 
 	createButton.Create("Create New Transform");
 	createButton.SetTooltip("Create a new entity with only a trasform component");
-	createButton.SetPos(XMFLOAT2(x, y += step));
+	createButton.SetPos(XMFLOAT2(x, y));
 	createButton.SetSize(XMFLOAT2(350, hei));
 	createButton.OnClick([=](wi::gui::EventArgs args) {
 		Entity entity = CreateEntity();

--- a/Editor/WeatherWindow.cpp
+++ b/Editor/WeatherWindow.cpp
@@ -12,14 +12,14 @@ void WeatherWindow::Create(EditorComponent* editor)
 	SetSize(XMFLOAT2(660, 680));
 
 	float x = 180;
-	float y = 20;
+	float y = 0;
 	float hei = 18;
 	float step = hei + 2;
 
 
 	heightFogCheckBox.Create("Height fog: ");
 	heightFogCheckBox.SetSize(XMFLOAT2(hei, hei));
-	heightFogCheckBox.SetPos(XMFLOAT2(x + 100, y += step));
+	heightFogCheckBox.SetPos(XMFLOAT2(x + 100, y));
 	heightFogCheckBox.OnClick([&](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.SetHeightFog(args.bValue);
@@ -396,11 +396,11 @@ void WeatherWindow::Create(EditorComponent* editor)
 
 
 	x = 340;
-	y = 20;
+	y = 0;
 
 	colorComboBox.Create("Color picker mode: ");
 	colorComboBox.SetSize(XMFLOAT2(120, hei));
-	colorComboBox.SetPos(XMFLOAT2(x + 150, y += step));
+	colorComboBox.SetPos(XMFLOAT2(x + 150, y));
 	colorComboBox.AddItem("Ambient color");
 	colorComboBox.AddItem("Horizon color");
 	colorComboBox.AddItem("Zenith color");

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -2151,7 +2151,7 @@ namespace wi::gui
 		scrollable_area.active_area.pos.y = float(scrollable_area.scissorRect.top);
 		scrollable_area.active_area.siz.x = float(scrollable_area.scissorRect.right) - float(scrollable_area.scissorRect.left);
 		scrollable_area.active_area.siz.y = float(scrollable_area.scissorRect.bottom) - float(scrollable_area.scissorRect.top);
-		if (pointerHitbox.intersects(hitBox))
+		if (GetState() == FOCUS)
 		{
 			// This is outside scrollbar code, because it can also be scrolled if parent widget is only in focus
 			scrollbar_vertical.Scroll(wi::input::GetPointer().z * 20);
@@ -3235,7 +3235,7 @@ namespace wi::gui
 			scrollbar.SetListLength(scroll_length);
 
 
-			if (state == FOCUS)
+			if (GetState() == FOCUS)
 			{
 				// This is outside scrollbar code, because it can also be scrolled if parent widget is only in focus
 				scrollbar.Scroll(wi::input::GetPointer().z * 10);

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -1947,6 +1947,8 @@ namespace wi::gui
 			scrollbar_vertical.sprites_knob[ScrollBar::SCROLLBAR_GRABBED].params.color = wi::Color::White();
 			scrollbar_vertical.knob_inset_border = XMFLOAT2(4, 2);
 			AddWidget(&scrollbar_vertical);
+
+			scrollable_area.AttachTo(this);
 		}
 		else
 		{
@@ -2096,10 +2098,12 @@ namespace wi::gui
 		}
 		scrollbar_horizontal.SetListLength(scroll_length_horizontal);
 		scrollbar_vertical.SetListLength(scroll_length_vertical);
+		scrollable_area.Detach();
 		scrollable_area.ClearTransform();
 		scrollable_area.Translate(translation);
 		scrollable_area.Translate(XMFLOAT3(scrollbar_horizontal.GetOffset(), windowcontrolSize + scrollbar_vertical.GetOffset(), 0));
 		scrollable_area.Update(canvas, dt);
+		scrollable_area.AttachTo(this);
 		scrollable_area.scissorRect = scissorRect;
 		scrollable_area.scissorRect.top += (int32_t)windowcontrolSize;
 		if (scrollbar_horizontal.IsScrollbarRequired())

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -3091,7 +3091,12 @@ namespace wi::gui
 	}
 	Hitbox2D TreeList::GetHitbox_ListArea() const
 	{
-		return Hitbox2D(XMFLOAT2(translation.x, translation.y + item_height() + 1), XMFLOAT2(scale.x - scrollbar.scale.x - 1, scale.y - item_height() - 1));
+		Hitbox2D retval = Hitbox2D(XMFLOAT2(translation.x, translation.y + item_height() + 1), XMFLOAT2(scale.x, scale.y - item_height() - 1));
+		if (scrollbar.IsScrollbarRequired())
+		{
+			retval.siz.x -= scrollbar.scale.x + 1;
+		}
+		return retval;
 	}
 	Hitbox2D TreeList::GetHitbox_Item(int visible_count, int level) const
 	{

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -1743,7 +1743,6 @@ namespace wi::gui
 			float scrollbar_begin;
 			float scrollbar_end;
 			float scrollbar_size;
-			float scrollbar_granularity;
 
 			if (vertical)
 			{
@@ -1767,7 +1766,7 @@ namespace wi::gui
 				scrollbar_state = SCROLLBAR_INACTIVE;
 			}
 
-			if (hitbox.intersects(pointerHitbox))
+			if (IsScrollbarRequired() && hitbox.intersects(pointerHitbox))
 			{
 				if (clicked)
 				{
@@ -1837,6 +1836,9 @@ namespace wi::gui
 		{
 			return;
 		}
+		if (!IsScrollbarRequired())
+			return;
+
 		// scrollbar background
 		wi::image::Params fx = sprites[state].params;
 		fx.pos = XMFLOAT3(translation.x, translation.y, 0);
@@ -2100,8 +2102,14 @@ namespace wi::gui
 		scrollable_area.Update(canvas, dt);
 		scrollable_area.scissorRect = scissorRect;
 		scrollable_area.scissorRect.top += (int32_t)windowcontrolSize;
-		scrollable_area.scissorRect.right -= (int32_t)windowcontrolSize;
-		scrollable_area.scissorRect.bottom -= (int32_t)windowcontrolSize;
+		if (scrollbar_horizontal.IsScrollbarRequired())
+		{
+			scrollable_area.scissorRect.bottom -= (int32_t)windowcontrolSize;
+		}
+		if (scrollbar_vertical.IsScrollbarRequired())
+		{
+			scrollable_area.scissorRect.right -= (int32_t)windowcontrolSize;
+		}
 		if (pointerHitbox.intersects(hitBox))
 		{
 			// This is outside scrollbar code, because it can also be scrolled if parent widget is only in focus

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -514,7 +514,7 @@ namespace wi::gui
 	{
 		XMFLOAT4 pointer = wi::input::GetPointer();
 		Hitbox2D hb = Hitbox2D(XMFLOAT2(pointer.x, pointer.y), XMFLOAT2(1, 1));
-		HitboxConstrain(hb);
+		HitboxConstrain(hb); // this is used to filter out pointer outside of active_area (outside of scissor basically)
 		return hb;
 	}
 	void Widget::HitboxConstrain(wi::primitive::Hitbox2D& hb) const
@@ -2173,10 +2173,10 @@ namespace wi::gui
 				widget->priority = ~0u;
 			}
 
-			if (widget->IsVisible() && widget->hitBox.intersects(pointerHitbox))
-			{
-				focus = true;
-			}
+			//if (widget->IsVisible() && widget->hitBox.intersects(pointerHitbox))
+			//{
+			//	focus = true;
+			//}
 			if (widget->GetState() > IDLE)
 			{
 				focus = true;

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -2156,13 +2156,7 @@ namespace wi::gui
 		bool focus = false;
 		for (auto& widget : widgets)
 		{
-			// These were already updated beforehand:
-			if (widget == &moveDragger)
-				continue;
-			if (widget == &resizeDragger_UpperLeft)
-				continue;
-			if (widget == &resizeDragger_BottomRight)
-				continue;
+			// Don't update these again:
 			if (widget == &scrollbar_horizontal)
 				continue;
 			if (widget == &scrollbar_vertical)
@@ -2194,7 +2188,7 @@ namespace wi::gui
 			return a->priority < b->priority;
 				});
 
-		if (GetState() == FOCUS && !focus) // when window is in focus, but other widgets aren't
+		if (pointerHitbox.intersects(hitBox) && !force_disable && !focus) // when window is in focus, but other widgets aren't
 		{
 			// This is outside scrollbar code, because it can also be scrolled if parent widget is only in focus
 			scrollbar_vertical.Scroll(wi::input::GetPointer().z * 20);

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -1938,7 +1938,7 @@ namespace wi::gui
 			scrollbar_horizontal.sprites_knob[ScrollBar::SCROLLBAR_INACTIVE].params.color = wi::Color(140, 140, 140, 140);
 			scrollbar_horizontal.sprites_knob[ScrollBar::SCROLLBAR_HOVER].params.color = wi::Color(180, 180, 180, 180);
 			scrollbar_horizontal.sprites_knob[ScrollBar::SCROLLBAR_GRABBED].params.color = wi::Color::White();
-			scrollbar_horizontal.knob_inset_border = XMFLOAT2(4, 2);
+			scrollbar_horizontal.knob_inset_border = XMFLOAT2(2, 4);
 			AddWidget(&scrollbar_horizontal);
 
 			scrollbar_vertical.SetColor(wi::Color(80, 80, 80, 100), wi::gui::IDLE);

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -1997,10 +1997,14 @@ namespace wi::gui
 		moveDragger.force_disable = force_disable;
 		resizeDragger_UpperLeft.force_disable = force_disable;
 		resizeDragger_BottomRight.force_disable = force_disable;
+		scrollbar_horizontal.force_disable = force_disable;
+		scrollbar_vertical.force_disable = force_disable;
 
 		moveDragger.Update(canvas, dt);
 		resizeDragger_UpperLeft.Update(canvas, dt);
 		resizeDragger_BottomRight.Update(canvas, dt);
+		scrollbar_horizontal.Update(canvas, dt);
+		scrollbar_vertical.Update(canvas, dt);
 
 		// Don't allow moving outside of screen:
 		if (parent == nullptr)

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -1773,6 +1773,14 @@ namespace wi::gui
 
 			list_offset = -scrollbar_value * (list_length - scrollbar_size * (1.0f - overscroll));
 		}
+
+		for (int i = 0; i < arraysize(sprites_knob); ++i)
+		{
+			sprites_knob[i].params.pos.x = translation.x + knob_inset_border;
+			sprites_knob[i].params.pos.y = translation.y + knob_inset_border + scrollbar_delta;
+			sprites_knob[i].params.siz.x = scale.x - knob_inset_border * 2;
+			sprites_knob[i].params.siz.y = scrollbar_length - knob_inset_border * 2;
+		}
 	}
 	void ScrollBar::Render(const wi::Canvas& canvas, CommandList cmd) const
 	{
@@ -1787,22 +1795,8 @@ namespace wi::gui
 		fx.color = sprites[IDLE].params.color;
 		wi::image::Draw(wi::texturehelper::getWhite(), fx, cmd);
 
-		// scrollbar
-		wi::Color scrollbar_color = wi::Color::fromFloat4(sprites[IDLE].params.color);
-		if (scrollbar_state == SCROLLBAR_HOVER)
-		{
-			scrollbar_color = wi::Color::fromFloat4(sprites[FOCUS].params.color);
-		}
-		else if (scrollbar_state == SCROLLBAR_GRABBED)
-		{
-			scrollbar_color = wi::Color::White();
-		}
-		wi::image::Draw(wi::texturehelper::getWhite()
-			, wi::image::Params(translation.x, translation.y + scrollbar_delta, scale.x, scrollbar_length, scrollbar_color), cmd);
-
-
-		//wi::image::Draw(wi::texturehelper::getWhite()
-		//	, wi::image::Params(translation.x, translation.y, scale.x, scale.y, wi::Color::Red()), cmd);
+		// scrollbar knob
+		sprites_knob[scrollbar_state].Draw(cmd);
 
 	}
 
@@ -1889,6 +1883,11 @@ namespace wi::gui
 			minimizeButton.SetTooltip("Minimize window");
 			AddWidget(&minimizeButton);
 
+			scrollbar.SetColor(wi::Color(80, 80, 80, 100), wi::gui::IDLE);
+			scrollbar.sprites_knob[ScrollBar::SCROLLBAR_INACTIVE].params.color = wi::Color(140, 140, 140, 140);
+			scrollbar.sprites_knob[ScrollBar::SCROLLBAR_HOVER].params.color = wi::Color(180, 180, 180, 180);
+			scrollbar.sprites_knob[ScrollBar::SCROLLBAR_GRABBED].params.color = wi::Color::White();
+			scrollbar.knob_inset_border = 4;
 			AddWidget(&scrollbar);
 		}
 		else
@@ -2993,7 +2992,6 @@ namespace wi::gui
 		OnSelect([](EventArgs args) {});
 
 		SetColor(wi::Color(100, 100, 100, 100), wi::gui::IDLE);
-		scrollbar.SetColor(wi::Color(100, 100, 100, 100), wi::gui::IDLE);
 		for (int i = FOCUS + 1; i < WIDGETSTATE_COUNT; ++i)
 		{
 			sprites[i].params.color = sprites[FOCUS].params.color;
@@ -3001,6 +2999,10 @@ namespace wi::gui
 		}
 		font.params.v_align = wi::font::WIFALIGN_CENTER;
 
+		scrollbar.SetColor(wi::Color(80, 80, 80, 100), wi::gui::IDLE);
+		scrollbar.sprites_knob[ScrollBar::SCROLLBAR_INACTIVE].params.color = wi::Color(140, 140, 140, 140);
+		scrollbar.sprites_knob[ScrollBar::SCROLLBAR_HOVER].params.color = wi::Color(180, 180, 180, 180);
+		scrollbar.sprites_knob[ScrollBar::SCROLLBAR_GRABBED].params.color = wi::Color::White();
 		scrollbar.SetOverScroll(0.25f);
 	}
 	float TreeList::GetItemOffset(int index) const

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -519,30 +519,31 @@ namespace wi::gui
 	}
 	void Widget::HitboxConstrain(wi::primitive::Hitbox2D& hb) const
 	{
+		Hitbox2D area = active_area;
+
+		float left = hb.pos.x;
+		float right = hb.pos.x + hb.siz.x;
+		float top = hb.pos.y;
+		float bottom = hb.pos.y + hb.siz.y;
+
+		float area_left = area.pos.x;
+		float area_right = area.pos.x + area.siz.x;
+		float area_top = area.pos.y;
+		float area_bottom = area.pos.y + area.siz.y;
+
+		bottom = std::min(bottom, area_bottom);
+		top = std::max(top, area_top);
+		left = std::max(left, area_left);
+		right = std::min(right, area_right);
+
+		hb.pos.x = left;
+		hb.pos.y = top;
+		hb.siz.x = std::max(0.0f, right - left);
+		hb.siz.y = std::max(0.0f, bottom - top);
+
 		if (parent != nullptr)
 		{
-			Hitbox2D area = active_area;
-			parent->HitboxConstrain(area);
-
-			float left = hb.pos.x;
-			float right = hb.pos.x + hb.siz.x;
-			float top = hb.pos.y;
-			float bottom = hb.pos.y + hb.siz.y;
-
-			float area_left = area.pos.x;
-			float area_right = area.pos.x + area.siz.x;
-			float area_top = area.pos.y;
-			float area_bottom = area.pos.y + area.siz.y;
-
-			bottom = std::min(bottom, area_bottom);
-			top = std::max(top, area_top);
-			left = std::max(left, area_left);
-			right = std::min(right, area_right);
-
-			hb.pos.x = left;
-			hb.pos.y = top;
-			hb.siz.x = right - left;
-			hb.siz.y = bottom - top;
+			parent->HitboxConstrain(hb);
 		}
 	}
 
@@ -2292,9 +2293,9 @@ namespace wi::gui
 		//scissorRect.top = (int32_t)(0);
 		//GraphicsDevice* device = wi::graphics::GetDevice();
 		//device->BindScissorRects(1, &scissorRect, cmd);
-		//wi::image::Draw(wi::texturehelper::getWhite(), wi::image::Params(scrollable_area.active_area.pos.x, scrollable_area.active_area.pos.y, scrollable_area.active_area.siz.x, scrollable_area.active_area.siz.y, wi::Color::Red()), cmd);
+		//wi::image::Draw(wi::texturehelper::getWhite(), wi::image::Params(scrollable_area.active_area.pos.x, scrollable_area.active_area.pos.y, scrollable_area.active_area.siz.x, scrollable_area.active_area.siz.y, wi::Color(255,0,255,100)), cmd);
 		//Hitbox2D p = scrollable_area.GetPointerHitbox();
-		//wi::image::Draw(wi::texturehelper::getWhite(), wi::image::Params(p.pos.x, p.pos.y, p.siz.x * 10, p.siz.y * 10, wi::Color::Red()), cmd);
+		//wi::image::Draw(wi::texturehelper::getWhite(), wi::image::Params(p.pos.x, p.pos.y, p.siz.x * 10, p.siz.y * 10, wi::Color(255,0,0,100)), cmd);
 	}
 	void Window::RenderTooltip(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const
 	{

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -519,17 +519,15 @@ namespace wi::gui
 	}
 	void Widget::HitboxConstrain(wi::primitive::Hitbox2D& hb) const
 	{
-		Hitbox2D area = active_area;
-
 		float left = hb.pos.x;
 		float right = hb.pos.x + hb.siz.x;
 		float top = hb.pos.y;
 		float bottom = hb.pos.y + hb.siz.y;
 
-		float area_left = area.pos.x;
-		float area_right = area.pos.x + area.siz.x;
-		float area_top = area.pos.y;
-		float area_bottom = area.pos.y + area.siz.y;
+		float area_left = active_area.pos.x;
+		float area_right = active_area.pos.x + active_area.siz.x;
+		float area_top = active_area.pos.y;
+		float area_bottom = active_area.pos.y + active_area.siz.y;
 
 		bottom = std::min(bottom, area_bottom);
 		top = std::max(top, area_top);

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -1772,6 +1772,10 @@ namespace wi::gui
 				if (clicked)
 				{
 					scrollbar_state = SCROLLBAR_GRABBED;
+					grab_pos = pointerHitbox.pos;
+					grab_pos.x = wi::math::Clamp(grab_pos.x, scrollbar_begin + scrollbar_delta, scrollbar_begin + scrollbar_delta + scrollbar_length);
+					grab_pos.y = wi::math::Clamp(grab_pos.y, scrollbar_begin + scrollbar_delta, scrollbar_begin + scrollbar_delta + scrollbar_length);
+					grab_delta = scrollbar_delta;
 				}
 				else if (!click_down)
 				{
@@ -1785,11 +1789,11 @@ namespace wi::gui
 				Activate();
 				if (vertical)
 				{
-					scrollbar_delta = pointerHitbox.pos.y - scrollbar_length * 0.5f - scrollbar_begin;
+					scrollbar_delta = grab_delta + pointerHitbox.pos.y - grab_pos.y;
 				}
 				else
 				{
-					scrollbar_delta = pointerHitbox.pos.x - scrollbar_length * 0.5f - scrollbar_begin;
+					scrollbar_delta = grab_delta + pointerHitbox.pos.x - grab_pos.x;
 				}
 			}
 

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -1776,10 +1776,10 @@ namespace wi::gui
 
 		for (int i = 0; i < arraysize(sprites_knob); ++i)
 		{
-			sprites_knob[i].params.pos.x = translation.x + knob_inset_border;
-			sprites_knob[i].params.pos.y = translation.y + knob_inset_border + scrollbar_delta;
-			sprites_knob[i].params.siz.x = scale.x - knob_inset_border * 2;
-			sprites_knob[i].params.siz.y = scrollbar_length - knob_inset_border * 2;
+			sprites_knob[i].params.pos.x = translation.x + knob_inset_border.x;
+			sprites_knob[i].params.pos.y = translation.y + knob_inset_border.y + scrollbar_delta;
+			sprites_knob[i].params.siz.x = scale.x - knob_inset_border.x * 2;
+			sprites_knob[i].params.siz.y = scrollbar_length - knob_inset_border.y * 2;
 		}
 	}
 	void ScrollBar::Render(const wi::Canvas& canvas, CommandList cmd) const
@@ -1887,7 +1887,7 @@ namespace wi::gui
 			scrollbar.sprites_knob[ScrollBar::SCROLLBAR_INACTIVE].params.color = wi::Color(140, 140, 140, 140);
 			scrollbar.sprites_knob[ScrollBar::SCROLLBAR_HOVER].params.color = wi::Color(180, 180, 180, 180);
 			scrollbar.sprites_knob[ScrollBar::SCROLLBAR_GRABBED].params.color = wi::Color::White();
-			scrollbar.knob_inset_border = 4;
+			scrollbar.knob_inset_border = XMFLOAT2(4, 2);
 			AddWidget(&scrollbar);
 		}
 		else

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -1947,8 +1947,6 @@ namespace wi::gui
 			scrollbar_vertical.sprites_knob[ScrollBar::SCROLLBAR_GRABBED].params.color = wi::Color::White();
 			scrollbar_vertical.knob_inset_border = XMFLOAT2(4, 2);
 			AddWidget(&scrollbar_vertical);
-
-			scrollable_area.AttachTo(this);
 		}
 		else
 		{

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -298,14 +298,6 @@ namespace wi::gui
 	class ScrollBar : public Widget
 	{
 	protected:
-		enum SCROLLBAR_STATE
-		{
-			SCROLLBAR_INACTIVE,
-			SCROLLBAR_HOVER,
-			SCROLLBAR_GRABBED,
-			TREESTATE_COUNT,
-		} scrollbar_state = SCROLLBAR_INACTIVE;
-
 		float scrollbar_delta = 0;
 		float scrollbar_length = 0;
 		float scrollbar_value = 0;
@@ -322,6 +314,16 @@ namespace wi::gui
 		void Scroll(float amount) { scrollbar_delta -= amount; }
 		// How much the max scrolling will offset the list even further than it would be necessary for fitting
 		void SetOverScroll(float amount) { overscroll = amount; }
+
+		enum SCROLLBAR_STATE
+		{
+			SCROLLBAR_INACTIVE,
+			SCROLLBAR_HOVER,
+			SCROLLBAR_GRABBED,
+			SCROLLBAR_STATE_COUNT,
+		} scrollbar_state = SCROLLBAR_INACTIVE;
+		wi::Sprite sprites_knob[SCROLLBAR_STATE_COUNT];
+		float knob_inset_border = 0;
 
 		void Update(const wi::Canvas& canvas, float dt) override;
 		void Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const override;

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -316,6 +316,9 @@ namespace wi::gui
 		// This can be called by user for extra scrolling on top of base functionality
 		void Scroll(float amount) { scrollbar_delta -= amount; }
 		// How much the max scrolling will offset the list even further than it would be necessary for fitting
+		//	this value is in percent of a full scrollbar's worth of extra offset
+		//	0: no extra offset
+		//	1: full extra offset
 		void SetOverScroll(float amount) { overscroll = amount; }
 
 		enum SCROLLBAR_STATE

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -323,7 +323,7 @@ namespace wi::gui
 			SCROLLBAR_STATE_COUNT,
 		} scrollbar_state = SCROLLBAR_INACTIVE;
 		wi::Sprite sprites_knob[SCROLLBAR_STATE_COUNT];
-		float knob_inset_border = 0;
+		XMFLOAT2 knob_inset_border = {};
 
 		void Update(const wi::Canvas& canvas, float dt) override;
 		void Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const override;

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -301,6 +301,7 @@ namespace wi::gui
 		float scrollbar_delta = 0;
 		float scrollbar_length = 0;
 		float scrollbar_value = 0;
+		float scrollbar_granularity = 1;
 		float list_length = 0;
 		float list_offset = 0;
 		float overscroll = 0;
@@ -320,6 +321,8 @@ namespace wi::gui
 		//	0: no extra offset
 		//	1: full extra offset
 		void SetOverScroll(float amount) { overscroll = amount; }
+		// Check whether the scrollbar is required (when the items don't and scrolling could be used)
+		bool IsScrollbarRequired() const { return scrollbar_granularity < 1; }
 
 		enum SCROLLBAR_STATE
 		{

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -100,7 +100,7 @@ namespace wi::gui
 		void SetImage(wi::Resource textureResource, WIDGETSTATE state = WIDGETSTATE_COUNT);
 
 		virtual void Update(const wi::Canvas& canvas, float dt);
-		virtual void Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const = 0;
+		virtual void Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const {}
 		virtual void RenderTooltip(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const;
 
 		wi::Sprite sprites[WIDGETSTATE_COUNT];
@@ -294,6 +294,28 @@ namespace wi::gui
 		void OnSelect(std::function<void(EventArgs args)> func);
 	};
 
+	// Generic scroll bar
+	class ScrollBar : public Widget
+	{
+	public:
+		enum SCROLLBAR_STATE
+		{
+			SCROLLBAR_INACTIVE,
+			SCROLLBAR_HOVER,
+			SCROLLBAR_GRABBED,
+			TREESTATE_COUNT,
+		} scrollbar_state = SCROLLBAR_INACTIVE;
+
+		float scrollbar_delta = 0;
+		float scrollbar_height = 0;
+		float scrollbar_value = 0;
+		float list_height = 0;
+		float list_offset = 0;
+
+		void Update(const wi::Canvas& canvas, float dt) override;
+		void Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const override;
+	};
+
 	// Widget container
 	class Window :public Widget
 	{
@@ -304,12 +326,14 @@ namespace wi::gui
 		Button resizeDragger_BottomRight;
 		Button moveDragger;
 		Label label;
+		ScrollBar scrollbar;
 		wi::vector<Widget*> widgets;
 		bool minimized = false;
+		Widget scrollable_area;
 	public:
 		void Create(const std::string& name, bool window_controls = true);
 
-		void AddWidget(Widget* widget);
+		void AddWidget(Widget* widget, bool scrollable = true);
 		void RemoveWidget(Widget* widget);
 		void RemoveWidgets();
 
@@ -373,22 +397,10 @@ namespace wi::gui
 		};
 	protected:
 		std::function<void(EventArgs args)> onSelect;
-		float list_height = 0;
-		float list_offset = 0;
 		int item_highlight = -1;
 		int opener_highlight = -1;
 
-		enum SCROLLBAR_STATE
-		{
-			SCROLLBAR_INACTIVE,
-			SCROLLBAR_HOVER,
-			SCROLLBAR_GRABBED,
-			TREESTATE_COUNT,
-		} scrollbar_state = SCROLLBAR_INACTIVE;
-
-		float scrollbar_delta = 0;
-		float scrollbar_height = 0;
-		float scrollbar_value = 0;
+		ScrollBar scrollbar;
 
 		wi::primitive::Hitbox2D GetHitbox_ListArea() const;
 		wi::primitive::Hitbox2D GetHitbox_Item(int visible_count, int level) const;

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -297,7 +297,7 @@ namespace wi::gui
 	// Generic scroll bar
 	class ScrollBar : public Widget
 	{
-	public:
+	protected:
 		enum SCROLLBAR_STATE
 		{
 			SCROLLBAR_INACTIVE,
@@ -307,10 +307,21 @@ namespace wi::gui
 		} scrollbar_state = SCROLLBAR_INACTIVE;
 
 		float scrollbar_delta = 0;
-		float scrollbar_height = 0;
+		float scrollbar_length = 0;
 		float scrollbar_value = 0;
-		float list_height = 0;
+		float list_length = 0;
 		float list_offset = 0;
+		float overscroll = 0;
+
+	public:
+		// Set the list's length that will be scrollable and moving
+		void SetListLength(float size) { list_length = size; }
+		// The scrolling offset that should be applied to the list items
+		float GetOffset() const { return list_offset; }
+		// This can be called by user for extra scrolling on top of base functionality
+		void Scroll(float amount) { scrollbar_delta -= amount; }
+		// How much the max scrolling will offset the list even further than it would be necessary for fitting
+		void SetOverScroll(float amount) { overscroll = amount; }
 
 		void Update(const wi::Canvas& canvas, float dt) override;
 		void Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const override;

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -305,6 +305,8 @@ namespace wi::gui
 		float list_offset = 0;
 		float overscroll = 0;
 		bool vertical = true;
+		XMFLOAT2 grab_pos = {};
+		float grab_delta = 0;
 
 	public:
 		// Set the list's length that will be scrollable and moving

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -122,6 +122,9 @@ namespace wi::gui
 		void ApplyScissor(const wi::Canvas& canvas, const wi::graphics::Rect rect, wi::graphics::CommandList cmd, bool constrain_to_parent = true) const;
 		wi::primitive::Hitbox2D GetPointerHitbox() const;
 
+		wi::primitive::Hitbox2D active_area; // Pointer hitbox constrain area
+		void HitboxConstrain(wi::primitive::Hitbox2D& hb) const;
+
 		bool priority_change = true;
 		uint32_t priority = 0;
 		bool force_disable = false;

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -304,6 +304,7 @@ namespace wi::gui
 		float list_length = 0;
 		float list_offset = 0;
 		float overscroll = 0;
+		bool vertical = true;
 
 	public:
 		// Set the list's length that will be scrollable and moving
@@ -339,7 +340,8 @@ namespace wi::gui
 		Button resizeDragger_BottomRight;
 		Button moveDragger;
 		Label label;
-		ScrollBar scrollbar;
+		ScrollBar scrollbar_vertical;
+		ScrollBar scrollbar_horizontal;
 		wi::vector<Widget*> widgets;
 		bool minimized = false;
 		Widget scrollable_area;

--- a/WickedEngine/wiMath.h
+++ b/WickedEngine/wiMath.h
@@ -154,9 +154,31 @@ namespace wi::math
 	}
 	constexpr float Clamp(float val, float min, float max)
 	{
-		if (val < min) return min;
-		else if (val > max) return max;
-		return val;
+		return std::min(max, std::max(min, val));
+	}
+	constexpr XMFLOAT2 Clamp(XMFLOAT2 val, XMFLOAT2 min, XMFLOAT2 max)
+	{
+		XMFLOAT2 retval = val;
+		retval.x = Clamp(retval.x, min.x, max.x);
+		retval.y = Clamp(retval.y, min.y, max.y);
+		return retval;
+	}
+	constexpr XMFLOAT3 Clamp(XMFLOAT3 val, XMFLOAT3 min, XMFLOAT3 max)
+	{
+		XMFLOAT3 retval = val;
+		retval.x = Clamp(retval.x, min.x, max.x);
+		retval.y = Clamp(retval.y, min.y, max.y);
+		retval.z = Clamp(retval.z, min.z, max.z);
+		return retval;
+	}
+	constexpr XMFLOAT4 Clamp(XMFLOAT4 val, XMFLOAT4 min, XMFLOAT4 max)
+	{
+		XMFLOAT4 retval = val;
+		retval.x = Clamp(retval.x, min.x, max.x);
+		retval.y = Clamp(retval.y, min.y, max.y);
+		retval.z = Clamp(retval.z, min.z, max.z);
+		retval.w = Clamp(retval.w, min.w, max.w);
+		return retval;
 	}
 	constexpr float SmoothStep(float value1, float value2, float amount)
 	{
@@ -165,6 +187,9 @@ namespace wi::math
 	}
 	constexpr bool Collision2D(const XMFLOAT2& hitBox1Pos, const XMFLOAT2& hitBox1Siz, const XMFLOAT2& hitBox2Pos, const XMFLOAT2& hitBox2Siz)
 	{
+		if (hitBox1Siz.x <= 0 || hitBox1Siz.y <= 0 || hitBox2Siz.x <= 0 || hitBox2Siz.y <= 0)
+			return false;
+
 		if (hitBox1Pos.x + hitBox1Siz.x < hitBox2Pos.x)
 			return false;
 		else if (hitBox1Pos.x > hitBox2Pos.x + hitBox2Siz.x)

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -1577,7 +1577,6 @@ namespace wi::scene
 		}
 
 		wi::jobsystem::context ctx;
-		wi::physics::RunPhysicsUpdateSystem(ctx, *this, dt);
 
 		// Scan mesh subset counts to allocate GPU geometry data:
 		geometryAllocator.store(0u);
@@ -1590,6 +1589,8 @@ namespace wi::scene
 			// Must not keep inactive TLAS instances, so zero them out for safety:
 			std::memset(TLAS_instancesMapped, 0, TLAS_instancesUpload->desc.size);
 		});
+
+		wi::physics::RunPhysicsUpdateSystem(ctx, *this, dt);
 
 		RunAnimationUpdateSystem(ctx);
 

--- a/WickedEngine/wiVersion.cpp
+++ b/WickedEngine/wiVersion.cpp
@@ -9,7 +9,7 @@ namespace wi::version
 	// minor features, major updates, breaking compatibility changes
 	const int minor = 60;
 	// minor bug fixes, alterations, refactors, updates
-	const int revision = 69;
+	const int revision = 70;
 
 	const std::string version_string = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(revision);
 


### PR DESCRIPTION
The gui windows support scrollbars. #51 
- Vertical scrollbar was brought to the window from the tree list.
- It is a float mode scrollbar, not like the combo box (which is per item)
- Window scaling will not scale scroll area elements, they will retain correct aspect ratio

TODO:
- refactors, make scrollbar integration easier
- maybe horizontal scrollbar too
- maybe make scrollbar only appear on windows when not enough space to display all elements