### PR TITLE
prevent the time loss that previously occurred between timer.elapsed() and timer.record()

### DIFF
--- a/WickedEngine/wiApplication.cpp
+++ b/WickedEngine/wiApplication.cpp
@@ -133,8 +133,7 @@ namespace wi
 
 		wi::profiler::BeginFrame();
 
-		deltaTime = float(std::max(0.0, timer.elapsed() / 1000.0));
-		timer.record();
+		deltaTime = float(std::max(0.0, timer.record_elapsed_seconds()));
 
 		wi::input::Update(window, canvas);
 

--- a/WickedEngine/wiTimer.h
+++ b/WickedEngine/wiTimer.h
@@ -15,24 +15,38 @@ namespace wi
 			timestamp = std::chrono::high_resolution_clock::now();
 		}
 
-		// Elapsed time in seconds since the wi::Timer creation or last call to record()
-		inline double elapsed_seconds()
+		// Elapsed time in seconds between the wi::Timer creation or last recording and "timestamp2"
+		inline double elapsed_seconds_since(std::chrono::high_resolution_clock::time_point timestamp2)
 		{
-			auto timestamp2 = std::chrono::high_resolution_clock::now();
 			std::chrono::duration<double> time_span = std::chrono::duration_cast<std::chrono::duration<double>>(timestamp2 - timestamp);
 			return time_span.count();
 		}
 
-		// Elapsed time in milliseconds since the wi::Timer creation or last call to record()
+		// Elapsed time in seconds since the wi::Timer creation or last recording
+		inline double elapsed_seconds()
+		{
+			return elapsed_seconds_since(std::chrono::high_resolution_clock::now());
+		}
+
+		// Elapsed time in milliseconds since the wi::Timer creation or last recording
 		inline double elapsed_milliseconds()
 		{
 			return elapsed_seconds() * 1000.0;
 		}
 
-		// Elapsed time in milliseconds since the wi::Timer creation or last call to record()
+		// Elapsed time in milliseconds since the wi::Timer creation or last recording
 		inline double elapsed()
 		{
 			return elapsed_milliseconds();
+		}
+
+		// Record a reference timestamp and return elapsed time in seconds since the wi::Timer creation or last recording
+		inline double record_elapsed_seconds()
+		{
+			auto timestamp2 = std::chrono::high_resolution_clock::now();
+			auto elapsed = elapsed_seconds_since(timestamp2);
+			timestamp = timestamp2;
+			return elapsed;
 		}
 	};
 }


### PR DESCRIPTION
prevent the time loss that previously occurred between timer.elapsed() and timer.record()