### PR TITLE
actions: don't use ccache direct mode

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -63,14 +63,14 @@ jobs:
         mkdir build
         cd build
         cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        make -j$(nproc)
+        CCACHE_NODIRECT=1 make -j$(nproc)
         echo "---Generating Shader Dump---"
         cd WickedEngine
         ./offlineshadercompiler spirv rebuild shaderdump
         mv wiShaderDump.h ../../WickedEngine/
         cd ..
         echo "---Rebuilding with ShaderDump---"
-        make -B -j $(nproc)
+        CCACHE_NODIRECT=1 make -B -j $(nproc)
         
     - name: Move files
       run: |

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -62,14 +62,14 @@ jobs:
         mkdir build
         cd build
         cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        make -j$(nproc)
+        CCACHE_NODIRECT=1 make -j$(nproc)
         echo "---Generating Shader Dump---"
         cd WickedEngine
         ./offlineshadercompiler spirv rebuild shaderdump
         mv wiShaderDump.h ../../WickedEngine/
         cd ..
         echo "---Rebuilding with ShaderDump---"
-        make -B -j $(nproc)
+        CCACHE_NODIRECT=1 make -B -j $(nproc)
 
         
     - name: Move binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,14 +64,14 @@ jobs:
         mkdir build
         cd build
         cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        make -j$(nproc)
+        CCACHE_NODIRECT=1 make -j$(nproc)
         echo "---Generating Shader Dump---"
         cd WickedEngine
         ./offlineshadercompiler spirv rebuild shaderdump
         mv wiShaderDump.h ../../WickedEngine/
         cd ..
         echo "---Rebuilding with ShaderDump---"
-        make -B -j $(nproc)
+        CCACHE_NODIRECT=1 make -B -j $(nproc)
 
         
     - name: Move files


### PR DESCRIPTION
Conditional inclusion based on what files are available is the one edge case that doesn't work in direct mode.

I thought that using globs in cmake would make ccache realize the files have changed, but header files are not listed in the command line, so it has no way of knowing. And indeed it caused the shaders to not be compiled in. whoops.

So force it to use the slower mode (running the preprocessor each time to find out what changed). It should still be much faster than not using ccache at all