### PR TITLE
get rid of compiler warning

### DIFF
--- a/WickedEngine/Utility/utility_common.cpp
+++ b/WickedEngine/Utility/utility_common.cpp
@@ -20,6 +20,7 @@
 
 #define MINIMP4_IMPLEMENTATION
 #include "minimp4.h"
+#undef RETURN_ERROR
 
 #define H264_IMPLEMENTATION
 #include "h264.h"


### PR DESCRIPTION
zstd.c also defines RETURN_ERROR, so make sure it's undefined before we get to include that