### PR TITLE
flush debug output streams immediately

### DIFF
--- a/WickedEngine/wiHelper.cpp
+++ b/WickedEngine/wiHelper.cpp
@@ -1388,12 +1388,15 @@ namespace wi::helper
 		default:
 		case DebugLevel::Normal:
 			std::cout << str;
+			std::flush(std::cout);
 			break;
 		case DebugLevel::Warning:
 			std::clog << str;
+			std::flush(std::clog);
 			break;
 		case DebugLevel::Error:
 			std::cerr << str;
+			std::flush(std::cerr);
 			break;
 	}
 #endif // _WIN32


### PR DESCRIPTION
using std::flush ensures debug logging even in case of unexpected termination:

"This manipulator may be used to produce an incomplete line of output immediately, e.g. when displaying output from a long-running process, logging activity of multiple threads or logging activity of a program that may crash unexpectedly."

https://en.cppreference.com/w/cpp/io/manip/flush