### PR TITLE
Improve entity remove

### DIFF
--- a/WickedEngine/wiECS.h
+++ b/WickedEngine/wiECS.h
@@ -112,7 +112,9 @@ namespace wi::ecs
 		virtual void Serialize(wi::Archive& archive, EntitySerializer& seri) = 0;
 		virtual void Component_Serialize(Entity entity, wi::Archive& archive, EntitySerializer& seri) = 0;
 		virtual void Remove(Entity entity) = 0;
+		virtual void Remove(wi::vector<Entity>& killEntities) = 0;
 		virtual void Remove_KeepSorted(Entity entity) = 0;
+		virtual void Remove_KeepSorted(wi::vector<Entity>& killEntities) = 0;
 		virtual void MoveItem(size_t index_from, size_t index_to) = 0;
 		virtual bool Contains(Entity entity) const = 0;
 		virtual size_t GetIndex(Entity entity) const = 0;
@@ -276,7 +278,6 @@ namespace wi::ecs
 
 			return components.back();
 		}
-
 		// Remove a component of a certain entity if it exists
 		inline void Remove(Entity entity)
 		{
@@ -301,6 +302,41 @@ namespace wi::ecs
 				components.pop_back();
 				entities.pop_back();
 				lookup.erase(entity);
+			}
+		}
+
+		// Remove a component of a certain entity if it exists
+		inline void Remove(wi::vector<Entity>& killEntities)
+		{
+			for (std::vector<Entity>::iterator vecIter = killEntities.begin(); vecIter != killEntities.end();)
+			{
+				Entity entity = *vecIter;
+				auto it = lookup.find(entity);
+				if (it != lookup.end())
+				{
+					// Directly index into components and entities array:
+					const size_t index = it->second;
+					const Entity entity = entities[index];
+
+					if (index < components.size() - 1)
+					{
+						// Swap out the dead element with the last one:
+						components[index] = std::move(components.back()); // try to use move instead of copy
+						entities[index] = entities.back();
+
+						// Update the lookup table:
+						lookup[entities[index]] = index;
+					}
+
+					// Shrink the container:
+					components.pop_back();
+					entities.pop_back();
+					lookup.erase(entity);
+					vecIter = killEntities.erase(vecIter);
+				}
+				else {
+					++vecIter;
+				}
 			}
 		}
 
@@ -333,6 +369,46 @@ namespace wi::ecs
 				components.pop_back();
 				entities.pop_back();
 				lookup.erase(entity);
+			}
+		}
+
+		// Remove a component of a certain entity if it exists while keeping the current ordering
+		inline void Remove_KeepSorted(wi::vector<Entity>& killEntities)
+		{
+			for (std::vector<Entity>::iterator vecIter = killEntities.begin(); vecIter != killEntities.end();)
+			{
+				Entity entity = *vecIter;
+				auto it = lookup.find(entity);
+				if (it != lookup.end())
+				{
+					// Directly index into components and entities array:
+					const size_t index = it->second;
+					const Entity entity = entities[index];
+
+					if (index < components.size() - 1)
+					{
+						// Move every component left by one that is after this element:
+						for (size_t i = index + 1; i < components.size(); ++i)
+						{
+							components[i - 1] = std::move(components[i]);
+						}
+						// Move every entity left by one that is after this element and update lut:
+						for (size_t i = index + 1; i < entities.size(); ++i)
+						{
+							entities[i - 1] = entities[i];
+							lookup[entities[i - 1]] = i - 1;
+						}
+					}
+
+					// Shrink the container:
+					components.pop_back();
+					entities.pop_back();
+					lookup.erase(entity);
+					vecIter = killEntities.erase(vecIter);
+				}
+				else {
+					++vecIter;
+				}
 			}
 		}
 

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -5065,7 +5065,8 @@ namespace wi::scene
 				const AABB& aabb = aabb_objects[objectIndex];
 				if (!ray.intersects(aabb) || (layerMask & aabb.layerMask) == 0)
 					continue;
-
+				if (objectIndex >= objects.GetCount())
+					continue;
 				const ObjectComponent& object = objects[objectIndex];
 				if (object.meshID == INVALID_ENTITY)
 					continue;
@@ -5731,10 +5732,13 @@ namespace wi::scene
 		{
 			for (size_t objectIndex = 0; objectIndex < aabb_objects.size(); ++objectIndex)
 			{
+				if (objectIndex >= objects.GetCount())
+					break;
+
 				const AABB& aabb = aabb_objects[objectIndex];
 				if (capsule_aabb.intersects(aabb) == AABB::INTERSECTION_TYPE::OUTSIDE || (layerMask & aabb.layerMask) == 0)
 					continue;
-
+				
 				const ObjectComponent& object = objects[objectIndex];
 
 				if (object.meshID == INVALID_ENTITY)

--- a/WickedEngine/wiScene.h
+++ b/WickedEngine/wiScene.h
@@ -61,7 +61,6 @@ namespace wi::scene
 		wi::ecs::ComponentManager<wi::Sprite>& sprites = componentLibrary.Register<wi::Sprite>("wi::scene::Scene::sprites");
 		wi::ecs::ComponentManager<wi::SpriteFont>& fonts = componentLibrary.Register<wi::SpriteFont>("wi::scene::Scene::fonts");
 		wi::ecs::ComponentManager<wi::VoxelGrid>& voxel_grids = componentLibrary.Register<wi::VoxelGrid>("wi::scene::Scene::voxel_grids");
-
 		// Non-serialized attributes:
 		float dt = 0;
 		enum FLAGS


### PR DESCRIPTION
I was seeing massive drop in framerate when removing entities during gameplay. Obviously, it's possible to simply transform entities instead of removing them, but this is more difficult and potentially a memory bloat when spawning a lot of projectiles. 

I have gotten rid of the recursive call from Entity_Remove, instead traversing through the hierarchy and populating a vector of entities to remove. I also put the removal on a separate thread. Potentially a spin lock might be needed, but in my testing I did not see any issues with the current implementation.

In addition, I have included the check on the objects index in the Intersects function. This time I put it in the condition of the loop.