### PR TITLE
vulkan fix: Ensure properties2 matches the physical device

### DIFF
--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -2505,10 +2505,11 @@ using namespace vulkan_internal;
 			wi::vector<const char*> enabled_deviceExtensions;
 
 			bool h264_decode_extension = false;
+			bool suitable = false;
 
-			for (const auto& dev : devices)
-			{
-				bool suitable = true;
+
+			auto checkPhysicalDeviceAndFillProperties2 = [&](VkPhysicalDevice dev) {
+				suitable = true;
 
 				uint32_t extensionCount;
 				VkResult res = vkEnumerateDeviceExtensionProperties(dev, nullptr, &extensionCount, nullptr);
@@ -2525,7 +2526,7 @@ using namespace vulkan_internal;
 					}
 				}
 				if (!suitable)
-					continue;
+					return;
 
 				h264_decode_extension = false;
 
@@ -2649,7 +2650,21 @@ using namespace vulkan_internal;
 					h264_decode_extension = true;
 				}
 
+				*properties_chain = nullptr;
+				*features_chain = nullptr;
 				vkGetPhysicalDeviceProperties2(dev, &properties2);
+
+			};
+
+			bool properties2_matches_physical_device = false;
+
+			for (const auto& dev : devices)
+			{
+				properties2_matches_physical_device = false;
+				checkPhysicalDeviceAndFillProperties2(dev);
+
+				if (!suitable)
+					continue;
 
 				bool priority = properties2.properties.deviceType == VkPhysicalDeviceType::VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU;
 				if (preference == GPUPreference::Integrated)
@@ -2659,6 +2674,7 @@ using namespace vulkan_internal;
 				if (priority || physicalDevice == VK_NULL_HANDLE)
 				{
 					physicalDevice = dev;
+					properties2_matches_physical_device = true;
 					if (priority)
 					{
 						break; // if this is prioritized GPU type, look no further
@@ -2671,6 +2687,12 @@ using namespace vulkan_internal;
 				assert(0);
 				wi::helper::messageBox("Failed to find a suitable GPU!");
 				wi::platform::Exit();
+			}
+
+			if (!properties2_matches_physical_device) {
+				// this redoes a few checks, but since this code path is only
+				// executed once, it doesn't affect execution time all that much
+				checkPhysicalDeviceAndFillProperties2(physicalDevice);
 			}
 
 			assert(properties2.properties.limits.timestampComputeAndGraphics == VK_TRUE);


### PR DESCRIPTION
Ensure that if there is more than one physical device, but no preferred one, (eg. iGPU and llvmpipe), properties2 will have the data for the selected device, and not the last one checked.