### PR TITLE
fix using wrong function when calculating stage mask

### DIFF
--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -405,7 +405,8 @@ namespace vulkan_internal
 
 		if (has_flag(value, ResourceState::SHADER_RESOURCE) ||
 			has_flag(value, ResourceState::SHADER_RESOURCE_COMPUTE) ||
-			has_flag(value, ResourceState::UNORDERED_ACCESS))
+			has_flag(value, ResourceState::UNORDERED_ACCESS) ||
+			has_flag(value, ResourceState::CONSTANT_BUFFER))
 		{
 			flags |= VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
 		}
@@ -434,10 +435,6 @@ namespace vulkan_internal
 		if (has_flag(value, ResourceState::INDEX_BUFFER))
 		{
 			flags |= VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT;
-		}
-		if (has_flag(value, ResourceState::CONSTANT_BUFFER))
-		{
-			flags |= VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
 		}
 		if (has_flag(value, ResourceState::INDIRECT_ARGUMENT))
 		{
@@ -8656,15 +8653,15 @@ using namespace vulkan_internal;
 				if (has_flag(desc.misc_flags, ResourceMiscFlag::RAY_TRACING))
 				{
 					assert(CheckCapability(GraphicsDeviceCapability::RAYTRACING));
-					barrierdesc.srcStageMask |= _ParseResourceState(ResourceState::RAYTRACING_ACCELERATION_STRUCTURE);
-					barrierdesc.dstStageMask |= _ParseResourceState(ResourceState::RAYTRACING_ACCELERATION_STRUCTURE);
+					barrierdesc.srcStageMask |= _ConvertPipelineStage(ResourceState::RAYTRACING_ACCELERATION_STRUCTURE);
+					barrierdesc.dstStageMask |= _ConvertPipelineStage(ResourceState::RAYTRACING_ACCELERATION_STRUCTURE);
 				}
 
 				if (has_flag(desc.misc_flags, ResourceMiscFlag::PREDICATION))
 				{
 					assert(CheckCapability(GraphicsDeviceCapability::PREDICATION));
-					barrierdesc.srcStageMask |= _ParseResourceState(ResourceState::PREDICATION);
-					barrierdesc.dstStageMask |= _ParseResourceState(ResourceState::PREDICATION);
+					barrierdesc.srcStageMask |= _ConvertPipelineStage(ResourceState::PREDICATION);
+					barrierdesc.dstStageMask |= _ConvertPipelineStage(ResourceState::PREDICATION);
 				}
 
 				bufferBarriers.push_back(barrierdesc);


### PR DESCRIPTION
This should be one of the last fixes, there is another small issue I'm currently working on, and I still need to figure out how to handle #722, but other than that, it looks good validation error wise.

As mentioned in the commit message, there were two instances where stageMasks were ORed with accessMasks:

```
barrierdesc.srcStageMask |= _ParseResourceState(ResourceState::RAYTRACING_ACCELERATION_STRUCTURE); 
barrierdesc.srcStageMask |= _ParseResourceState(ResourceState::PREDICATION);
```

I'm not 100% sure if srcAccessMask was supposed to be modified here or srcStageMask. Since `_ParseResourceState` does not handle `RAYTRACING_ACCELERATION_STRUCTURE` at all, I decided that those calls should have been to `_ConvertPipelineStage` instead, but I'm not 100% about this.

---------

Unlike VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT, the ALL_GRAPHICS_BIT specifies *all* pipeline stages, even unsupported ones. Since specifying unsupported stages is not allowed, that bit is useless unless all stages are actually supported by the device.

Hence, we need to calculate our own "ALL_USED_GRAPHICS_BIT".

Furthermore, this commit fixes an issue where the stageMask was accidentially ORed with accessFlags.