### PR TITLE
Change RenderPassAttachment texture member to be owning

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -124,32 +124,35 @@ void EditorComponent::ResizeBuffers()
 
 		{
 			RenderPassDesc desc;
-			desc.attachments.push_back(RenderPassAttachment::RenderTarget(&rt_selectionOutline[0], RenderPassAttachment::LoadOp::CLEAR));
+			desc.attachments.push_back(RenderPassAttachment::RenderTarget(rt_selectionOutline[0], RenderPassAttachment::LoadOp::CLEAR));
 			if (renderPath->getMSAASampleCount() > 1)
 			{
-				desc.attachments[0].texture = &rt_selectionOutline_MSAA;
-				desc.attachments.push_back(RenderPassAttachment::Resolve(&rt_selectionOutline[0]));
+				desc.attachments[0].texture = rt_selectionOutline_MSAA;
+				desc.attachments.push_back(RenderPassAttachment::Resolve(rt_selectionOutline[0]));
 			}
-			desc.attachments.push_back(
-				RenderPassAttachment::DepthStencil(
-					renderPath->GetDepthStencil(),
-					RenderPassAttachment::LoadOp::LOAD,
-					RenderPassAttachment::StoreOp::STORE,
-					ResourceState::DEPTHSTENCIL_READONLY,
-					ResourceState::DEPTHSTENCIL_READONLY,
-					ResourceState::DEPTHSTENCIL_READONLY
-				)
-			);
+			if (renderPath->GetDepthStencil() != nullptr)
+			{
+				desc.attachments.push_back(
+					RenderPassAttachment::DepthStencil(
+						*renderPath->GetDepthStencil(),
+						RenderPassAttachment::LoadOp::LOAD,
+						RenderPassAttachment::StoreOp::STORE,
+						ResourceState::DEPTHSTENCIL_READONLY,
+						ResourceState::DEPTHSTENCIL_READONLY,
+						ResourceState::DEPTHSTENCIL_READONLY
+					)
+				);
+			}
 			success = device->CreateRenderPass(&desc, &renderpass_selectionOutline[0]);
 			assert(success);
 
 			if (renderPath->getMSAASampleCount() == 1)
 			{
-				desc.attachments[0].texture = &rt_selectionOutline[1]; // rendertarget
+				desc.attachments[0].texture = rt_selectionOutline[1]; // rendertarget
 			}
 			else
 			{
-				desc.attachments[1].texture = &rt_selectionOutline[1]; // resolve
+				desc.attachments[1].texture = rt_selectionOutline[1]; // resolve
 			}
 			success = device->CreateRenderPass(&desc, &renderpass_selectionOutline[1]);
 			assert(success);
@@ -171,14 +174,14 @@ void EditorComponent::ResizeBuffers()
 			RenderPassDesc desc;
 			desc.attachments.push_back(
 				RenderPassAttachment::DepthStencil(
-					&editor_depthbuffer,
+					editor_depthbuffer,
 					RenderPassAttachment::LoadOp::CLEAR,
 					RenderPassAttachment::StoreOp::DONTCARE
 				)
 			);
 			desc.attachments.push_back(
 				RenderPassAttachment::RenderTarget(
-					&renderPath->GetRenderResult(),
+					renderPath->GetRenderResult(),
 					RenderPassAttachment::LoadOp::CLEAR,
 					RenderPassAttachment::StoreOp::STORE
 				)

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -130,19 +130,17 @@ void EditorComponent::ResizeBuffers()
 				desc.attachments[0].texture = rt_selectionOutline_MSAA;
 				desc.attachments.push_back(RenderPassAttachment::Resolve(rt_selectionOutline[0]));
 			}
-			if (renderPath->GetDepthStencil() != nullptr)
-			{
-				desc.attachments.push_back(
-					RenderPassAttachment::DepthStencil(
-						*renderPath->GetDepthStencil(),
-						RenderPassAttachment::LoadOp::LOAD,
-						RenderPassAttachment::StoreOp::STORE,
-						ResourceState::DEPTHSTENCIL_READONLY,
-						ResourceState::DEPTHSTENCIL_READONLY,
-						ResourceState::DEPTHSTENCIL_READONLY
-					)
-				);
-			}
+			desc.attachments.push_back(
+				RenderPassAttachment::DepthStencil(
+					*renderPath->GetDepthStencil(),
+					RenderPassAttachment::LoadOp::LOAD,
+					RenderPassAttachment::StoreOp::STORE,
+					ResourceState::DEPTHSTENCIL_READONLY,
+					ResourceState::DEPTHSTENCIL_READONLY,
+					ResourceState::DEPTHSTENCIL_READONLY
+				)
+			);
+			
 			success = device->CreateRenderPass(&desc, &renderpass_selectionOutline[0]);
 			assert(success);
 

--- a/WickedEngine/wiApplication.cpp
+++ b/WickedEngine/wiApplication.cpp
@@ -561,7 +561,7 @@ namespace wi
 			graphicsDevice->SetName(&rendertarget, "Application::rendertarget");
 
 			RenderPassDesc renderpassdesc;
-			renderpassdesc.attachments.push_back(RenderPassAttachment::RenderTarget(&rendertarget, RenderPassAttachment::LoadOp::CLEAR));
+			renderpassdesc.attachments.push_back(RenderPassAttachment::RenderTarget(rendertarget, RenderPassAttachment::LoadOp::CLEAR));
 			success = graphicsDevice->CreateRenderPass(&renderpassdesc, &renderpass);
 			assert(success);
 		}

--- a/WickedEngine/wiGraphics.h
+++ b/WickedEngine/wiGraphics.h
@@ -625,143 +625,6 @@ namespace wi::graphics
 		}
 	};
 
-	struct RenderPassAttachment
-	{
-		enum class Type
-		{
-			RENDERTARGET,
-			DEPTH_STENCIL,
-			RESOLVE, // resolve render target (color)
-			RESOLVE_DEPTH,
-			SHADING_RATE_SOURCE
-		} type = Type::RENDERTARGET;
-		enum class LoadOp
-		{
-			LOAD,
-			CLEAR,
-			DONTCARE,
-		} loadop = LoadOp::LOAD;
-		const Texture* texture = nullptr;
-		int subresource = -1;
-		enum class StoreOp
-		{
-			STORE,
-			DONTCARE,
-		} storeop = StoreOp::STORE;
-		ResourceState initial_layout = ResourceState::UNDEFINED;	// layout before the render pass
-		ResourceState subpass_layout = ResourceState::UNDEFINED;	// layout within the render pass
-		ResourceState final_layout = ResourceState::UNDEFINED;		// layout after the render pass
-		enum class DepthResolveMode
-		{
-			Min,
-			Max,
-		} depth_resolve_mode = DepthResolveMode::Min;
-
-		static RenderPassAttachment RenderTarget(
-			const Texture* resource = nullptr,
-			LoadOp load_op = LoadOp::LOAD,
-			StoreOp store_op = StoreOp::STORE,
-			ResourceState initial_layout = ResourceState::SHADER_RESOURCE,
-			ResourceState subpass_layout = ResourceState::RENDERTARGET,
-			ResourceState final_layout = ResourceState::SHADER_RESOURCE,
-			int subresource_RTV = -1
-		)
-		{
-			RenderPassAttachment attachment;
-			attachment.type = Type::RENDERTARGET;
-			attachment.texture = resource;
-			attachment.loadop = load_op;
-			attachment.storeop = store_op;
-			attachment.initial_layout = initial_layout;
-			attachment.subpass_layout = subpass_layout;
-			attachment.final_layout = final_layout;
-			attachment.subresource = subresource_RTV;
-			return attachment;
-		}
-
-		static RenderPassAttachment DepthStencil(
-			const Texture* resource = nullptr,
-			LoadOp load_op = LoadOp::LOAD,
-			StoreOp store_op = StoreOp::STORE,
-			ResourceState initial_layout = ResourceState::DEPTHSTENCIL,
-			ResourceState subpass_layout = ResourceState::DEPTHSTENCIL,
-			ResourceState final_layout = ResourceState::DEPTHSTENCIL,
-			int subresource_DSV = -1
-		)
-		{
-			RenderPassAttachment attachment;
-			attachment.type = Type::DEPTH_STENCIL;
-			attachment.texture = resource;
-			attachment.loadop = load_op;
-			attachment.storeop = store_op;
-			attachment.initial_layout = initial_layout;
-			attachment.subpass_layout = subpass_layout;
-			attachment.final_layout = final_layout;
-			attachment.subresource = subresource_DSV;
-			return attachment;
-		}
-
-		static RenderPassAttachment Resolve(
-			const Texture* resource = nullptr,
-			ResourceState initial_layout = ResourceState::SHADER_RESOURCE,
-			ResourceState final_layout = ResourceState::SHADER_RESOURCE,
-			int subresource_SRV = -1
-		)
-		{
-			RenderPassAttachment attachment;
-			attachment.type = Type::RESOLVE;
-			attachment.texture = resource;
-			attachment.initial_layout = initial_layout;
-			attachment.final_layout = final_layout;
-			attachment.subresource = subresource_SRV;
-			return attachment;
-		}
-
-		static RenderPassAttachment ResolveDepth(
-			const Texture* resource = nullptr,
-			DepthResolveMode depth_resolve_mode = DepthResolveMode::Min,
-			ResourceState initial_layout = ResourceState::SHADER_RESOURCE,
-			ResourceState final_layout = ResourceState::SHADER_RESOURCE,
-			int subresource_SRV = -1
-		)
-		{
-			RenderPassAttachment attachment;
-			attachment.type = Type::RESOLVE_DEPTH;
-			attachment.texture = resource;
-			attachment.initial_layout = initial_layout;
-			attachment.final_layout = final_layout;
-			attachment.subresource = subresource_SRV;
-			attachment.depth_resolve_mode = depth_resolve_mode;
-			return attachment;
-		}
-
-		static RenderPassAttachment ShadingRateSource(
-			const Texture* resource = nullptr,
-			ResourceState initial_layout = ResourceState::SHADING_RATE_SOURCE,
-			ResourceState final_layout = ResourceState::SHADING_RATE_SOURCE
-		)
-		{
-			RenderPassAttachment attachment;
-			attachment.type = Type::SHADING_RATE_SOURCE;
-			attachment.texture = resource;
-			attachment.initial_layout = initial_layout;
-			attachment.subpass_layout = ResourceState::SHADING_RATE_SOURCE;
-			attachment.final_layout = final_layout;
-			return attachment;
-		}
-	};
-
-	struct RenderPassDesc
-	{
-		enum class Flags
-		{
-			EMPTY = 0,
-			ALLOW_UAV_WRITES = 1 << 0,
-		};
-		Flags flags = Flags::EMPTY;
-		wi::vector<RenderPassAttachment> attachments;
-	};
-
 	struct SwapChainDesc
 	{
 		uint32_t width = 0;
@@ -870,6 +733,151 @@ namespace wi::graphics
 		constexpr const TextureDesc& GetDesc() const { return desc; }
 	};
 
+	struct RenderPassAttachment
+	{
+		enum class Type
+		{
+			RENDERTARGET,
+			DEPTH_STENCIL,
+			RESOLVE, // resolve render target (color)
+			RESOLVE_DEPTH,
+			SHADING_RATE_SOURCE
+		} type = Type::RENDERTARGET;
+		enum class LoadOp
+		{
+			LOAD,
+			CLEAR,
+			DONTCARE,
+		} loadop = LoadOp::LOAD;
+		Texture texture;
+		int subresource = -1;
+		enum class StoreOp
+		{
+			STORE,
+			DONTCARE,
+		} storeop = StoreOp::STORE;
+		ResourceState initial_layout = ResourceState::UNDEFINED;	// layout before the render pass
+		ResourceState subpass_layout = ResourceState::UNDEFINED;	// layout within the render pass
+		ResourceState final_layout = ResourceState::UNDEFINED;		// layout after the render pass
+		enum class DepthResolveMode
+		{
+			Min,
+			Max,
+		} depth_resolve_mode = DepthResolveMode::Min;
+
+		static RenderPassAttachment RenderTarget(
+			const Texture& resource,
+			LoadOp load_op = LoadOp::LOAD,
+			StoreOp store_op = StoreOp::STORE,
+			ResourceState initial_layout = ResourceState::SHADER_RESOURCE,
+			ResourceState subpass_layout = ResourceState::RENDERTARGET,
+			ResourceState final_layout = ResourceState::SHADER_RESOURCE,
+			int subresource_RTV = -1
+		)
+		{
+			RenderPassAttachment attachment;
+			attachment.type = Type::RENDERTARGET;
+			attachment.texture = resource;
+			attachment.loadop = load_op;
+			attachment.storeop = store_op;
+			attachment.initial_layout = initial_layout;
+			attachment.subpass_layout = subpass_layout;
+			attachment.final_layout = final_layout;
+			attachment.subresource = subresource_RTV;
+			return attachment;
+		}
+
+		static RenderPassAttachment DepthStencil(
+			const Texture& resource,
+			LoadOp load_op = LoadOp::LOAD,
+			StoreOp store_op = StoreOp::STORE,
+			ResourceState initial_layout = ResourceState::DEPTHSTENCIL,
+			ResourceState subpass_layout = ResourceState::DEPTHSTENCIL,
+			ResourceState final_layout = ResourceState::DEPTHSTENCIL,
+			int subresource_DSV = -1
+		)
+		{
+			RenderPassAttachment attachment;
+			attachment.type = Type::DEPTH_STENCIL;
+			attachment.texture = resource;
+			attachment.loadop = load_op;
+			attachment.storeop = store_op;
+			attachment.initial_layout = initial_layout;
+			attachment.subpass_layout = subpass_layout;
+			attachment.final_layout = final_layout;
+			attachment.subresource = subresource_DSV;
+			return attachment;
+		}
+
+		static RenderPassAttachment Resolve(
+			const Texture& resource,
+			ResourceState initial_layout = ResourceState::SHADER_RESOURCE,
+			ResourceState final_layout = ResourceState::SHADER_RESOURCE,
+			int subresource_SRV = -1
+		)
+		{
+			RenderPassAttachment attachment;
+			attachment.type = Type::RESOLVE;
+			attachment.texture = resource;
+			attachment.initial_layout = initial_layout;
+			attachment.final_layout = final_layout;
+			attachment.subresource = subresource_SRV;
+			return attachment;
+		}
+
+		static RenderPassAttachment ResolveDepth(
+			const Texture& resource,
+			DepthResolveMode depth_resolve_mode = DepthResolveMode::Min,
+			ResourceState initial_layout = ResourceState::SHADER_RESOURCE,
+			ResourceState final_layout = ResourceState::SHADER_RESOURCE,
+			int subresource_SRV = -1
+		)
+		{
+			RenderPassAttachment attachment;
+			attachment.type = Type::RESOLVE_DEPTH;
+			attachment.texture = resource;
+			attachment.initial_layout = initial_layout;
+			attachment.final_layout = final_layout;
+			attachment.subresource = subresource_SRV;
+			attachment.depth_resolve_mode = depth_resolve_mode;
+			return attachment;
+		}
+
+		static RenderPassAttachment ShadingRateSource(
+			const Texture& resource,
+			ResourceState initial_layout = ResourceState::SHADING_RATE_SOURCE,
+			ResourceState final_layout = ResourceState::SHADING_RATE_SOURCE
+		)
+		{
+			RenderPassAttachment attachment;
+			attachment.type = Type::SHADING_RATE_SOURCE;
+			attachment.texture = resource;
+			attachment.initial_layout = initial_layout;
+			attachment.subpass_layout = ResourceState::SHADING_RATE_SOURCE;
+			attachment.final_layout = final_layout;
+			return attachment;
+		}
+	};
+
+	struct RenderPassDesc
+	{
+		enum class Flags
+		{
+			EMPTY = 0,
+			ALLOW_UAV_WRITES = 1 << 0,
+		};
+		Flags flags = Flags::EMPTY;
+		wi::vector<RenderPassAttachment> attachments;
+	};
+
+	struct RenderPass : public GraphicsDeviceChild
+	{
+		size_t hash = 0;
+		RenderPassDesc desc;
+
+		constexpr const RenderPassDesc& GetDesc() const { return desc; }
+	};
+
 	struct GPUQueryHeap : public GraphicsDeviceChild
 	{
 		GPUQueryHeapDesc desc;
@@ -885,21 +893,12 @@ namespace wi::graphics
 		constexpr const PipelineStateDesc& GetDesc() const { return desc; }
 	};
 
-	struct RenderPass : public GraphicsDeviceChild
-	{
-		size_t hash = 0;
-		RenderPassDesc desc;
-
-		constexpr const RenderPassDesc& GetDesc() const { return desc; }
-	};
-
 	struct SwapChain : public GraphicsDeviceChild
 	{
 		SwapChainDesc desc;
 
 		constexpr const SwapChainDesc& GetDesc() const { return desc; }
 	};
-
 
 	struct RaytracingAccelerationStructureDesc
 	{

--- a/WickedEngine/wiGraphicsDevice_DX12.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX12.cpp
@@ -2026,10 +2026,10 @@ using namespace dx12_internal;
 				{
 					if (attachment.type == RenderPassAttachment::Type::RESOLVE ||
 						attachment.type == RenderPassAttachment::Type::RESOLVE_DEPTH ||
-						attachment.type == RenderPassAttachment::Type::SHADING_RATE_SOURCE ||
-						!attachment.texture.IsValid())
+						attachment.type == RenderPassAttachment::Type::SHADING_RATE_SOURCE)
 						continue;
 
+					assert(attachment.texture.desc.format != Format::UNKNOWN);
 					switch (attachment.type)
 					{
 					case RenderPassAttachment::Type::RENDERTARGET:

--- a/WickedEngine/wiRenderPath2D.cpp
+++ b/WickedEngine/wiRenderPath2D.cpp
@@ -51,10 +51,10 @@ namespace wi
 		if (rtStenciled.IsValid())
 		{
 			RenderPassDesc desc;
-			desc.attachments.push_back(RenderPassAttachment::RenderTarget(&rtStenciled, RenderPassAttachment::LoadOp::CLEAR));
+			desc.attachments.push_back(RenderPassAttachment::RenderTarget(rtStenciled, RenderPassAttachment::LoadOp::CLEAR));
 			desc.attachments.push_back(
 				RenderPassAttachment::DepthStencil(
-					dsv,
+					*dsv,
 					RenderPassAttachment::LoadOp::LOAD,
 					RenderPassAttachment::StoreOp::STORE,
 					ResourceState::DEPTHSTENCIL_READONLY,
@@ -65,7 +65,7 @@ namespace wi
 
 			if (rtStenciled.GetDesc().sample_count > 1)
 			{
-				desc.attachments.push_back(RenderPassAttachment::Resolve(&rtStenciled_resolved));
+				desc.attachments.push_back(RenderPassAttachment::Resolve(rtStenciled_resolved));
 			}
 
 			device->CreateRenderPass(&desc, &renderpass_stenciled);
@@ -74,13 +74,13 @@ namespace wi
 		}
 		{
 			RenderPassDesc desc;
-			desc.attachments.push_back(RenderPassAttachment::RenderTarget(&rtFinal, RenderPassAttachment::LoadOp::CLEAR));
+			desc.attachments.push_back(RenderPassAttachment::RenderTarget(rtFinal, RenderPassAttachment::LoadOp::CLEAR));
 
 			if (dsv != nullptr && !rtStenciled.IsValid())
 			{
 				desc.attachments.push_back(
 					RenderPassAttachment::DepthStencil(
-						dsv,
+						*dsv,
 						RenderPassAttachment::LoadOp::LOAD,
 						RenderPassAttachment::StoreOp::STORE,
 						ResourceState::DEPTHSTENCIL_READONLY,

--- a/WickedEngine/wiRenderPath3D.cpp
+++ b/WickedEngine/wiRenderPath3D.cpp
@@ -284,7 +284,7 @@ void RenderPath3D::ResizeBuffers()
 		RenderPassDesc desc;
 		desc.attachments.push_back(
 			RenderPassAttachment::DepthStencil(
-				&depthBuffer_Main,
+				depthBuffer_Main,
 				RenderPassAttachment::LoadOp::CLEAR,
 				RenderPassAttachment::StoreOp::STORE,
 				ResourceState::DEPTHSTENCIL_READONLY,
@@ -294,7 +294,7 @@ void RenderPath3D::ResizeBuffers()
 		);
 		desc.attachments.push_back(
 			RenderPassAttachment::RenderTarget(
-				&rtPrimitiveID_render,
+				rtPrimitiveID_render,
 				RenderPassAttachment::LoadOp::CLEAR,
 				RenderPassAttachment::StoreOp::STORE,
 				ResourceState::SHADER_RESOURCE_COMPUTE,
@@ -307,13 +307,13 @@ void RenderPath3D::ResizeBuffers()
 		desc.attachments.clear();
 		desc.attachments.push_back(
 			RenderPassAttachment::RenderTarget(
-				&rtMain_render,
+				rtMain_render,
 				RenderPassAttachment::LoadOp::LOAD
 			)
 		);
 		desc.attachments.push_back(
 			RenderPassAttachment::DepthStencil(
-				&depthBuffer_Main,
+				depthBuffer_Main,
 				RenderPassAttachment::LoadOp::LOAD,
 				RenderPassAttachment::StoreOp::STORE,
 				ResourceState::DEPTHSTENCIL_READONLY,
@@ -323,22 +323,22 @@ void RenderPath3D::ResizeBuffers()
 		);
 		if (getMSAASampleCount() > 1)
 		{
-			desc.attachments.push_back(RenderPassAttachment::Resolve(&rtMain));
+			desc.attachments.push_back(RenderPassAttachment::Resolve(rtMain));
 		}
 
 		if (device->CheckCapability(GraphicsDeviceCapability::VARIABLE_RATE_SHADING_TIER2) && rtShadingRate.IsValid())
 		{
-			desc.attachments.push_back(RenderPassAttachment::ShadingRateSource(&rtShadingRate, ResourceState::UNORDERED_ACCESS, ResourceState::UNORDERED_ACCESS));
+			desc.attachments.push_back(RenderPassAttachment::ShadingRateSource(rtShadingRate, ResourceState::UNORDERED_ACCESS, ResourceState::UNORDERED_ACCESS));
 		}
 
 		device->CreateRenderPass(&desc, &renderpass_main);
 	}
 	{
 		RenderPassDesc desc;
-		desc.attachments.push_back(RenderPassAttachment::RenderTarget(&rtMain_render, RenderPassAttachment::LoadOp::LOAD));
+		desc.attachments.push_back(RenderPassAttachment::RenderTarget(rtMain_render, RenderPassAttachment::LoadOp::LOAD));
 		desc.attachments.push_back(
 			RenderPassAttachment::DepthStencil(
-				&depthBuffer_Main,
+				depthBuffer_Main,
 				RenderPassAttachment::LoadOp::LOAD,
 				RenderPassAttachment::StoreOp::STORE,
 				ResourceState::DEPTHSTENCIL_READONLY,
@@ -348,7 +348,7 @@ void RenderPath3D::ResizeBuffers()
 		);
 		if (getMSAASampleCount() > 1)
 		{
-			desc.attachments.push_back(RenderPassAttachment::Resolve(&rtMain));
+			desc.attachments.push_back(RenderPassAttachment::Resolve(rtMain));
 		}
 		device->CreateRenderPass(&desc, &renderpass_transparent);
 	}
@@ -356,7 +356,7 @@ void RenderPath3D::ResizeBuffers()
 		RenderPassDesc desc;
 		desc.attachments.push_back(
 			RenderPassAttachment::DepthStencil(
-				&depthBuffer_Reflection,
+				depthBuffer_Reflection,
 				RenderPassAttachment::LoadOp::CLEAR,
 				RenderPassAttachment::StoreOp::STORE,
 				ResourceState::DEPTHSTENCIL_READONLY,
@@ -371,7 +371,7 @@ void RenderPath3D::ResizeBuffers()
 		RenderPassDesc desc;
 		desc.attachments.push_back(
 			RenderPassAttachment::RenderTarget(
-				&rtReflection,
+				rtReflection,
 				RenderPassAttachment::LoadOp::DONTCARE,
 				RenderPassAttachment::StoreOp::STORE,
 				ResourceState::SHADER_RESOURCE,
@@ -381,7 +381,7 @@ void RenderPath3D::ResizeBuffers()
 		);
 		desc.attachments.push_back(
 			RenderPassAttachment::DepthStencil(
-				&depthBuffer_Reflection, 
+				depthBuffer_Reflection, 
 				RenderPassAttachment::LoadOp::LOAD, 
 				RenderPassAttachment::StoreOp::DONTCARE,
 				ResourceState::SHADER_RESOURCE,
@@ -394,7 +394,7 @@ void RenderPath3D::ResizeBuffers()
 	}
 	{
 		RenderPassDesc desc;
-		desc.attachments.push_back(RenderPassAttachment::RenderTarget(&rtSceneCopy, RenderPassAttachment::LoadOp::DONTCARE));
+		desc.attachments.push_back(RenderPassAttachment::RenderTarget(rtSceneCopy, RenderPassAttachment::LoadOp::DONTCARE));
 
 		device->CreateRenderPass(&desc, &renderpass_downsamplescene);
 	}
@@ -402,7 +402,7 @@ void RenderPath3D::ResizeBuffers()
 		RenderPassDesc desc;
 		desc.attachments.push_back(
 			RenderPassAttachment::DepthStencil(
-				&depthBuffer_Main,
+				depthBuffer_Main,
 				RenderPassAttachment::LoadOp::LOAD,
 				RenderPassAttachment::StoreOp::STORE,
 				ResourceState::DEPTHSTENCIL_READONLY,
@@ -410,27 +410,27 @@ void RenderPath3D::ResizeBuffers()
 				ResourceState::DEPTHSTENCIL_READONLY
 			)
 		);
-		desc.attachments.push_back(RenderPassAttachment::RenderTarget(&rtSun[0], RenderPassAttachment::LoadOp::CLEAR));
+		desc.attachments.push_back(RenderPassAttachment::RenderTarget(rtSun[0], RenderPassAttachment::LoadOp::CLEAR));
 		if (getMSAASampleCount() > 1)
 		{
 			desc.attachments.back().storeop = RenderPassAttachment::StoreOp::DONTCARE;
-			desc.attachments.push_back(RenderPassAttachment::Resolve(&rtSun_resolved));
+			desc.attachments.push_back(RenderPassAttachment::Resolve(rtSun_resolved));
 		}
 
 		device->CreateRenderPass(&desc, &renderpass_lightshafts);
 	}
 	{
 		RenderPassDesc desc;
-		desc.attachments.push_back(RenderPassAttachment::RenderTarget(&rtVolumetricLights[0], RenderPassAttachment::LoadOp::CLEAR));
+		desc.attachments.push_back(RenderPassAttachment::RenderTarget(rtVolumetricLights[0], RenderPassAttachment::LoadOp::CLEAR));
 
 		device->CreateRenderPass(&desc, &renderpass_volumetriclight);
 	}
 	{
 		RenderPassDesc desc;
-		desc.attachments.push_back(RenderPassAttachment::RenderTarget(&rtParticleDistortion, RenderPassAttachment::LoadOp::CLEAR));
+		desc.attachments.push_back(RenderPassAttachment::RenderTarget(rtParticleDistortion, RenderPassAttachment::LoadOp::CLEAR));
 		desc.attachments.push_back(
 			RenderPassAttachment::DepthStencil(
-				&depthBuffer_Main,
+				depthBuffer_Main,
 				RenderPassAttachment::LoadOp::LOAD,
 				RenderPassAttachment::StoreOp::STORE,
 				ResourceState::DEPTHSTENCIL_READONLY,
@@ -441,14 +441,14 @@ void RenderPath3D::ResizeBuffers()
 
 		if (getMSAASampleCount() > 1)
 		{
-			desc.attachments.push_back(RenderPassAttachment::Resolve(&rtParticleDistortion_Resolved));
+			desc.attachments.push_back(RenderPassAttachment::Resolve(rtParticleDistortion_Resolved));
 		}
 
 		device->CreateRenderPass(&desc, &renderpass_particledistortion);
 	}
 	{
 		RenderPassDesc desc;
-		desc.attachments.push_back(RenderPassAttachment::RenderTarget(&rtWaterRipple, RenderPassAttachment::LoadOp::CLEAR));
+		desc.attachments.push_back(RenderPassAttachment::RenderTarget(rtWaterRipple, RenderPassAttachment::LoadOp::CLEAR));
 
 		device->CreateRenderPass(&desc, &renderpass_waterripples);
 	}
@@ -664,8 +664,8 @@ void RenderPath3D::Update(float dt)
 		if(!renderpass_outline_source.IsValid())
 		{
 			RenderPassDesc desc;
-			desc.attachments.push_back(RenderPassAttachment::RenderTarget(&rtOutlineSource, RenderPassAttachment::LoadOp::CLEAR));
-			desc.attachments.push_back(RenderPassAttachment::DepthStencil(&depthBuffer_Main, RenderPassAttachment::LoadOp::LOAD));
+			desc.attachments.push_back(RenderPassAttachment::RenderTarget(rtOutlineSource, RenderPassAttachment::LoadOp::CLEAR));
+			desc.attachments.push_back(RenderPassAttachment::DepthStencil(depthBuffer_Main, RenderPassAttachment::LoadOp::LOAD));
 
 			device->CreateRenderPass(&desc, &renderpass_outline_source);
 		}
@@ -1410,7 +1410,7 @@ void RenderPath3D::RenderLightShafts(CommandList cmd) const
 				XMFLOAT2 sun;
 				XMStoreFloat2(&sun, sunPos);
 				wi::renderer::Postprocess_LightShafts(
-					*renderpass_lightshafts.desc.attachments.back().texture,
+					renderpass_lightshafts.desc.attachments.back().texture,
 					rtSun[1],
 					cmd,
 					sun,
@@ -1529,7 +1529,7 @@ void RenderPath3D::RenderTransparents(CommandList cmd) const
 	{
 		device->EventBegin("Contribute Volumetric Lights", cmd);
 		wi::renderer::Postprocess_Upsample_Bilateral(rtVolumetricLights[0], rtLinearDepth, 
-			*renderpass_transparent.desc.attachments[0].texture, cmd, true, 1.5f);
+			renderpass_transparent.desc.attachments[0].texture, cmd, true, 1.5f);
 		device->EventEnd(cmd);
 	}
 

--- a/WickedEngine/wiRenderPath3D_PathTracing.cpp
+++ b/WickedEngine/wiRenderPath3D_PathTracing.cpp
@@ -90,7 +90,7 @@ namespace wi
 
 		{
 			RenderPassDesc desc;
-			desc.attachments.push_back(RenderPassAttachment::RenderTarget(&traceResult, RenderPassAttachment::LoadOp::CLEAR));
+			desc.attachments.push_back(RenderPassAttachment::RenderTarget(traceResult, RenderPassAttachment::LoadOp::CLEAR));
 
 			device->CreateRenderPass(&desc, &renderpass_debugbvh);
 		}

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -3174,7 +3174,7 @@ void UpdatePerFrameData(
 						RenderPassDesc renderpassdesc;
 						renderpassdesc.attachments.push_back(
 							RenderPassAttachment::DepthStencil(
-								&shadowMapAtlas,
+								shadowMapAtlas,
 								RenderPassAttachment::LoadOp::CLEAR,
 								RenderPassAttachment::StoreOp::STORE,
 								ResourceState::SHADER_RESOURCE,
@@ -3184,7 +3184,7 @@ void UpdatePerFrameData(
 						);
 						renderpassdesc.attachments.push_back(
 							RenderPassAttachment::RenderTarget(
-								&shadowMapAtlas_Transparent,
+								shadowMapAtlas_Transparent,
 								RenderPassAttachment::LoadOp::CLEAR,
 								RenderPassAttachment::StoreOp::STORE,
 								ResourceState::SHADER_RESOURCE,

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -2882,7 +2882,7 @@ namespace wi::scene
 				RenderPassDesc renderpassdesc;
 				renderpassdesc.attachments.push_back(
 					RenderPassAttachment::RenderTarget(
-						&impostorArray,
+						impostorArray,
 						RenderPassAttachment::LoadOp::CLEAR,
 						RenderPassAttachment::StoreOp::STORE,
 						ResourceState::RENDERTARGET,
@@ -2894,7 +2894,7 @@ namespace wi::scene
 
 				renderpassdesc.attachments.push_back(
 					RenderPassAttachment::RenderTarget(
-						&impostorArray,
+						impostorArray,
 						RenderPassAttachment::LoadOp::CLEAR,
 						RenderPassAttachment::StoreOp::STORE,
 						ResourceState::RENDERTARGET,
@@ -2906,7 +2906,7 @@ namespace wi::scene
 
 				renderpassdesc.attachments.push_back(
 					RenderPassAttachment::RenderTarget(
-						&impostorArray,
+						impostorArray,
 						RenderPassAttachment::LoadOp::CLEAR,
 						RenderPassAttachment::StoreOp::STORE,
 						ResourceState::RENDERTARGET,
@@ -2918,7 +2918,7 @@ namespace wi::scene
 
 				renderpassdesc.attachments.push_back(
 					RenderPassAttachment::DepthStencil(
-						&impostorDepthStencil,
+						impostorDepthStencil,
 						RenderPassAttachment::LoadOp::CLEAR,
 						RenderPassAttachment::StoreOp::DONTCARE
 					)
@@ -3236,7 +3236,7 @@ namespace wi::scene
 
 							RenderPassDesc renderpassdesc;
 
-							renderpassdesc.attachments.push_back(RenderPassAttachment::RenderTarget(&object.lightmap, RenderPassAttachment::LoadOp::CLEAR));
+							renderpassdesc.attachments.push_back(RenderPassAttachment::RenderTarget(object.lightmap, RenderPassAttachment::LoadOp::CLEAR));
 
 							device->CreateRenderPass(&renderpassdesc, &object.renderpass_lightmap_clear);
 
@@ -3250,7 +3250,7 @@ namespace wi::scene
 
 					if (!object.lightmapTextureData.empty() && !object.lightmap.IsValid())
 					{
-						// Create a GPU-side per object lighmap if there is none yet, but the data exists already:
+						// Create a GPU-side per object lightmap if there is none yet, but the data exists already:
 						object.lightmap.desc.format = Format::R11G11B10_FLOAT;
 						wi::texturehelper::CreateTexture(object.lightmap, object.lightmapTextureData.data(), object.lightmapWidth, object.lightmapHeight, object.lightmap.desc.format);
 						device->SetName(&object.lightmap, "lightmap");
@@ -3427,7 +3427,7 @@ namespace wi::scene
 					RenderPassDesc renderpassdesc;
 					renderpassdesc.attachments.push_back(
 						RenderPassAttachment::DepthStencil(
-							&envrenderingDepthBuffer,
+							envrenderingDepthBuffer,
 							RenderPassAttachment::LoadOp::CLEAR,
 							RenderPassAttachment::StoreOp::STORE,
 							ResourceState::SHADER_RESOURCE,
@@ -3436,7 +3436,7 @@ namespace wi::scene
 						)
 					);
 					renderpassdesc.attachments.push_back(
-						RenderPassAttachment::RenderTarget(&envmapArray,
+						RenderPassAttachment::RenderTarget(envmapArray,
 							RenderPassAttachment::LoadOp::DONTCARE,
 							RenderPassAttachment::StoreOp::STORE,
 							ResourceState::SHADER_RESOURCE,
@@ -3454,7 +3454,7 @@ namespace wi::scene
 					renderpassdesc.attachments.clear();
 					renderpassdesc.attachments.push_back(
 						RenderPassAttachment::DepthStencil(
-							&envrenderingDepthBuffer_MSAA,
+							envrenderingDepthBuffer_MSAA,
 							RenderPassAttachment::LoadOp::CLEAR,
 							RenderPassAttachment::StoreOp::STORE,
 							ResourceState::SHADER_RESOURCE,
@@ -3463,7 +3463,7 @@ namespace wi::scene
 						)
 					);
 					renderpassdesc.attachments.push_back(
-						RenderPassAttachment::RenderTarget(&envrenderingColorBuffer_MSAA,
+						RenderPassAttachment::RenderTarget(envrenderingColorBuffer_MSAA,
 							RenderPassAttachment::LoadOp::DONTCARE,
 							RenderPassAttachment::StoreOp::DONTCARE,
 							ResourceState::RENDERTARGET,
@@ -3472,7 +3472,7 @@ namespace wi::scene
 						)
 					);
 					renderpassdesc.attachments.push_back(
-						RenderPassAttachment::Resolve(&envmapArray,
+						RenderPassAttachment::Resolve(envmapArray,
 							ResourceState::SHADER_RESOURCE,
 							ResourceState::SHADER_RESOURCE,
 							envmapArray.desc.mip_levels + envmapCount + i // subresource: individual cubes only mip0


### PR DESCRIPTION
- Change RenderPassAttachment texture member to be owning (`const Texture*` -> `Texture`). Due to on-demand PSO creation, the description on the textures can potentially be read at any point during the RenderPass's lifetime. The previous use of a `Texture*` meant that a _particular reference_ of a texture had to be kept live.
    - There are only around 150 RenderPassAttachment objects live at any moment in Wicked Engine, and they are created up-front. So the additional cost of ref counting and description duplication should not be an issue.
- Changed the RenderPassAttachment builder functions to not accept null textures. The graphics device does not actually handle them being null and would crash.

Testing:

Loaded up a terrain scene in the editor with d3d12 and vk.