### PR TITLE
fix SDL_Init check

### DIFF
--- a/Editor/main_SDL2.cpp
+++ b/Editor/main_SDL2.cpp
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
     wi::arguments::Parse(argc, argv);
 
     sdl2::sdlsystem_ptr_t system = sdl2::make_sdlsystem(SDL_INIT_EVERYTHING | SDL_INIT_EVENTS);
-    if (!system) {
+    if (*system) {
         throw sdl2::SDLError("Error creating SDL2 system");
     }
 

--- a/Example_ImGui/main_SDL2.cpp
+++ b/Example_ImGui/main_SDL2.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
     wi::arguments::Parse(argc, argv);
 
     sdl2::sdlsystem_ptr_t system = sdl2::make_sdlsystem(SDL_INIT_EVERYTHING | SDL_INIT_EVENTS);
-    if (!system) {
+    if (*system) {
         throw sdl2::SDLError("Error creating SDL2 system");
     }
 

--- a/Example_ImGui_Docking/main_SDL2.cpp
+++ b/Example_ImGui_Docking/main_SDL2.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
     wi::arguments::Parse(argc, argv);
 
     sdl2::sdlsystem_ptr_t system = sdl2::make_sdlsystem(SDL_INIT_EVERYTHING | SDL_INIT_EVENTS);
-    if (!system) {
+    if (*system) {
         throw sdl2::SDLError("Error creating SDL2 system");
     }
 

--- a/Tests/main_SDL2.cpp
+++ b/Tests/main_SDL2.cpp
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
     wi::arguments::Parse(argc, argv);
 
     sdl2::sdlsystem_ptr_t system = sdl2::make_sdlsystem(SDL_INIT_EVERYTHING | SDL_INIT_EVENTS);
-    if (!system) {
+    if (*system) {
         throw sdl2::SDLError("Error creating SDL2 system");
     }
 


### PR DESCRIPTION
make_sdlsystem always returns a valid int pointer containing the result of SDL_Init. SDL_Init is 0 on success, and a negative int on failure.