### PR TITLE
gamepad bluetooth assert work around

### DIFF
--- a/WickedEngine/wiRawInput.cpp
+++ b/WickedEngine/wiRawInput.cpp
@@ -305,12 +305,13 @@ namespace wi::input::rawinput
 				for (USHORT i = 0; i < Caps.NumberInputValueCaps; i++)
 				{
 					ULONG value;
-					status = HidP_GetUsageValue(
+					if(HidP_GetUsageValue(
 						HidP_Input, pValueCaps[i].UsagePage, 0,
 						pValueCaps[i].Range.UsageMin, &value, pPreparsedData,
-						(PCHAR)raw.data.hid.bRawData, raw.data.hid.dwSizeHid
-					);
-					assert(status == HIDP_STATUS_SUCCESS);
+						(PCHAR)raw.data.hid.bRawData, raw.data.hid.dwSizeHid) != HIDP_STATUS_SUCCESS)
+					{
+						continue;
+					}
 
 					switch (pValueCaps[i].Range.UsageMin)
 					{


### PR DESCRIPTION
When I start engine with dualsense connected via bluetooth(via usb cabel works fine) assert appears infinitly.

I suggesting this as a temporal work around overwise it supposed to be fixed other way.

Thats what I got after quick debug.
Seems like HidP_GetValueCaps starts to return buffer with one element has ReportCount > 1 so in that case it supposed to get usage values by HidP_GetUsageValueArray instead. But I couldn't figure out what these values are and how they supposed to be used in engine.