### PR TITLE
Engine optionally compiled as a dynamic library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,14 @@
 cmake_minimum_required(VERSION 3.8)
 
+
+option(WICKED_DYNAMIC_LIBRARY "Build WickedEngine as a dynamic library" OFF)
+
+option(WICKED_EDITOR "Build WickedEngine editor" ON)
+option(WICKED_TESTS "Build WickedEngine tests" ON)
+option(WICKED_IMGUI_EXAMPLE "Build WickedEngine imgui example" ON)
+option(WICKED_LINUX_TEMPLATE "Build WickedEngine Linux template" ON)
+
+
 # Configure CMake global variables
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -23,23 +32,19 @@ endif()
 
 add_subdirectory(WickedEngine)
 
-option(WICKED_EDITOR "Build WickedEngine editor" ON)
 if (WICKED_EDITOR)
     add_subdirectory(Editor)
 endif()
 
-option(WICKED_TESTS "Build WickedEngine tests" ON)
 if (WICKED_TESTS)
     add_subdirectory(Tests)
 endif()
 
-option(WICKED_IMGUI_EXAMPLE "Build WickedEngine imgui example" ON)
 if (WICKED_TESTS)
     add_subdirectory(Example_ImGui)
     add_subdirectory(Example_ImGui_Docking)
 endif()
 
-option(WICKED_LINUX_TEMPLATE "Build WickedEngine Linux template" ON)
 if (WICKED_LINUX_TEMPLATE)
     add_subdirectory(Template_Linux)
 endif()

--- a/WickedEngine/BULLET/CMakeLists.txt
+++ b/WickedEngine/BULLET/CMakeLists.txt
@@ -453,7 +453,11 @@ add_library(Bullet STATIC
 )
 
 target_include_directories(Bullet PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-        $<INSTALL_INTERFACE:include/WickedEngine/BULLET>
-        )
-set_property(TARGET "Bullet" PROPERTY FOLDER "ThirdParty")
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<INSTALL_INTERFACE:include/WickedEngine/BULLET>
+)
+
+set_target_properties(Bullet PROPERTIES
+	FOLDER "ThirdParty"
+	POSITION_INDEPENDENT_CODE ${WICKED_DYNAMIC_LIBRARY}
+)

--- a/WickedEngine/CMakeLists.txt
+++ b/WickedEngine/CMakeLists.txt
@@ -4,6 +4,14 @@ include(GNUInstallDirs)
 set(INSTALL_LOCAL_CONFIGDIR "${CMAKE_BINARY_DIR}/cmake")
 set(INSTALL_CONFIGDIR "${CMAKE_INSTALL_LIBDIR}/cmake/WickedEngine")
 
+if (WICKED_DYNAMIC_LIBRARY)
+	set(WICKED_LIBRARY_TYPE SHARED)
+	message(STATUS "Building WickedEngine as a shared library")
+else()
+	set(WICKED_LIBRARY_TYPE STATIC)
+	message(STATUS "Building WickedEngine as a static library")
+endif()
+
 if (WIN32)
 	# TODO: Choose whether to use SDL2 on windows as well
 	set(TARGET_NAME WickedEngine_Windows)
@@ -130,7 +138,7 @@ set(HEADER_FILES
 		wiXInput.h
 		)
 
-add_library(${TARGET_NAME} STATIC
+add_library(${TARGET_NAME} ${WICKED_LIBRARY_TYPE}
 	wiLoadingScreen.cpp
 	wiLoadingScreen_BindLua.cpp
 	wiApplication.cpp

--- a/WickedEngine/LUA/CMakeLists.txt
+++ b/WickedEngine/LUA/CMakeLists.txt
@@ -69,7 +69,10 @@ if (UNIX)
     target_compile_definitions(LUA PUBLIC LUA_USE_POSIX=1)
 endif()
 
-set_property(TARGET "LUA" PROPERTY FOLDER "ThirdParty")
+set_target_properties(LUA PROPERTIES
+	FOLDER "ThirdParty"
+	POSITION_INDEPENDENT_CODE ${WICKED_DYNAMIC_LIBRARY}
+)
 
 install(FILES ${LUA_HEADERS}
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/WickedEngine/LUA/")

--- a/WickedEngine/Utility/CMakeLists.txt
+++ b/WickedEngine/Utility/CMakeLists.txt
@@ -169,4 +169,7 @@ add_library(Utility STATIC
 		${HEADER_FILES_zstd}
 		)
 
-set_property(TARGET "Utility" PROPERTY FOLDER "ThirdParty")
+set_target_properties("Utility" PROPERTIES
+	FOLDER "ThirdParty"
+	POSITION_INDEPENDENT_CODE ${WICKED_DYNAMIC_LIBRARY}
+)

--- a/WickedEngine/Utility/FAudio/CMakeLists.txt
+++ b/WickedEngine/Utility/FAudio/CMakeLists.txt
@@ -46,7 +46,7 @@ set(PUBLIC_HEADERS
 	)
 
 # Source lists
-add_library(FAudio
+add_library(FAudio STATIC
 	# Public Headers
 	${PUBLIC_HEADERS}
 	# Internal Headers
@@ -90,9 +90,11 @@ target_include_directories(FAudio PUBLIC
 )
 
 # Soname
-set_target_properties(FAudio PROPERTIES OUTPUT_NAME "FAudio"
+set_target_properties(FAudio PROPERTIES
+	OUTPUT_NAME "FAudio"
 	VERSION ${LIB_VERSION}
 	SOVERSION ${LIB_MAJOR_VERSION}
+	POSITION_INDEPENDENT_CODE ${WICKED_DYNAMIC_LIBRARY}
 )
 
 # SDL2 Dependency


### PR DESCRIPTION
use `-DWICKED_DYNAMIC_LIBRARY=ON` to compile as a dynamic library
disabled by default