### PR TITLE
Joystick improvements

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -784,7 +784,7 @@ void EditorComponent::Update(float dt)
 
 			const float speed = ((wi::input::Down(wi::input::KEYBOARD_BUTTON_LSHIFT) ? 10.0f : 1.0f) + rightTrigger.x * 10.0f) * optionsWnd.cameraWnd.movespeedSlider.GetValue() * clampedDT;
 			XMVECTOR move = XMLoadFloat3(&editorscene.cam_move);
-			XMVECTOR moveNew = XMVectorSet(leftStick.x, 0, leftStick.y, 0);
+			XMVECTOR moveNew = XMVectorSet(0, 0, 0, 0);
 
 			if (!wi::input::Down(wi::input::KEYBOARD_BUTTON_LCONTROL))
 			{
@@ -795,8 +795,9 @@ void EditorComponent::Update(float dt)
 				if (wi::input::Down((wi::input::BUTTON)'S') || wi::input::Down(wi::input::GAMEPAD_BUTTON_DOWN)) { moveNew += XMVectorSet(0, 0, -1, 0); }
 				if (wi::input::Down((wi::input::BUTTON)'E') || wi::input::Down(wi::input::GAMEPAD_BUTTON_2)) { moveNew += XMVectorSet(0, 1, 0, 0); }
 				if (wi::input::Down((wi::input::BUTTON)'Q') || wi::input::Down(wi::input::GAMEPAD_BUTTON_1)) { moveNew += XMVectorSet(0, -1, 0, 0); }
-				moveNew += XMVector3Normalize(moveNew);
+				moveNew = XMVector3Normalize(moveNew);
 			}
+			moveNew += XMVectorSet(leftStick.x, 0, leftStick.y, 0);
 			moveNew *= speed;
 
 			move = XMVectorLerp(move, moveNew, optionsWnd.cameraWnd.accelerationSlider.GetValue() * clampedDT / 0.0166f); // smooth the movement a bit
@@ -1297,7 +1298,7 @@ void EditorComponent::Update(float dt)
 				{
 					// Union selection:
 					wi::vector<wi::scene::PickResult> saved = translator.selected;
-					translator.selected.clear(); 
+					translator.selected.clear();
 					for (const wi::scene::PickResult& picked : saved)
 					{
 						AddSelected(picked);

--- a/WickedEngine/wiSDLInput.cpp
+++ b/WickedEngine/wiSDLInput.cpp
@@ -38,7 +38,7 @@ namespace wi::input::sdlinput
         }
     }
 
-    void ProcessEvent(SDL_Event &event){
+    void ProcessEvent(const SDL_Event &event){
         events.push_back(event);
     }
 
@@ -133,7 +133,8 @@ namespace wi::input::sdlinput
                     auto controller_get = controller_mapped.find(event.caxis.which);
                     if(controller_get != controller_mapped.end()){
                         float raw = event.caxis.value / 32767.0f;
-                        float deadzoned = (raw < -0.01 || raw > 0.01) ? raw : 0;
+                        const float deadzone = 0.2;
+                        float deadzoned = (raw < -deadzone || raw > deadzone) ? raw : 0;
                         switch(event.caxis.axis){
                             case SDL_CONTROLLER_AXIS_LEFTX:
                                 controllers[controller_get->second].state.thumbstick_L.x = deadzoned;
@@ -223,7 +224,7 @@ namespace wi::input::sdlinput
         //Update rumble every call
         for(auto& controller : controllers){
             SDL_GameControllerRumble(
-                controller.controller, 
+                controller.controller,
                 controller.rumble_l,
                 controller.rumble_r,
                 60); //Buffer at 60ms
@@ -316,7 +317,7 @@ namespace wi::input::sdlinput
         }
 
         return -1;
-        
+
     }
 
     void controller_to_wicked(uint32_t *current, Uint8 button, bool pressed){
@@ -376,9 +377,9 @@ namespace wi::input::sdlinput
         if(index < controllers.size()){
 #ifdef SDL2_FEATURE_CONTROLLER_LED
             SDL_GameControllerSetLED(
-                controllers[index].controller, 
-                data.led_color.getR(), 
-                data.led_color.getG(), 
+                controllers[index].controller,
+                data.led_color.getR(),
+                data.led_color.getG(),
                 data.led_color.getB());
 #endif
             controllers[index].rumble_l = (Uint16)floor(data.vibration_left * 0xFFFF);

--- a/WickedEngine/wiSDLInput.h
+++ b/WickedEngine/wiSDLInput.h
@@ -34,6 +34,6 @@ namespace wi::input::sdlinput
 	// External events can be used for events that is needed outside the engine library, like main_SDL2.cpp for example
 #ifdef SDL2
 	// Call this within the main.cpp program loop for the engine to be able handle the input
-	void ProcessEvent(SDL_Event &event);
+	void ProcessEvent(const SDL_Event &event);
 #endif
 }


### PR DESCRIPTION
- Fix joystick drift on linux (deadzone was way too low, SDL suggest at least 10%, my xbox360 wired controller suggests at least 20%)
- Editor should not normalize joystick movement.