### PR TITLE
Compiler warnings fixes (part 2)

### DIFF
--- a/WickedEngine/CMakeLists.txt
+++ b/WickedEngine/CMakeLists.txt
@@ -249,6 +249,8 @@ else ()
 			-Wwrite-strings
 			-Winit-self
 			-Wreturn-type
+			-Wreorder
+			-Werror=delete-non-virtual-dtor
 			-Werror)
 
 	target_link_libraries(${TARGET_NAME} PRIVATE dl)

--- a/WickedEngine/wiArchive.cpp
+++ b/WickedEngine/wiArchive.cpp
@@ -15,7 +15,8 @@ namespace wi
 	{
 		CreateEmpty();
 	}
-	Archive::Archive(const std::string& fileName, bool readMode) : fileName(fileName), readMode(readMode)
+	Archive::Archive(const std::string& fileName, bool readMode)
+		: readMode(readMode), fileName(fileName)
 	{
 		if (!fileName.empty())
 		{

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -2388,16 +2388,11 @@ namespace wi::gui
 	}
 	void ComboBox::RemoveItem(int index)
 	{
-		wi::vector<Item> newItems(0);
-		newItems.reserve(items.size());
-		for (size_t i = 0; i < items.size(); ++i)
-		{
-			if (i != index)
-			{
-				newItems.push_back(items[i]);
-			}
+		if (index < 0 || (size_t)index >= items.size()) {
+			return;
 		}
-		items = newItems;
+
+		items.erase(items.begin() + index);
 
 		if (items.empty())
 		{

--- a/WickedEngine/wiGraphics.h
+++ b/WickedEngine/wiGraphics.h
@@ -1042,9 +1042,10 @@ namespace wi::graphics
 		case Format::R32G8X24_TYPELESS:
 		case Format::R24G8_TYPELESS:
 			return true;
+		default:
+			return false;
 		}
 
-		return false;
 	}
 	constexpr bool IsFormatUnorm(Format format)
 	{
@@ -1063,9 +1064,9 @@ namespace wi::graphics
 		case Format::R16_UNORM:
 		case Format::R8_UNORM:
 			return true;
+		default:
+			return false;
 		}
-
-		return false;
 	}
 	constexpr bool IsFormatBlockCompressed(Format format)
 	{
@@ -1086,9 +1087,9 @@ namespace wi::graphics
 		case Format::BC7_UNORM:
 		case Format::BC7_UNORM_SRGB:
 			return true;
+		default:
+			return false;
 		}
-
-		return false;
 	}
 	constexpr bool IsFormatStencilSupport(Format format)
 	{
@@ -1099,9 +1100,9 @@ namespace wi::graphics
 		case Format::R24G8_TYPELESS:
 		case Format::D24_UNORM_S8_UINT:
 			return true;
+		default:
+			return false;
 		}
-
-		return false;
 	}
 	constexpr uint32_t GetFormatBlockSize(Format format)
 	{
@@ -1201,10 +1202,8 @@ namespace wi::graphics
 
 		default:
 			assert(0); // didn't catch format!
-			break;
+			return 16u;
 		}
-
-		return 16u;
 	}
 
 	constexpr uint32_t AlignTo(uint32_t value, uint32_t alignment)

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -376,32 +376,23 @@ namespace vulkan_internal
 		{
 		case wi::graphics::StencilOp::KEEP:
 			return VK_STENCIL_OP_KEEP;
-			break;
 		case wi::graphics::StencilOp::ZERO:
 			return VK_STENCIL_OP_ZERO;
-			break;
 		case wi::graphics::StencilOp::REPLACE:
 			return VK_STENCIL_OP_REPLACE;
-			break;
 		case wi::graphics::StencilOp::INCR_SAT:
 			return VK_STENCIL_OP_INCREMENT_AND_CLAMP;
-			break;
 		case wi::graphics::StencilOp::DECR_SAT:
 			return VK_STENCIL_OP_DECREMENT_AND_CLAMP;
-			break;
 		case wi::graphics::StencilOp::INVERT:
 			return VK_STENCIL_OP_INVERT;
-			break;
 		case wi::graphics::StencilOp::INCR:
 			return VK_STENCIL_OP_INCREMENT_AND_WRAP;
-			break;
 		case wi::graphics::StencilOp::DECR:
 			return VK_STENCIL_OP_DECREMENT_AND_WRAP;
-			break;
 		default:
-			break;
+			return VK_STENCIL_OP_KEEP;
 		}
-		return VK_STENCIL_OP_KEEP;
 	}
 	constexpr VkImageLayout _ConvertImageLayout(ResourceState value)
 	{
@@ -426,8 +417,9 @@ namespace vulkan_internal
 			return VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
 		case ResourceState::SHADING_RATE_SOURCE:
 			return VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR;
+		default:
+			return VK_IMAGE_LAYOUT_UNDEFINED;
 		}
-		return VK_IMAGE_LAYOUT_UNDEFINED;
 	}
 	constexpr VkShaderStageFlags _ConvertStageFlags(ShaderStage value)
 	{
@@ -2004,7 +1996,9 @@ using namespace vulkan_internal;
 					}
 					break;
 
+					default: break;
 					}
+
 				}
 			}
 
@@ -5759,6 +5753,9 @@ using namespace vulkan_internal;
 				view_desc.format = VK_FORMAT_D32_SFLOAT_S8_UINT;
 				view_desc.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
 				break;
+			default:
+				assert(0);
+				break;
 			}
 
 			Texture_Vulkan::TextureSubresource subresource;
@@ -5884,6 +5881,9 @@ using namespace vulkan_internal;
 			case Format::R32G8X24_TYPELESS:
 				view_desc.format = VK_FORMAT_D32_SFLOAT_S8_UINT;
 				view_desc.subresourceRange.aspectMask |= VK_IMAGE_ASPECT_STENCIL_BIT;
+				break;
+			default:
+				assert(0);
 				break;
 			}
 
@@ -7248,6 +7248,8 @@ using namespace vulkan_internal;
 			break;
 		case GpuQueryType::OCCLUSION:
 			vkCmdBeginQuery(commandlist.GetCommandBuffer(), internal_state->pool, index, VK_QUERY_CONTROL_PRECISE_BIT);
+			break;
+		case GpuQueryType::TIMESTAMP:
 			break;
 		}
 	}

--- a/WickedEngine/wiInput.cpp
+++ b/WickedEngine/wiInput.cpp
@@ -337,6 +337,9 @@ namespace wi::input
 				case Controller::SDLINPUT:
 					connected = wi::input::sdlinput::GetControllerState(&controller.state, controller.deviceIndex);
 					break;
+				case Controller::DISCONNECTED:
+					connected = false;
+					break;
 			}
 
 			if (!connected)
@@ -410,6 +413,7 @@ namespace wi::input
 				case GAMEPAD_BUTTON_8: return state.buttons & (1 << (GAMEPAD_BUTTON_8 - GAMEPAD_RANGE_START - 1));
 				case GAMEPAD_BUTTON_9: return state.buttons & (1 << (GAMEPAD_BUTTON_9 - GAMEPAD_RANGE_START - 1));
 				case GAMEPAD_BUTTON_10: return state.buttons & (1 << (GAMEPAD_BUTTON_10 - GAMEPAD_RANGE_START - 1));
+				default: break;
 				}
 
 			}
@@ -424,17 +428,14 @@ namespace wi::input
 				if (mouse.left_button_press) 
 					return true;
 				return false;
-				break;
 			case wi::input::MOUSE_BUTTON_RIGHT:
 				if (mouse.right_button_press) 
 					return true;
 				return false;
-				break;
 			case wi::input::MOUSE_BUTTON_MIDDLE:
 				if (mouse.middle_button_press) 
 					return true;
 				return false;
-				break;
 #ifdef _WIN32
 			case wi::input::KEYBOARD_BUTTON_UP:
 				keycode = VK_UP;
@@ -521,6 +522,7 @@ namespace wi::input
 				keycode = VK_PRIOR;
 				break;
 #endif // _WIN32
+				default: break;
 			}
 #ifdef _WIN32
 			return KEY_DOWN(keycode) || KEY_TOGGLE(keycode);

--- a/WickedEngine/wiRenderPath3D.cpp
+++ b/WickedEngine/wiRenderPath3D.cpp
@@ -1311,6 +1311,8 @@ void RenderPath3D::RenderAO(CommandList cmd) const
 				instanceInclusionMask_RTAO
 			);
 			break;
+		case AO_DISABLED:
+			break;
 		}
 	}
 }

--- a/WickedEngine/wiRenderPath_BindLua.h
+++ b/WickedEngine/wiRenderPath_BindLua.h
@@ -16,6 +16,7 @@ namespace wi::lua
 		RenderPath_BindLua() = default;
 		RenderPath_BindLua(RenderPath* component) :component(component) {}
 		RenderPath_BindLua(lua_State* L) {}
+		virtual ~RenderPath_BindLua() = default;
 
 		virtual int GetLayerMask(lua_State* L);
 		virtual int SetLayerMask(lua_State* L);


### PR DESCRIPTION
Please double check the new `assert(0)` I've added, if they are correctly placed

- added extra useful warnings
- added a virtual destructor when necessary
- cleaned up and added default to different switch blocks (should have zero impact on performance)
- cleaned and made faster `ComboBox::RemoveItem(int index)`

part 2 of #522 