### PR TITLE
Update wiGraphicsDevice_Vulkan.cpp

### DIFF
--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -1178,7 +1178,7 @@ namespace vulkan_internal
 			}
 		}
 
-		if (swapchain_capabilities.currentExtent.width != 0xFFFFFFFF && swapchain_capabilities.currentExtent.width != 0xFFFFFFFF)
+		if (swapchain_capabilities.currentExtent.width != 0xFFFFFFFF && swapchain_capabilities.currentExtent.height != 0xFFFFFFFF)
 		{
 			internal_state->swapChainExtent = swapchain_capabilities.currentExtent;
 		}


### PR DESCRIPTION
swapchain_capabilities.currentExtent.width being checked twice instead of width and height