### PR TITLE
vulkan: workaround a crash during window resizing

### DIFF
--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -1228,6 +1228,10 @@ namespace vulkan_internal
 		createInfo.clipped = VK_TRUE;
 		createInfo.oldSwapchain = internal_state->swapChain;
 
+		// An explicit wait is added as a workaround for crashes experienced on some systems when rapidly resizing the screen
+		res = vkDeviceWaitIdle(device);
+		assert(res == VK_SUCCESS);
+
 		res = vkCreateSwapchainKHR(device, &createInfo, nullptr, &internal_state->swapChain);
 		assert(res == VK_SUCCESS);
 


### PR DESCRIPTION
Add a vkDeviceWaitIdle in the swapchain creation function

I experienced frequent crashes whenever I resized the app window in Linux. I'm new to Vulkan, but reading online I learned that one should wait for the Vulkan device to become idle before re-creating the swapchain. This change fixes the crashes for me, however I'm not sure if this is the best way to fix the issue given the larger architecture.
