### PR TITLE
cmake: don't depend on a 3.26+ command

### DIFF
--- a/Content/CMakeLists.txt
+++ b/Content/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 add_custom_target(Content
-    COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
         ${WICKED_ROOT_DIR}/Content
 
         ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
I accidentially used a CMake 3.26+ only command. In my defense, "copy", "copy_directory", and "copy_if_different" were all introduced in 3.5, but "copy_directory_if_different" wasn't

Copying the content directory doesn't take that long, so requiring 3.26 doesn't seem to be worth it at the time. So just replace it with copy_directory