### PR TITLE
Fixed uncompressed transcoding of KTX2 and basis files

### DIFF
--- a/WickedEngine/wiResourceManager.cpp
+++ b/WickedEngine/wiResourceManager.cpp
@@ -314,7 +314,8 @@ namespace wi
 							basist::transcoder_texture_format fmt = basist::transcoder_texture_format::cTFRGBA32;
 							desc.format = Format::R8G8B8A8_UNORM;
 
-							if (has_flag(flags, Flags::IMPORT_BLOCK_COMPRESSED))
+							bool import_compressed = has_flag(flags, Flags::IMPORT_BLOCK_COMPRESSED);
+							if (import_compressed)
 							{
 								// BC5 is disabled because it's missing green channel!
 								//if (has_flag(flags, Flags::IMPORT_NORMALMAP))
@@ -358,13 +359,16 @@ namespace wi
 											basist::ktx2_image_level_info level_info;
 											if (transcoder.get_image_level_info(level_info, mip, layer, face))
 											{
-												transcoded_data_size += level_info.m_total_blocks * bytes_per_block;
+												uint32_t pixel_or_block_count = (import_compressed
+													? level_info.m_total_blocks
+													: (level_info.m_orig_width * level_info.m_orig_height));
+												transcoded_data_size += bytes_per_block * pixel_or_block_count;
 											}
 										}
 									}
 								}
 								wi::vector<uint8_t> transcoded_data(transcoded_data_size);
-
+								
 								wi::vector<SubresourceData> InitData;
 								size_t transcoded_data_offset = 0;
 								for (uint32_t layer = 0; layer < layers; ++layer)
@@ -377,20 +381,23 @@ namespace wi
 											if (transcoder.get_image_level_info(level_info, mip, layer, face))
 											{
 												void* data_ptr = transcoded_data.data() + transcoded_data_offset;
-												transcoded_data_offset += level_info.m_total_blocks * bytes_per_block;
+												uint32_t pixel_or_block_count = (import_compressed
+													? level_info.m_total_blocks
+													: (level_info.m_orig_width * level_info.m_orig_height));
+												transcoded_data_offset += bytes_per_block * pixel_or_block_count;
 												if (transcoder.transcode_image_level(
 													mip,
 													layer,
 													face,
 													data_ptr,
-													level_info.m_total_blocks,
+													pixel_or_block_count,
 													fmt
 												))
 												{
 													SubresourceData subresourceData;
 													subresourceData.data_ptr = data_ptr;
-													subresourceData.row_pitch = level_info.m_num_blocks_x * bytes_per_block;
-													subresourceData.slice_pitch = subresourceData.row_pitch * level_info.m_num_blocks_y;
+													subresourceData.row_pitch = (import_compressed ? level_info.m_num_blocks_x : level_info.m_orig_width) * bytes_per_block;
+													subresourceData.slice_pitch = subresourceData.row_pitch * (import_compressed ? level_info.m_num_blocks_y : level_info.m_orig_height);
 													InitData.push_back(subresourceData);
 												}
 												else


### PR DESCRIPTION
When targgeting non-block formats for transcoding, operations should be done with pixel counts rather than block counts.

# Testing

Tested loading a ktx2+basis file with compressed and uncompressed transcoding - both now work.