### PR TITLE
Lua Script Debug Fix

### DIFF
--- a/WickedEngine/wiArguments.cpp
+++ b/WickedEngine/wiArguments.cpp
@@ -7,7 +7,7 @@
 
 namespace wi::arguments
 {
-	wi::unordered_set<std::string> params;
+	wi::vector<std::string> params;
 
 	void Parse(const wchar_t* args)
 	{
@@ -29,13 +29,22 @@ namespace wi::arguments
     {
 		for (int i = 1; i < argc; i++)
 		{
-			params.insert(std::string(argv[i]));
+			params.push_back(std::string(argv[i]));
 		}
     }
 
 	bool HasArgument(const std::string& value)
 	{
-		return params.find(value) != params.end();
+		for(auto& param : params)
+		{
+			if(param == value)
+				return true;
+		}
+		return false;
 	}
 
+	wi::vector<std::string>* GetParameters()
+	{
+		return &params;
+	}
 }

--- a/WickedEngine/wiArguments.cpp
+++ b/WickedEngine/wiArguments.cpp
@@ -35,6 +35,6 @@ namespace wi::arguments
 
 	bool HasArgument(const std::string& value)
 	{
-		return (params.find(value) != params.end());
+		return params.find(value) != params.end();
 	}
 }

--- a/WickedEngine/wiArguments.cpp
+++ b/WickedEngine/wiArguments.cpp
@@ -7,7 +7,7 @@
 
 namespace wi::arguments
 {
-	wi::vector<std::string> params;
+	wi::unordered_set<std::string> params;
 
 	void Parse(const wchar_t* args)
 	{
@@ -29,22 +29,12 @@ namespace wi::arguments
     {
 		for (int i = 1; i < argc; i++)
 		{
-			params.push_back(std::string(argv[i]));
+			params.insert(std::string(argv[i]));
 		}
     }
 
 	bool HasArgument(const std::string& value)
 	{
-		for(auto& param : params)
-		{
-			if(param == value)
-				return true;
-		}
-		return false;
-	}
-
-	wi::vector<std::string>* GetParameters()
-	{
-		return &params;
+		return (params.find(value) != params.end());
 	}
 }

--- a/WickedEngine/wiArguments.h
+++ b/WickedEngine/wiArguments.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "wiVector.h"
 #include <string>
 
 // This can be used to parse and retrieve startup/command arguments of the application
@@ -8,4 +8,5 @@ namespace wi::arguments
 	void Parse(const wchar_t* args);
     void Parse(int argc, char *argv[]);
 	bool HasArgument(const std::string& value);
+	wi::vector<std::string>* GetParameters();
 }

--- a/WickedEngine/wiArguments.h
+++ b/WickedEngine/wiArguments.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <string>
 
 // This can be used to parse and retrieve startup/command arguments of the application

--- a/WickedEngine/wiArguments.h
+++ b/WickedEngine/wiArguments.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "wiVector.h"
 #include <string>
 
 // This can be used to parse and retrieve startup/command arguments of the application

--- a/WickedEngine/wiArguments.h
+++ b/WickedEngine/wiArguments.h
@@ -8,5 +8,4 @@ namespace wi::arguments
 	void Parse(const wchar_t* args);
     void Parse(int argc, char *argv[]);
 	bool HasArgument(const std::string& value);
-	wi::vector<std::string>* GetParameters();
 }

--- a/WickedEngine/wiLua.cpp
+++ b/WickedEngine/wiLua.cpp
@@ -25,7 +25,6 @@
 #include "wiVector.h"
 
 #include <memory>
-#include <algorithm>
 
 namespace wi::lua
 {
@@ -55,7 +54,7 @@ namespace wi::lua
 		return scriptpid_next.fetch_add(1);
 	}
 
-	uint32_t AttachScriptParameters(std::string& script, const std::string& filename, uint32_t PID, const std::string& customparameters_prepend, const std::string& customparameters_append, uint32_t customparameters_line_offset)
+	uint32_t AttachScriptParameters(std::string& script, const std::string& filename, uint32_t PID, const std::string& customparameters_prepend, const std::string& customparameters_append)
 	{
 		static const std::string persistent_inject =
 			"local runProcess = function(func) "
@@ -98,15 +97,13 @@ namespace wi::lua
 			if(argc >= 3) customparameters_prepend = SGetString(L, 3);
 			std::string customparameters_append;
 			if(argc >= 4) customparameters_prepend = SGetString(L, 4);
-			uint32_t customparameters_line_offset = 0;
-			if(argc >= 5) customparameters_line_offset = SGetInt(L, 5);
 
 			wi::vector<uint8_t> filedata;
 
 			if (wi::helper::FileRead(filename, filedata))
 			{
 				std::string command = std::string(filedata.begin(), filedata.end());
-				PID = AttachScriptParameters(command, filename, PID, customparameters_prepend, customparameters_append, customparameters_line_offset);
+				PID = AttachScriptParameters(command, filename, PID, customparameters_prepend, customparameters_append);
 
 				int status = luaL_loadstring(L, command.c_str());
 				if (status == 0)
@@ -539,7 +536,7 @@ namespace wi::lua
 		{
 			ss += error;
 		}
-		wi::backlog::post(ss);
+		wi::backlog::post(ss, wi::backlog::LogLevel::Error);
 	}
 
 	void SAddMetatable(lua_State* L, const std::string& name)

--- a/WickedEngine/wiLua.h
+++ b/WickedEngine/wiLua.h
@@ -193,9 +193,5 @@ namespace wi::lua
 	
 	//add new metatable
 	void SAddMetatable(lua_State* L, const std::string& name);
-
-	//For script debugging, we need to ensure the line reported during error is correct
-	//To do this, we need to offset the script agreed for the debugger to check
-	void SetAttachScriptLineOffset(uint32_t offset);
 };
 

--- a/WickedEngine/wiLua.h
+++ b/WickedEngine/wiLua.h
@@ -66,7 +66,7 @@ namespace wi::lua
 
 	// Adds some local management functions to the script
 	//	returns the PID
-	uint32_t AttachScriptParameters(std::string& script, const std::string& filename = "", uint32_t PID = GeneratePID(), const std::string& customparameters_prepend = "",  const std::string& customparameters_append = "");
+	uint32_t AttachScriptParameters(std::string& script, const std::string& filename = "", uint32_t PID = GeneratePID(), const std::string& customparameters_prepend = "", const std::string& customparameters_append = "", uint32_t customparameters_line_offset = 0);
 
 	//Following functions are "static", operating on specified lua state:
 
@@ -193,5 +193,9 @@ namespace wi::lua
 	
 	//add new metatable
 	void SAddMetatable(lua_State* L, const std::string& name);
+
+	//For script debugging, we need to ensure the line reported during error is correct
+	//To do this, we need to offset the script agreed for the debugger to check
+	void SetAttachScriptLineOffset(uint32_t offset);
 };
 

--- a/WickedEngine/wiLua.h
+++ b/WickedEngine/wiLua.h
@@ -66,7 +66,7 @@ namespace wi::lua
 
 	// Adds some local management functions to the script
 	//	returns the PID
-	uint32_t AttachScriptParameters(std::string& script, const std::string& filename = "", uint32_t PID = GeneratePID(), const std::string& customparameters_prepend = "", const std::string& customparameters_append = "", uint32_t customparameters_line_offset = 0);
+	uint32_t AttachScriptParameters(std::string& script, const std::string& filename = "", uint32_t PID = GeneratePID(), const std::string& customparameters_prepend = "", const std::string& customparameters_append = "");
 
 	//Following functions are "static", operating on specified lua state:
 

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -4231,7 +4231,7 @@ namespace wi::scene
 				if (script.script.empty() && script.resource.IsValid())
 				{
 					script.script += script.resource.GetScript();
-					wi::lua::AttachScriptParameters(script.script, script.filename, wi::lua::GeneratePID(), "local function GetEntity() return " + std::to_string(entity) + "; end\n", "", 1);
+					wi::lua::AttachScriptParameters(script.script, script.filename, wi::lua::GeneratePID(), "local function GetEntity() return " + std::to_string(entity) + "; end;", "");
 				}
 				wi::lua::RunText(script.script);
 

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -4230,9 +4230,8 @@ namespace wi::scene
 			{
 				if (script.script.empty() && script.resource.IsValid())
 				{
-					script.script += "local function GetEntity() return " + std::to_string(entity) + "; end\n";
 					script.script += script.resource.GetScript();
-					wi::lua::AttachScriptParameters(script.script, script.filename);
+					wi::lua::AttachScriptParameters(script.script, script.filename, wi::lua::GeneratePID(), "local function GetEntity() return " + std::to_string(entity) + "; end\n", "", 1);
 				}
 				wi::lua::RunText(script.script);
 

--- a/WickedEngine/wiVersion.cpp
+++ b/WickedEngine/wiVersion.cpp
@@ -9,7 +9,7 @@ namespace wi::version
 	// minor features, major updates, breaking compatibility changes
 	const int minor = 71;
 	// minor bug fixes, alterations, refactors, updates
-	const int revision = 137;
+	const int revision = 138;
 
 	const std::string version_string = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(revision);
 


### PR DESCRIPTION
I have added a fix for lua debug line error by adding a line offset that is agreed between `AttachScriptParameters` and `SError` in wiLua source code.

Also for wiArguments, I've added a function to get all arguments to be parsed externally from wicked, is used by the game demo for the dev console.