### PR TITLE
avoid double `SDL_Quit()`

### DIFF
--- a/Editor/main_SDL2.cpp
+++ b/Editor/main_SDL2.cpp
@@ -160,6 +160,5 @@ int main(int argc, char *argv[])
 
     int ret = sdl_loop(editor);
 
-    SDL_Quit();
     return ret;
 }


### PR DESCRIPTION
`SDL_Quit` is already called by the smart pointer de-constructor. Calling it twice could cause issues.