### PR TITLE
vulkan: fix locking for non-dedicated queues

### DIFF
--- a/WickedEngine/wiGraphicsDevice_Vulkan.h
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.h
@@ -118,7 +118,7 @@ namespace wi::graphics
 			wi::vector<VkCommandBufferSubmitInfo> submit_cmds;
 
 			bool sparse_binding_supported = false;
-			std::mutex locker;
+			std::shared_ptr<std::mutex> locker;
 
 			void submit(GraphicsDevice_Vulkan* device, VkFence fence);
 


### PR DESCRIPTION
This replaces #718. I had hoped we could avoid having more lock contention, but it seems like this is not possible.

--------

Some devices don't offer dedicated queues, just one "does everything" queue. In those cases, our logically separate queues are the same Vulkan queue, so we need to make sure that those queue share the same mutex.