### PR TITLE
fix calculation bug

### DIFF
--- a/WickedEngine/wiHelper.cpp
+++ b/WickedEngine/wiHelper.cpp
@@ -1501,11 +1501,11 @@ namespace wi::helper
 		}
 		else if (timerSeconds < 60 * 60)
 		{
-			ss << timerSeconds * 60 << " min";
+			ss << timerSeconds / 60 << " min";
 		}
 		else
 		{
-			ss << timerSeconds * 60 * 60 << " hours";
+			ss << timerSeconds / 60 / 60 << " hours";
 		}
 		return ss.str();
 	}


### PR DESCRIPTION
1 minute would be shown as 3600 min, similar for hours