### PR TITLE
Prevent delete key from removing an entity when TextInputField is active

### DIFF
--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -4977,7 +4977,7 @@ namespace wi::gui
 				clicked = true;
 			}
 
-			if (onDelete && state == FOCUS && wi::input::Press(wi::input::KEYBOARD_BUTTON_DELETE))
+			if (onDelete && state == FOCUS && wi::input::Press(wi::input::KEYBOARD_BUTTON_DELETE) && !typing_active)
 			{
 				int index = 0;
 				for (auto& item : items)


### PR DESCRIPTION
It is similar to https://github.com/turanszkij/WickedEngine/issues/901. Fixed an issue where pressing the delete key would remove an entity if the mouse was hovering over the entity tree list, instead of deleting a character in the TextInputField.