### PR TITLE
Fix wi::scene::LoadModel returning the wrong entity

### DIFF
--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -6982,7 +6982,7 @@ namespace wi::scene
 	void LoadModel2(const std::string& fileName, const XMMATRIX& transformMatrix, Entity rootEntity)
 	{
 		Scene scene;
-		LoadModel(scene, fileName, transformMatrix, rootEntity);
+		LoadModel2(scene, fileName, transformMatrix, rootEntity);
 		GetScene().Merge(scene);
 	}
 

--- a/WickedEngine/wiScene.h
+++ b/WickedEngine/wiScene.h
@@ -318,6 +318,7 @@ namespace wi::scene
 		virtual void Clear();
 		// Merge an other scene into this.
 		//	The contents of the other scene will be lost (and moved to this)!
+		//  Any references to entities or components from the other scene will now reference them in this scene.
 		virtual void Merge(Scene& other);
 		// Similar to merge but skipping some things that are safe to skip within the Update look
 		void MergeFastInternal(Scene& other);


### PR DESCRIPTION
Fixed a bug caused by a typo in the `LoadModel` function call. The issue occurred because LoadModel(scene, fileName, transformMatrix, rootEntity) was mistakenly called instead of LoadModel2(scene, fileName, transformMatrix, rootEntity). The compiler did not catch this mistake because the last parameter of LoadModel is a boolean, and rootEntity was incorrectly used to satisfy that parameter.

I was using the code below (teapot tutorial) to debug this, focusing mainly on the `testBool` and `testBool2` variables:

```
    class MyRender : public wi::RenderPath3D
    {
        private:
            wi::Sprite sprite;
            wi::SpriteFont font;
            wi::ecs::Entity entity;

        public:
            MyRender()
            {
                sprite = wi::Sprite("../Content/logo_small.png");
                sprite.params.pos = XMFLOAT3(100, 100, 0);
                sprite.params.siz = XMFLOAT2(256, 256);
                sprite.anim.wobbleAnim.amount = XMFLOAT2(0.5f, .5f);
                AddSprite(&sprite);

                font.SetText("Hello World");
                font.params.posX = 100;
                font.params.posY = sprite.params.pos.y + sprite.params.siz.y;
                font.params.size = 87;
                font.anim.typewriter.time = 3.0f;
                AddFont(&font);

                entity = wi::scene::LoadModel("../Content/models/teapot.wiscene", XMMatrixTranslation(0, 0, 20.0f), true);

            }

        void Update(float dt) override
        {
            using namespace wi::scene;

            TransformComponent* transform = GetScene().transforms.GetComponent(entity);
            // TransformComponent* transform = GetScene().transforms.GetComponent(2);

            bool testBool = wi::scene::GetScene().transforms.Contains(entity);
            bool testBool2 = wi::scene::GetScene().transforms.Contains(2);

            if (transform != nullptr)
            {
                transform->RotateRollPitchYaw(XMFLOAT3(0, 0.1f, 0));
            }

            wi::RenderPath3D::Update(dt);
        }

    };
```