### PR TITLE
Proposal to change SDL_Quit to SDL_PushEvent

### DIFF
--- a/WickedEngine/wiPlatform.h
+++ b/WickedEngine/wiPlatform.h
@@ -67,7 +67,9 @@ namespace wi::platform
 #endif // PLATFORM_UWP
 #endif // _WIN32
 #ifdef SDL2
-		SDL_Quit();
+		SDL_Event quit_event;
+		quit_event.type = SDL_QUIT;
+		SDL_PushEvent(&quit_event);
 #endif
 	}
 


### PR DESCRIPTION
There's a problem in which application which calls `wi::platform::Exit()` in SDL would either crash or becoming vegetative.

SDL_Quit() is not inteded to be used as a key to quit the program, instead it is to wrap up program that runs SDL in the code.

In this proposal, the function `wi::platform::Exit()` will instead push an event in the SDL system for it to be read at the main file: at the part where the program polls input from SDL for `SDL_QUIT` event type.