### PR TITLE
cmake: replace explicit list of files with globs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.12)
 
 set(WICKED_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -1,55 +1,9 @@
+cmake_minimum_required(VERSION 3.12)
 
-set (SOURCE_FILES
-	main_${PLATFORM}.cpp
-	#$<$<STREQUAL:${PLATFORM},Windows>:App_${PLATFORM}.cpp>
-	AnimationWindow.cpp
-	CameraWindow.cpp
-	CameraComponentWindow.cpp
-	DecalWindow.cpp
-	Editor.cpp
-	EmitterWindow.cpp
-	EnvProbeWindow.cpp
-	ForceFieldWindow.cpp
-	HairParticleWindow.cpp
-	IKWindow.cpp
-	LayerWindow.cpp
-	LightWindow.cpp
-	MaterialWindow.cpp
-	MaterialPickerWindow.cpp
-	MeshWindow.cpp
-	ModelImporter_GLTF.cpp
-	ModelImporter_OBJ.cpp
-	ModelImporter_FBX.cpp
-	NameWindow.cpp
-	ObjectWindow.cpp
-	PaintToolWindow.cpp
-	GraphicsWindow.cpp
-	SoundWindow.cpp
-	VideoWindow.cpp
-	SpringWindow.cpp
-	ScriptWindow.cpp
-	stdafx.cpp
-	TransformWindow.cpp
-	Translator.cpp
-	WeatherWindow.cpp
-	RigidBodyWindow.cpp
-	SoftBodyWindow.cpp
-	ColliderWindow.cpp
-	HierarchyWindow.cpp
-	ExpressionWindow.cpp
-	ArmatureWindow.cpp
-	ComponentsWindow.cpp
-	TerrainWindow.cpp
-	HumanoidWindow.cpp
-	GeneralWindow.cpp
-	ProfilerWindow.cpp
-	SpriteWindow.cpp
-	FontWindow.cpp
- 	VoxelGridWindow.cpp
-	ContentBrowserWindow.cpp
-	xatlas.cpp
-	EmbeddedResources.cpp
-)
+file(GLOB SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
+list(FILTER SOURCE_FILES EXCLUDE REGEX ${CMAKE_CURRENT_SOURCE_DIR}/main_.*)
+list(APPEND SOURCE_FILES main_${PLATFORM}.cpp)
+
 
 if (WIN32)
 	list (APPEND SOURCE_FILES

--- a/Template_Linux/CMakeLists.txt
+++ b/Template_Linux/CMakeLists.txt
@@ -11,9 +11,9 @@ if (${INSTALLED_ENGINE})
     find_package(WickedEngine REQUIRED)
 endif()
 
-set (SOURCE_FILES
+set(SOURCE_FILES
     main.cpp
-    stdafx.h    
+    stdafx.h
 )
 
 set(LIB_DXCOMPILER "libdxcompiler.so")

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-
-
 set (SOURCE_FILES
 	stdafx.cpp
 	Tests.cpp
@@ -16,7 +14,7 @@ if (WIN32)
 
 	add_executable(Tests WIN32 ${SOURCE_FILES})
 
-	target_link_libraries(Tests PUBLIC 
+	target_link_libraries(Tests PUBLIC
 		WickedEngine_Windows
 	)
 
@@ -28,7 +26,7 @@ else()
 
 	add_executable(Tests ${SOURCE_FILES})
 
-	target_link_libraries(Tests PUBLIC 
+	target_link_libraries(Tests PUBLIC
 		WickedEngine
 	)
 
@@ -38,7 +36,6 @@ endif ()
 if (MSVC)
 	set_property(TARGET Tests PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 endif ()
-
 
 # Copy content to build folder:
 add_custom_command(

--- a/WickedEngine/CMakeLists.txt
+++ b/WickedEngine/CMakeLists.txt
@@ -1,5 +1,6 @@
-set(MIN_OpenImageDenoise_VERSION "2.0")
+cmake_minimum_required(VERSION 3.12)
 
+set(MIN_OpenImageDenoise_VERSION "2.0")
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
@@ -55,189 +56,16 @@ add_compile_definitions(JPH_DEBUG_RENDERER=1)
 set(PHYSICS_REPO_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 include(${PHYSICS_REPO_ROOT}/Jolt/Jolt.cmake)
 
-set(HEADER_FILES
-		WickedEngine.h
-		CommonInclude.h
-		logo.h
-		sdl2.h
-		wiApplication.h
-		wiApplication_BindLua.h
-		wiArchive.h
-		wiArguments.h
-		wiAudio.h
-		wiAudio_BindLua.h
-		wiBacklog.h
-		wiBacklog_BindLua.h
-		wiCanvas.h
-		wiColor.h
-		wiECS.h
-		wiEmittedParticle.h
-		wiEnums.h
-		wiEventHandler.h
-		wiFadeManager.h
-		wiFFTGenerator.h
-		wiFont.h
-		wiGPUBVH.h
-		wiGPUSortLib.h
-		wiGraphics.h
-		wiGraphicsDevice.h
-		wiGraphicsDevice_DX12.h
-		wiGraphicsDevice_Vulkan.h
-		wiGUI.h
-		wiHairParticle.h
-		wiHelper.h
-		wiImage.h
-		wiImageParams_BindLua.h
-		wiInitializer.h
-		wiInput.h
-		wiInput_BindLua.h
-		wiJobSystem.h
-		wiLoadingScreen.h
-		wiLoadingScreen_BindLua.h
-		wiLua.h
-		wiLua_Globals.h
-		wiLuna.h
-		wiMath.h
-		wiMath_BindLua.h
-		wiNetwork.h
-		wiNetwork_BindLua.h
-		wiNoise.h
-		wiOcean.h
-		wiPhysics.h
-		wiPhysics_BindLua.h
-		wiPlatform.h
-		wiPrimitive.h
-		wiPrimitive_BindLua.h
-		wiProfiler.h
-		wiRandom.h
-		wiRawInput.h
-		wiRectPacker.h
-		wiRenderer.h
-		wiRenderer_BindLua.h
-		wiRenderPath.h
-		wiRenderPath2D.h
-		wiRenderPath2D_BindLua.h
-		wiRenderPath3D.h
-		wiRenderPath3D_BindLua.h
-		wiRenderPath3D_PathTracing.h
-		wiRenderPath_BindLua.h
-		wiResourceManager.h
-		wiScene.h
-		wiScene_BindLua.h
-		wiScene_Decl.h
-		wiScene_Components.h
-		wiSDLInput.h
-		wiShaderCompiler.h
-		wiSheenLUT.h
-		wiSpinLock.h
-		wiSprite.h
-		wiSprite_BindLua.h
-		wiSpriteAnim_BindLua.h
-		wiSpriteFont.h
-		wiSpriteFont_BindLua.h
-		wiTexture_BindLua.h
-		wiTextureHelper.h
-		wiTimer.h
-		wiUnorderedMap.h
-		wiUnorderedSet.h
-		wiVector.h
-		wiVersion.h
-		wiXInput.h
-		wiConfig.h
-		wiTerrain.h
-		wiAllocator.h
-		wiBVH.h
-		wiLocalization.h
-		wiVideo.h
-		wiVoxelGrid.h
-		wiPathQuery.h
- 		wiVoxelGrid_BindLua.h
-  		wiPathQuery_BindLua.h
-		wiTrailRenderer.h
-		wiTrailRenderer_BindLua.h
-		wiAsync_BindLua.h
-		)
+file(GLOB HEADER_FILES CONFIGURE_DEPENDS *.h)
+
+file(GLOB SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
+list(REMOVE_ITEM SOURCE_FILES offlineshadercompiler.cpp)
 
 add_library(${TARGET_NAME} ${WICKED_LIBRARY_TYPE}
-	wiLoadingScreen.cpp
-	wiLoadingScreen_BindLua.cpp
-	wiApplication.cpp
-	wiApplication_BindLua.cpp
-	wiRenderPath_BindLua.cpp
-	wiRenderPath2D.cpp
-	wiRenderPath2D_BindLua.cpp
-	wiRenderPath3D.cpp
-	wiRenderPath3D_BindLua.cpp
-	wiRenderPath3D_PathTracing.cpp
-	wiSpriteAnim_BindLua.cpp
-	wiTexture_BindLua.cpp
-	wiMath_BindLua.cpp
-	wiArchive.cpp
-	wiAudio.cpp
-	wiAudio_BindLua.cpp
-	wiBacklog.cpp
-	wiBacklog_BindLua.cpp
-	wiEmittedParticle.cpp
-	wiEventHandler.cpp
-	wiFadeManager.cpp
-	wiFFTGenerator.cpp
-	wiFont.cpp
-	wiGPUBVH.cpp
-	wiGPUSortLib.cpp
-	wiGraphicsDevice_DX12.cpp
-	wiGraphicsDevice_Vulkan.cpp
-	wiGUI.cpp
-	wiHairParticle.cpp
-	wiHelper.cpp
-	wiImage.cpp
-	wiImageParams_BindLua.cpp
-	wiInitializer.cpp
-	wiInput.cpp
-	wiInput_BindLua.cpp
-	wiPrimitive.cpp
-	wiPrimitive_BindLua.cpp
-	wiJobSystem.cpp
-	wiLua.cpp
-	wiMath.cpp
-	wiNetwork_BindLua.cpp
-	wiNetwork_Linux.cpp
-	wiNetwork_Windows.cpp
-	wiOcean.cpp
-	wiPhysics_Jolt.cpp
-	wiPhysics_BindLua.cpp
-	wiProfiler.cpp
-	wiRandom.cpp
-	wiRawInput.cpp
-	wiRenderer.cpp
-	wiRenderer_BindLua.cpp
-	wiResourceManager.cpp
-	wiScene.cpp
-	wiScene_Components.cpp
-	wiScene_BindLua.cpp
-	wiScene_Serializers.cpp
-	wiSDLInput.cpp
-	wiSprite.cpp
-	wiSprite_BindLua.cpp
-	wiSpriteFont.cpp
-	wiSpriteFont_BindLua.cpp
-	wiArguments.cpp
-	wiTextureHelper.cpp
-	wiVersion.cpp
-	wiXInput.cpp
-	wiShaderCompiler.cpp
-	wiConfig.cpp
-	wiTerrain.cpp
-	wiLocalization.cpp
-	wiVideo.cpp
-	wiVoxelGrid.cpp
-	wiPathQuery.cpp
- 	wiVoxelGrid_BindLua.cpp
-  	wiPathQuery_BindLua.cpp
-	wiTrailRenderer.cpp
-	wiTrailRenderer_BindLua.cpp
-	wiAsync_BindLua.cpp
+	${SOURCE_FILES}
 	${HEADER_FILES}
 )
+
 add_library(WickedEngine ALIAS ${TARGET_NAME})
 set_target_properties(${TARGET_NAME} PROPERTIES PUBLIC_HEADER "${HEADER_FILES}")
 

--- a/WickedEngine/LUA/CMakeLists.txt
+++ b/WickedEngine/LUA/CMakeLists.txt
@@ -1,66 +1,8 @@
-set(LUA_HEADERS
-    ${CMAKE_CURRENT_SOURCE_DIR}/lapi.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lauxlib.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lcode.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lctype.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/ldebug.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/ldo.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lfunc.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lgc.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/llex.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/llimits.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lmem.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lobject.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lopcodes.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lparser.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lprefix.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lstate.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lstring.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/ltable.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/ltm.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lua.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/luaconf.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lualib.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lundump.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lvm.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/lzio.h
-)
+file(GLOB LUA_HEADERS CONFIGURE_DEPENDS *.h)
+file(GLOB LUA_SOURCES CONFIGURE_DEPENDS *.c)
 
 add_library(LUA STATIC
-    lapi.c
-    lauxlib.c
-    lbaselib.c
-    lbitlib.c
-    lcode.c
-    lcorolib.c
-    lctype.c
-    ldblib.c
-    ldebug.c
-    ldo.c
-    ldump.c
-    lfunc.c
-    lgc.c
-    linit.c
-    liolib.c
-    llex.c
-    lmathlib.c
-    lmem.c
-    loadlib.c
-    lobject.c
-    lopcodes.c
-    loslib.c
-    lparser.c
-    lstate.c
-    lstring.c
-    lstrlib.c
-    ltable.c
-    ltablib.c
-    ltm.c
-    lua.c
-    lundump.c
-    lutf8lib.c
-    lvm.c
-    lzio.c
+    ${LUA_SOURCES}
     ${LUA_HEADERS}
 )
 

--- a/WickedEngine/Utility/CMakeLists.txt
+++ b/WickedEngine/Utility/CMakeLists.txt
@@ -1,155 +1,57 @@
+cmake_minimum_required(VERSION 3.12)
+
 include(GNUInstallDirs)
 if (PLATFORM MATCHES "SDL2")
 	add_subdirectory(FAudio)
 endif()
 
-set(HEADER_FILES
-		${CMAKE_CURRENT_SOURCE_DIR}/DirectXCollision.h
-		${CMAKE_CURRENT_SOURCE_DIR}/DirectXColors.h
-		${CMAKE_CURRENT_SOURCE_DIR}/DirectXMath.h
-		${CMAKE_CURRENT_SOURCE_DIR}/DirectXMathCommon.h
-		${CMAKE_CURRENT_SOURCE_DIR}/DirectXPackedVector.h
-		${CMAKE_CURRENT_SOURCE_DIR}/DirectXCollision.inl
-		${CMAKE_CURRENT_SOURCE_DIR}/DirectXMathConvert.inl
-		${CMAKE_CURRENT_SOURCE_DIR}/DirectXMathMatrix.inl
-		${CMAKE_CURRENT_SOURCE_DIR}/DirectXMathMisc.inl
-		${CMAKE_CURRENT_SOURCE_DIR}/DirectXMathVector.inl
-		${CMAKE_CURRENT_SOURCE_DIR}/DirectXPackedVector.inl
-		${CMAKE_CURRENT_SOURCE_DIR}/liberation_sans.h
-		${CMAKE_CURRENT_SOURCE_DIR}/portable-file-dialogs.h
-		${CMAKE_CURRENT_SOURCE_DIR}/sal.h
-		${CMAKE_CURRENT_SOURCE_DIR}/robin_hood.h
-		${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.h
-		${CMAKE_CURRENT_SOURCE_DIR}/stb_image.h
-		${CMAKE_CURRENT_SOURCE_DIR}/stb_image_write.h
-		${CMAKE_CURRENT_SOURCE_DIR}/stb_rect_pack.h
-		${CMAKE_CURRENT_SOURCE_DIR}/stb_truetype.h
-		${CMAKE_CURRENT_SOURCE_DIR}/qoi.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dxcapi.h
-		${CMAKE_CURRENT_SOURCE_DIR}/WinAdapter.h
-		${CMAKE_CURRENT_SOURCE_DIR}/D3D12MemAlloc.h
-		${CMAKE_CURRENT_SOURCE_DIR}/volk.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vk_mem_alloc.h
-		${CMAKE_CURRENT_SOURCE_DIR}/flat_hash_map.hpp
-		${CMAKE_CURRENT_SOURCE_DIR}/pugixml.hpp
-		${CMAKE_CURRENT_SOURCE_DIR}/pugiconfig.hpp
-		${CMAKE_CURRENT_SOURCE_DIR}/h264.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dds.h
-		${CMAKE_CURRENT_SOURCE_DIR}/lodepng.h
-		${CMAKE_CURRENT_SOURCE_DIR}/meshoptimizer/meshoptimizer.h
-		)
-install(FILES ${HEADER_FILES}
-		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/WickedEngine/Utility/")
-
-set(HEADER_FILES_dx12
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3d12.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3d12compatibility.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3d12sdklayers.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3dcommon.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/dxgicommon.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/dxgiformat.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3d12shader.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3d12video.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3dx12.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3dx12_barriers.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3dx12_check_feature_support.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3dx12_core.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3dx12_default.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3dx12_pipeline_state_stream.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3dx12_render_pass.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3dx12_resource_helpers.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3dx12_root_signature.h
-		${CMAKE_CURRENT_SOURCE_DIR}/dx12/d3dx12_state_object.h
-		)
-install(FILES ${HEADER_FILES_dx12}
-		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/WickedEngine/Utility/dx12")
-
-set(HEADER_FILES_spirv
-		${CMAKE_CURRENT_SOURCE_DIR}/include/spirv/unified1/spirv.h
-		)
-install(FILES ${HEADER_FILES_spirv}
-		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/WickedEngine/Utility/include/spirv/unified1/")
-
-set(HEADER_FILES_vulkan
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vk_layer.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_directfb.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_ggp.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_ios.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_macos.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_metal.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_screen.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_vi.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_wayland.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_win32.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_xcb.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_xlib.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_xlib_xrandr.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vk_icd.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vk_platform.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_android.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_beta.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_core.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan_fuchsia.h
-		)
-install(FILES ${HEADER_FILES_vulkan}
-		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/WickedEngine/Utility/vulkan/")
-
-		
-set(HEADER_FILES_vk_video
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vk_video/vulkan_video_codec_h264std.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vk_video/vulkan_video_codec_h264std_decode.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vk_video/vulkan_video_codec_h264std_encode.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vk_video/vulkan_video_codec_h265std.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vk_video/vulkan_video_codec_h265std_decode.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vk_video/vulkan_video_codec_h265std_encode.h
-		${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vk_video/vulkan_video_codecs_common.h
-		)
-install(FILES ${HEADER_FILES_vulkan}
-		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/WickedEngine/Utility/vulkan/vk_video/")
-
-
-set (SOURCE_FILES
-	utility_common.cpp
-	spirv_reflect.c
-	stb_vorbis.c
-	samplerBlueNoiseErrorDistribution_128x128_OptimizedFor_2d2d2d2d_1spp.cpp
-	pugixml.cpp
-	lodepng.cpp
-	meshoptimizer/allocator.cpp
-	meshoptimizer/clusterizer.cpp
-	meshoptimizer/indexcodec.cpp
-	meshoptimizer/indexgenerator.cpp
-	meshoptimizer/overdrawanalyzer.cpp
-	meshoptimizer/overdrawoptimizer.cpp
-	meshoptimizer/simplifier.cpp
-	meshoptimizer/spatialorder.cpp
-	meshoptimizer/stripifier.cpp
-	meshoptimizer/vcacheanalyzer.cpp
-	meshoptimizer/vcacheoptimizer.cpp
-	meshoptimizer/vertexcodec.cpp
-	meshoptimizer/vertexfilter.cpp
-	meshoptimizer/vfetchanalyzer.cpp
-	meshoptimizer/vfetchoptimizer.cpp
+file(GLOB_RECURSE HEADER_FILES CONFIGURE_DEPENDS
+	*.h
+	*.hpp
+	*.inl
+)
+file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS
+	*.c
+	*.cpp
 )
 
-if (WIN32)
-	list (APPEND SOURCE_FILES
-		D3D12MemAlloc.cpp
-	)
-endif ()
+# FAudio has their own CMakeLists
+list(FILTER HEADER_FILES
+	EXCLUDE REGEX ${CMAKE_CURRENT_SOURCE_DIR}/FAudio/.*
+)
+list(FILTER SOURCE_FILES
+	EXCLUDE REGEX ${CMAKE_CURRENT_SOURCE_DIR}/FAudio/.*
+)
 
+install(FILES ${HEADER_FILES}
+	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/WickedEngine/Utility/")
+
+# some *.cpp and *.c files are included by other files,
+# so they are not source files that should be
+# compiled on their own; hence we mark them as header files
+file(GLOB_RECURSE DIRECTLY_INCLUDED_FILES CONFIGURE_DEPENDS
+	# included by utility_common.cpp
+	basis_universal/*.cpp
+	basis_universal/*.c
+	mikktspace.c
+
+	# included by volk.h
+	volk.c
+)
+set_property(
+	SOURCE ${DIRECTLY_INCLUDED_FILES}
+	PROPERTY HEADER_FILE_ONLY ON
+)
+
+if (NOT WIN32)
+	list(REMOVE_ITEM SOURCE_FILES
+		${CMAKE_CURRENT_SOURCE_DIR}/D3D12MemAlloc.cpp
+	)
+endif()
 add_library(Utility STATIC
-		${SOURCE_FILES}
-		${HEADER_FILES}
-		${HEADER_FILES_dx12}
-		${HEADER_FILES_dxc}
-		${HEADER_FILES_encoder}
-		${HEADER_FILES_transcoder}
-		${HEADER_FILES_spirv}
-		${HEADER_FILES_vulkan}
-		${HEADER_FILES_zstd}
-		)
+	${SOURCE_FILES}
+	${HEADER_FILES}
+)
 
 set_target_properties("Utility" PROPERTIES
 	FOLDER "ThirdParty"

--- a/WickedEngine/Utility/FAudio/CMakeLists.txt
+++ b/WickedEngine/Utility/FAudio/CMakeLists.txt
@@ -1,18 +1,14 @@
 # CMake Project for FAudio
 # Written by @NeroBurner
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(FAudio C)
 
 # Options
 option(BUILD_SHARED_LIBS "Build shared library" OFF)
 
 # C99 Requirement
-if(${CMAKE_VERSION} VERSION_LESS "3.1.3")
-	message(WARNING "Your CMake version is too old, set -std=c99 yourself!")
-else()
-	set(CMAKE_C_STANDARD 99)
-	set(CMAKE_C_EXTENSIONS OFF)
-endif()
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_EXTENSIONS OFF)
 
 # Version
 SET(LIB_MAJOR_VERSION "0")


### PR DESCRIPTION
This PR is due to a recent discussion in Discord. I'm in two minds about this one. It prevents the problem of missing *.cpp files in the CMakeLists, and makes it a bit clearer which files are used for what (especially the Utility folder had a nice gotcha that wasn't obvious from the old CMakeLists), but it is also recommended against by the CMake team, however, I think the problem they mention is currently more theoretical.

Note that keeping CMakeLists.txt in the Template folder as-is is intentional: there's a edge case when a *.c file is listed in the root directory, so to prevent people from ever falling into that trap, and to follow CMake recommendation to not use globs, I've left it as it. If people want, they can always modify the cmakefile in their program based on the template. 

-------

CMake recommends against doing this because some build systems might not support CONFIGURE_DEPENDS. But currently, the ones we care about (Make, Ninja) do, and if there's ever a problem, we can just start listing them again.

Using globs has the advantage that the linux build will not break when a file is added in VS and somebody forgets to add the file to cmakelists as well. I've also found some instances were some *.h files were not listed, which means they weren't copied when installing.