### PR TITLE
Add Instantiate() method to Scene

### DIFF
--- a/Content/scripts/instantiate.lua
+++ b/Content/scripts/instantiate.lua
@@ -1,0 +1,31 @@
+-- This script demonstrates spawning multiple objects from one source scene
+killProcesses() -- stops all running lua coroutine processes
+
+backlog_post("---> START SCRIPT: instantiate.lua")
+
+scene = GetScene()
+scene.Clear()
+
+local prefab = Scene()
+LoadModel(prefab, script_dir() .. "../models/hologram_test.wiscene")
+
+-- Instantiate first object
+scene.Instantiate(prefab)
+
+runProcess(function()
+	while true do
+		
+		-- Instantiate more objects whenever the user presses space
+		if input.Press(KEYBOARD_BUTTON_SPACE) then
+			-- passing true as second parameter attaches all entities to a common root
+			local root_entity = scene.Instantiate(prefab, true)
+
+			local transform_component = scene.Component_GetTransform(root_entity)
+			transform_component.Translate(Vector(math.random() * 10 - 5, 0, math.random() * 10 - 5))
+		end
+
+		update()
+	end
+end)
+
+backlog_post("---> END SCRIPT: instantiate.lua")

--- a/WickedEngine/wiScene.h
+++ b/WickedEngine/wiScene.h
@@ -309,6 +309,11 @@ namespace wi::scene
 		// Merge an other scene into this.
 		//	The contents of the other scene will be lost (and moved to this)!
 		virtual void Merge(Scene& other);
+		// Create a copy of prefab and merge it into this.
+		//	prefab		: source scene to be copied from
+		//	attached	: if true, everything from prefab will be attached to a root entity
+		//	returns new root entity if attached is set to true, otherwise returns INVALID_ENTITY
+		virtual wi::ecs::Entity Instantiate(Scene& prefab, bool attached = false);
 		// Finds all entities in the scene that have any components attached
 		void FindAllEntities(wi::unordered_set<wi::ecs::Entity>& entities) const;
 

--- a/WickedEngine/wiScene_BindLua.cpp
+++ b/WickedEngine/wiScene_BindLua.cpp
@@ -514,6 +514,7 @@ Luna<Scene_BindLua>::FunctionType Scene_BindLua::methods[] = {
 	lunamethod(Scene_BindLua, Update),
 	lunamethod(Scene_BindLua, Clear),
 	lunamethod(Scene_BindLua, Merge),
+	lunamethod(Scene_BindLua, Instantiate),
 	lunamethod(Scene_BindLua, UpdateHierarchy),
 	lunamethod(Scene_BindLua, Intersects),
 	lunamethod(Scene_BindLua, IntersectsFirst),
@@ -710,6 +711,33 @@ int Scene_BindLua::Merge(lua_State* L)
 	else
 	{
 		wi::lua::SError(L, "Scene::Merge(Scene other) not enough arguments!");
+	}
+	return 0;
+}
+int Scene_BindLua::Instantiate(lua_State* L)
+{
+	int argc = wi::lua::SGetArgCount(L);
+	if (argc > 0)
+	{
+		Scene_BindLua* other = Luna<Scene_BindLua>::lightcheck(L, 1);
+		if (other)
+		{
+			bool attached = argc > 1 ? wi::lua::SGetBool(L, 2) : false;
+
+			Entity rootEntity = scene->Instantiate(*other->scene, attached);
+
+			wi::lua::SSetLongLong(L, rootEntity);
+
+			return 1;
+		}
+		else
+		{
+			wi::lua::SError(L, "Scene::Instantiate(Scene prefab, opt bool attached) first argument is not of type Scene!");
+		}
+	}
+	else
+	{
+		wi::lua::SError(L, "Scene::Instantiate(Scene prefab, opt bool attached) not enough arguments!");
 	}
 	return 0;
 }

--- a/WickedEngine/wiScene_BindLua.h
+++ b/WickedEngine/wiScene_BindLua.h
@@ -34,6 +34,7 @@ namespace wi::lua::scene
 		int Update(lua_State* L);
 		int Clear(lua_State* L);
 		int Merge(lua_State* L);
+		int Instantiate(lua_State* L);
 
 		int UpdateHierarchy(lua_State* L);
 


### PR DESCRIPTION
This adds a helper function to the Scene which allows to quickly duplicate and merge one scene into another. This enables using scenes as prefabs. Also see https://github.com/turanszkij/WickedEngine/issues/455#issuecomment-1146807159.