### PR TITLE
Dev/terrain generation fix

### DIFF
--- a/Editor/TerrainWindow.cpp
+++ b/Editor/TerrainWindow.cpp
@@ -1708,6 +1708,17 @@ void TerrainWindow::SetupAssets()
 		grass->frameStart = grass_config.GetInt("frameStart");
 	}
 
+	{
+		Entity sunEntity = currentScene.Entity_CreateLight("sun");
+		LightComponent& light = *currentScene.lights.GetComponent(sunEntity);
+		light.SetType(LightComponent::LightType::DIRECTIONAL);
+		light.intensity = 16;
+		light.SetCastShadow(true);
+		TransformComponent& transform = *currentScene.transforms.GetComponent(sunEntity);
+		transform.RotateRollPitchYaw(XMFLOAT3(XM_PIDIV4, 0, XM_PIDIV4));
+		transform.Translate(XMFLOAT3(0, 4, 0));
+	}
+
 	terrain = &terrain_preset;
 	presetCombo.SetSelected(0);
 

--- a/WickedEngine/wiTerrain.cpp
+++ b/WickedEngine/wiTerrain.cpp
@@ -452,18 +452,9 @@ namespace wi::terrain
 		}
 		chunks.clear();
 
-		wi::vector<Entity> entities_to_remove;
-		for (size_t i = 0; i < scene->hierarchy.GetCount(); ++i)
+		if (chunkGroupEntity != INVALID_ENTITY)
 		{
-			const HierarchyComponent& hier = scene->hierarchy[i];
-			if (hier.parentID == terrainEntity)
-			{
-				entities_to_remove.push_back(scene->hierarchy.GetEntity(i));
-			}
-		}
-		for (Entity x : entities_to_remove)
-		{
-			scene->Entity_Remove(x);
+			scene->Entity_Remove(chunkGroupEntity);
 		}
 
 		perlin_noise.init(seed);
@@ -481,18 +472,6 @@ namespace wi::terrain
 		if (!weather.IsOceanEnabled())
 		{
 			scene->ocean = {};
-		}
-
-		{
-			Entity sunEntity = scene->Entity_CreateLight("sun");
-			scene->Component_Attach(sunEntity, terrainEntity);
-			LightComponent& light = *scene->lights.GetComponent(sunEntity);
-			light.SetType(LightComponent::LightType::DIRECTIONAL);
-			light.intensity = 16;
-			light.SetCastShadow(true);
-			TransformComponent& transform = *scene->transforms.GetComponent(sunEntity);
-			transform.RotateRollPitchYaw(XMFLOAT3(XM_PIDIV4, 0, XM_PIDIV4));
-			transform.Translate(XMFLOAT3(0, 4, 0));
 		}
 
 		// Restore surface source materials:


### PR DESCRIPTION
If you try to change settings terrain will remove children which leads to buggy behaviour even with current default terrain setup. 
fresh terrain:
![fresh terrain](https://github.com/turanszkij/WickedEngine/assets/7123610/182b856e-ddb2-4978-85cc-087b9626146d)
after any settings change:
![after](https://github.com/turanszkij/WickedEngine/assets/7123610/c563fa64-4205-4336-aff3-781428f09f8d)
I moved sun creation to "first setup" stage and replaced "all children" removement to "chunks only".