### PR TITLE
ensure GetPositionOnSurface doesn't return an uninitialized value for softbodies

### DIFF
--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -6263,23 +6263,18 @@ namespace wi::scene
 			p0 = SkinVertex(*mesh, *armature, vertexID0);
 			p1 = SkinVertex(*mesh, *armature, vertexID1);
 			p2 = SkinVertex(*mesh, *armature, vertexID2);
-
-			P = XMVectorBaryCentric(p0, p1, p2, bary.x, bary.y);
-			const size_t objectIndex = objects.GetIndex(objectEntity);
-			const XMMATRIX objectMat = XMLoadFloat4x4(&matrix_objects[objectIndex]);
-			P = XMVector3Transform(P, objectMat);
-		}
+	    }
 		else
 		{
 			p0 = XMLoadFloat3(&mesh->vertex_positions[vertexID0]);
 			p1 = XMLoadFloat3(&mesh->vertex_positions[vertexID1]);
 			p2 = XMLoadFloat3(&mesh->vertex_positions[vertexID2]);
-
-			P = XMVectorBaryCentric(p0, p1, p2, bary.x, bary.y);
-			const size_t objectIndex = objects.GetIndex(objectEntity);
-			const XMMATRIX objectMat = XMLoadFloat4x4(&matrix_objects[objectIndex]);
-			P = XMVector3Transform(P, objectMat);
 		}
+
+		P = XMVectorBaryCentric(p0, p1, p2, bary.x, bary.y);
+		const size_t objectIndex = objects.GetIndex(objectEntity);
+		const XMMATRIX objectMat = XMLoadFloat4x4(&matrix_objects[objectIndex]);
+		P = XMVector3Transform(P, objectMat);
 
 		XMFLOAT3 result;
 		XMStoreFloat3(&result, P);


### PR DESCRIPTION
Clang was complaining that P was not always initialized to a value, and it has a point. For softbodies, P was not calculated.

I assume that the same calculation needs to be done than in the other cases, but I'm not sure, so this PR might be complete garbage.