### PR TITLE
Make dofile return results

### DIFF
--- a/WickedEngine/wiLua.cpp
+++ b/WickedEngine/wiLua.cpp
@@ -107,12 +107,17 @@ namespace wi::lua
 				std::string command = std::string(filedata.begin(), filedata.end());
 				PID = AttachScriptParameters(command, filename, PID, customparameters_prepend, customparameters_append);
 
+				lua_settop(L, 0);
+
 				int status = luaL_loadstring(L, command.c_str());
 				if (status == 0)
 				{
 					status = lua_pcall(L, 0, LUA_MULTRET, 0);
-					auto return_PID = std::to_string(PID);
-					SSetString(L, return_PID);
+				}
+
+				if (status == 0)
+				{
+					return lua_gettop(L);
 				}
 				else
 				{
@@ -134,7 +139,7 @@ namespace wi::lua
 			SError(L, "dofile(string filename) not enough arguments!");
 		}
 
-		return 1;
+		return 0;
 	}
 	int Internal_DoBinaryFile(lua_State* L)
 	{

--- a/WickedEngine/wiLua.cpp
+++ b/WickedEngine/wiLua.cpp
@@ -91,10 +91,18 @@ namespace wi::lua
 
 		if (argc > 0)
 		{
-			uint32_t PID = 0;
+			uint32_t PID;
 
 			std::string filename = SGetString(L, 1);
-			if(argc >= 2) PID = SGetInt(L, 2);
+			if (argc >= 2)
+			{
+				PID = SGetInt(L, 2);
+			}
+			else
+			{
+				PID = GeneratePID();
+			}
+				
 			std::string customparameters_prepend;
 			if(argc >= 3) customparameters_prepend = SGetString(L, 3);
 			std::string customparameters_append;
@@ -117,6 +125,8 @@ namespace wi::lua
 
 				if (status == 0)
 				{
+					SSetString(L, std::to_string(PID));
+					lua_insert(L, 1);
 					return lua_gettop(L);
 				}
 				else


### PR DESCRIPTION
Currently dofile returns a PID value, but this seems to be a input argument into the function anyways.

Most Lua implementations for dofile return the results of the dofile execution. Only easyish way currently to get the results from executing another Lua script in a Lua script is something like

`
print(loadfile("../Content/scripts/exampleScript.lua")())
`

or a require call if you don't mind the caching, although I don't think you get some of the globals set in dofile if you do any of these alternatives

