### PR TITLE
Lua: pop the metatable we created off the stack

### DIFF
--- a/WickedEngine/wiLuna.h
+++ b/WickedEngine/wiLuna.h
@@ -130,6 +130,8 @@ public:
 			lua_pushnumber(L, i | (1 << 8));						// Add a number indexing which func it is
 			lua_settable(L, metatable);								//
 		}
+
+		lua_pop(L, 1);
 	}
 
 	/*


### PR DESCRIPTION
Lua 5.4 crashes without this, given enough calls to Register()

And I can also get 5.3 to crash if I loop 10 times around https://github.com/turanszkij/WickedEngine/blob/1bec95698a7976233fcdebdded0d97a226b5a7f9/WickedEngine/wiScene_BindLua.cpp#L475-L501 without this patch applies. With this patch, it doesn't crash