### PR TITLE
CMake win32 fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,9 @@ option(USE_LIBCXX "Link WickedEngine to llvm libc++ library - only available wit
 option(WICKED_EDITOR "Build WickedEngine editor" ON)
 option(WICKED_TESTS "Build WickedEngine tests" ON)
 option(WICKED_IMGUI_EXAMPLE "Build WickedEngine imgui example" ON)
-option(WICKED_LINUX_TEMPLATE "Build WickedEngine Linux template" ON)
 
+include(CMakeDependentOption)
+cmake_dependent_option(WICKED_LINUX_TEMPLATE "Build WickedEngine Linux template" ON "UNIX" OFF)
 
 # Configure CMake global variables
 set(CMAKE_CXX_STANDARD 17)

--- a/Example_ImGui/CMakeLists.txt
+++ b/Example_ImGui/CMakeLists.txt
@@ -18,8 +18,6 @@ set (SOURCE_FILES
 	ImGui/imstb_rectpack.h
 	ImGui/imstb_textedit.h
 	ImGui/imstb_truetype.h
-	ImGui/imgui_impl_sdl.cpp
-	ImGui/imgui_impl_sdl.h
 )
 
 if (WIN32)
@@ -27,6 +25,8 @@ if (WIN32)
 		main_Windows.cpp
 		main_Windows.h
 		Tests.rc
+		ImGui/imgui_impl_win32.cpp
+		ImGui/imgui_impl_win32.h
 	)
 
 	add_executable(Example_ImGui WIN32 ${SOURCE_FILES})
@@ -38,6 +38,8 @@ if (WIN32)
 else()
 	list (APPEND SOURCE_FILES
 		main_SDL2.cpp
+		ImGui/imgui_impl_sdl.cpp
+		ImGui/imgui_impl_sdl.h
 	)
 
 	add_executable(Example_ImGui ${SOURCE_FILES})

--- a/Example_ImGui_Docking/CMakeLists.txt
+++ b/Example_ImGui_Docking/CMakeLists.txt
@@ -18,8 +18,6 @@ set (SOURCE_FILES
 	ImGui/imstb_rectpack.h
 	ImGui/imstb_textedit.h
 	ImGui/imstb_truetype.h
-	ImGui/imgui_impl_sdl.cpp
-	ImGui/imgui_impl_sdl.h
 	ImGui/ImGuizmo.cpp
 	ImGui/ImGuizmo.h
 	ImGui/IconsMaterialDesign.h
@@ -31,6 +29,8 @@ if (WIN32)
 		main_Windows.cpp
 		main_Windows.h
 		Tests.rc
+		ImGui/imgui_impl_win32.cpp
+		ImGui/imgui_impl_win32.h
 	)
 
 	add_executable(Example_ImGui_Docking WIN32 ${SOURCE_FILES})
@@ -42,6 +42,8 @@ if (WIN32)
 else()
 	list (APPEND SOURCE_FILES
 		main_SDL2.cpp
+		ImGui/imgui_impl_sdl.cpp
+		ImGui/imgui_impl_sdl.h
 	)
 
 	add_executable(Example_ImGui_Docking ${SOURCE_FILES})


### PR DESCRIPTION
Building with CMake on windows currently produces errors when trying to build Example_ImGui, Example_ImGui_Docking and Template_Linux.

This PR tries to fix this by compiling imgui_impl_sdl.cpp only on linux and by making WICKED_LINUX_TEMPLATE a dependent option that is turned ON only on unix.

Also it might be a good idea to include the cmake windows build into the github build workflow?