### PR TITLE
Work around GCC "maybe uninitialized" warning

### DIFF
--- a/WickedEngine/wiScene_Serializers.cpp
+++ b/WickedEngine/wiScene_Serializers.cpp
@@ -874,9 +874,7 @@ namespace wi::scene
 			boneCollection.resize(boneCount);
 			for (size_t i = 0; i < boneCount; ++i)
 			{
-				Entity boneID;
-				SerializeEntity(archive, boneID, seri);
-				boneCollection[i] = boneID;
+				SerializeEntity(archive, boneCollection[i], seri);
 			}
 
 			archive >> inverseBindMatrices;


### PR DESCRIPTION
GCC 14.2 can't tell that SerializeEntity will initialize it, so disable the warning, otherwise it will fail the build if -Werror is active (which is the case for CMake atm)

Fixes #916