### PR TITLE
use ccache on linux builds

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -46,16 +46,23 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.run_id }}
+        restore-keys: ccache
+        save-always: true
+
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install libsdl2-dev
+        sudo apt install libsdl2-dev ccache
 
     - name: Build
       run: |
         mkdir build
         cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j$(nproc)
         echo "---Generating Shader Dump---"
         cd WickedEngine

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -43,18 +43,25 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.run_id }}
+        restore-keys: ccache
+        save-always: true
+
     - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install libsdl2-dev
+        sudo apt install libsdl2-dev ccache
 
     - name: Build
       run: |
         mkdir build
         cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j$(nproc)
         echo "---Generating Shader Dump---"
         cd WickedEngine

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,18 +44,26 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
+
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.run_id }}
+        restore-keys: ccache
+        save-always: true
+
     - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install libsdl2-dev
+        sudo apt install libsdl2-dev ccache
 
     - name: Build
       run: |
         mkdir build
         cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j$(nproc)
         echo "---Generating Shader Dump---"
         cd WickedEngine


### PR DESCRIPTION
While debugging the failing linux build on my cmake pull request, the long build time for linux became annoying.

This PR changes the linux build targets on linux to cache the results using ccache and github's cache action; the effects are significant, in my tests, the build time went from 25m to 9m for the very first build (because the rebuild after compiling shaders can already use it) and just over 3m for a small change that didn't affect many files.

ccache also exists in a windows version for MSVC, but it's not officially supported, so I skipped it for the windows build for now, but I'm open to experiment with it if there's interest.

Another optimization could be cache of the compiled shaders, but I'm not 100% sure what actually can change the output apart from the shader files themselves, offlineshadercompiler.cpp and dxcompiler/dxil, so I didn't add it for now. It's certainly doable, if there's interest, though.

For context: ccache is a mature compiler cache that guarantees the results for any given command line and contents of source files will be the same as if the compiler was called directly. I've been using it in the past for various projects as well as for my local wicked builds on my laptop without any problems.