### PR TITLE
Fixed: Cmake doesnt include Windows Template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,9 @@ option(WICKED_IMGUI_EXAMPLE "Build WickedEngine imgui example" ON)
 include(CMakeDependentOption)
 
 if(UNIX)
-    cmake_dependent_option(WICKED_LINUX_TEMPLATE "Build WickedEngine Linux template" ON)
+    option(WICKED_LINUX_TEMPLATE "Build WickedEngine Linux template" ON)
 elseif(WIN32)
-    cmake_dependent_option(WICKED_WINDOWS_TEMPLATE "Build WickedEngine Windows template" ON)
+    option(WICKED_WINDOWS_TEMPLATE "Build WickedEngine Windows template" ON)
 endif()
 
 # Configure CMake global variables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,12 @@ option(WICKED_TESTS "Build WickedEngine tests" ON)
 option(WICKED_IMGUI_EXAMPLE "Build WickedEngine imgui example" ON)
 
 include(CMakeDependentOption)
-cmake_dependent_option(WICKED_LINUX_TEMPLATE "Build WickedEngine Linux template" ON "UNIX" OFF)
+
+if(UNIX)
+    cmake_dependent_option(WICKED_LINUX_TEMPLATE "Build WickedEngine Linux template" ON)
+elseif(WIN32)
+    cmake_dependent_option(WICKED_WINDOWS_TEMPLATE "Build WickedEngine Windows template" ON)
+endif()
 
 # Configure CMake global variables
 set(CMAKE_CXX_STANDARD 17)
@@ -64,4 +69,8 @@ endif()
 
 if (WICKED_LINUX_TEMPLATE)
     add_subdirectory(Template_Linux)
+endif()
+
+if (WICKED_WINDOWS_TEMPLATE)
+    add_subdirectory(Template_Windows)
 endif()

--- a/Template_Windows/CMakeLists.txt
+++ b/Template_Windows/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.8)
+project(Template_Windows)
+
+file(GLOB SOURCE_FILES CONFIGURE_DEPENDS "*.cpp" "*.h")
+
+set(LIB_DXCOMPILER "libdxcompiler.dll")
+
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+    # These are cmake generator expressions. They seem more dauting than they are
+    # Basically if the variable is ON it will give WickedEngine,
+    # if it's off, it will give WickedEngine::WickedEngine
+    $<$<NOT:$<BOOL:${INSTALLED_ENGINE}>>:WickedEngine>
+    $<$<BOOL:${INSTALLED_ENGINE}>:WickedEngine::WickedEngine>
+)
+
+
+set(LIBDXCOMPILER_PATH "${WICKED_ROOT_DIR}/WickedEngine/${LIB_DXCOMPILER}")
+set(STARTUP_LUA "${WICKED_ROOT_DIR}/Editor/startup.lua")
+message("libdxcompiler found at ${LIBDXCOMPILER_PATH}")
+message("startup lua found at ${STARTUP_LUA}")
+
+# this may not work on windows
+add_custom_command(
+    TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LIBDXCOMPILER_PATH} ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${STARTUP_LUA} ${CMAKE_CURRENT_BINARY_DIR}/startup.lua
+)


### PR DESCRIPTION
The cmake version of wicked engine doesnt include the template but with this fix it does 