### PR TITLE
ensure shader list is not modified while we're iterating over it

### DIFF
--- a/WickedEngine/wiShaderCompiler.cpp
+++ b/WickedEngine/wiShaderCompiler.cpp
@@ -806,6 +806,7 @@ namespace wi::shadercompiler
 	bool CheckRegisteredShadersOutdated()
 	{
 #ifdef SHADERCOMPILER_ENABLED
+		std::scoped_lock lock(locker);
 		for (auto& x : registered_shaders)
 		{
 			if (IsShaderOutdated(x))


### PR DESCRIPTION
This fixes (some of?) the random crashes on startup.

On my machine, using ska::flat_hash_set often crashes, and I can confirm the lock fixes the issue. When using std::unordered_set, I can't get it to crash even without the lock, but according to Google iterating over std::unordered_set while it is being modified is only safe if no rehashing occurs, which I don't think can be guaranteed. Also CheckRegisteredShadersOutdated is rarely called, so the lock shouldn't have a noticable impact anyway.