### PR TITLE
Window resize fix.

### DIFF
--- a/WickedEngine/wiApplication.cpp
+++ b/WickedEngine/wiApplication.cpp
@@ -620,6 +620,7 @@ namespace wi
 		}
 		wi::graphics::GetDevice() = graphicsDevice.get();
 
+		rendertarget = {};
 		canvas.init(window);
 
 		SwapChainDesc desc;


### PR DESCRIPTION
Noticed a bug then hdr is on. It happend when I tried to resize window.

Seems like `rendertarget` used for final composition never got resized since app initialization.

![image](https://github.com/turanszkij/WickedEngine/assets/7123610/9a3ead6c-c958-4a1b-9b8a-383f0ca58935)
