### PR TITLE
Avoid calling backlog when Home key is pressed in TextInputField

### DIFF
--- a/Editor/AnimationWindow.cpp
+++ b/Editor/AnimationWindow.cpp
@@ -29,7 +29,6 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	float wid = 200;
 	float step = hei + 4;
 	float padding = 4;
-	float lastDirection = 1;
 
 	infoLabel.Create("");
 	infoLabel.SetSize(XMFLOAT2(100, 50));
@@ -224,7 +223,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 		if (animation != nullptr)
 		{
 			// Adjusts the new animation speed based on the previous direction of animation->speed.
-			lastDirection = std::signbit(animation->speed) ? -1 : 1;
+			float lastDirection = std::signbit(animation->speed) ? -1.0f : 1.0f;
 			animation->speed = args.fValue * lastDirection;
 		}
 	});

--- a/WickedEngine/wiBacklog.cpp
+++ b/WickedEngine/wiBacklog.cpp
@@ -42,6 +42,7 @@ namespace wi::backlog
 	bool refitscroll = false;
 	wi::gui::TextInputField inputField;
 	wi::gui::Button toggleButton;
+	wi::gui::GUI GUI;
 
 	bool locked = false;
 	bool blockLuaExec = false;
@@ -87,7 +88,7 @@ namespace wi::backlog
 	{
 		if (!locked)
 		{
-			if (wi::input::Press(wi::input::KEYBOARD_BUTTON_HOME))
+			if (wi::input::Press(wi::input::KEYBOARD_BUTTON_HOME) && !GUI.IsTyping())
 			{
 				Toggle();
 			}

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -1467,7 +1467,6 @@ namespace wi::gui
 			if (state == DEACTIVATING)
 			{
 				state = IDLE;
-				typing_active = false;
 			}
 
 			// hover the button
@@ -1501,8 +1500,8 @@ namespace wi::gui
 						args.fValue = (float)atof(args.sValue.c_str());
 						onInputAccepted(args);
 					}
-
 					Deactivate();
+					typing_active = false;
 				}
 				//else if (wi::input::Press(wi::input::KEYBOARD_BUTTON_BACKSPACE))
 				//{
@@ -1539,6 +1538,7 @@ namespace wi::gui
 					// cancel input
 					font_input.text.clear();
 					Deactivate();
+					typing_active = false;
 				}
 				else if (wi::input::Down(wi::input::MOUSE_BUTTON_LEFT))
 				{
@@ -4879,7 +4879,7 @@ namespace wi::gui
 
 			float vscale = scale.y;
 			Hitbox2D bottomhitbox = Hitbox2D(XMFLOAT2(translation.x, translation.y + vscale), XMFLOAT2(scale.x, resizehitboxwidth));
-			
+
 			if (resize_state == RESIZE_STATE_NONE && wi::input::Press(wi::input::MOUSE_BUTTON_LEFT))
 			{
 				if (pointerHitbox.intersects(bottomhitbox))
@@ -5131,7 +5131,7 @@ namespace wi::gui
 			// hitboxes are recomputed because window transform might have changed since update!!
 			float vscale = scale.y;
 			Hitbox2D bottomhitbox = Hitbox2D(XMFLOAT2(translation.x, translation.y + vscale), XMFLOAT2(scale.x, resizehitboxwidth));
-			
+
 			const Hitbox2D pointerHitbox = GetPointerHitbox(false);
 
 			wi::image::Params fx = sprites[state].params;


### PR DESCRIPTION
- Added functionality to prevent calling the backlog when the Home key is pressed while typing in the TextField. The hotkeys could be called even while typing in the TextInputField. I found out that the following part from TextInputField::Update was causing this

			if (state == DEACTIVATING)
			{
				state = IDLE;
				typing_active = false;
			}

  So, I moved typing_active = false closer to the two lines calling Deactivate() in TextInputField::Update().
- Using explicit conversion when calling std::signbit() in AnimationWindow::speedSlider::OnSlide() to resolve the warning during compilation.
- Moved AnimationWindow::lastDirection to local scope within AnimationWindow::speedSlider::OnSlide(), as it is only used there.