### PR TITLE
cmake: use copy_directory_if_different if available

### DIFF
--- a/Content/CMakeLists.txt
+++ b/Content/CMakeLists.txt
@@ -1,10 +1,15 @@
 cmake_minimum_required(VERSION 3.12)
+
+if(CMAKE_VERSION VERSION_LESS "3.26.0")
+  set(COPY_DIR_CMD copy_directory)
+else()
+  set(COPY_DIR_CMD copy_directory_if_different)
+endif()
+
 add_custom_target(Content
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    COMMAND ${CMAKE_COMMAND} -E ${COPY_DIR_CMD}
         ${WICKED_ROOT_DIR}/Content
-
         ${CMAKE_CURRENT_BINARY_DIR}
-
     COMMENT "Copying Content"
     VERBATIM
 )


### PR DESCRIPTION
After a discussion with Matteo, we decided it's better to use if_different on CMake 3.26+ and just copy_directory on previous versions. It seems to copy less files each run, so it's good to use it if available.