### PR TITLE
fix: prevent crash when folder name does not contain slashes

### DIFF
--- a/Editor/ContentBrowserWindow.cpp
+++ b/Editor/ContentBrowserWindow.cpp
@@ -213,7 +213,11 @@ void ContentBrowserWindow::RefreshContent()
 		{
 			folder.pop_back();
 		}
-		folder = folder.substr(folder.find_last_of("/\\"));
+		
+		auto last_slash = folder.find_last_of("/\\");
+		if (last_slash != folder.npos) {
+			folder = folder.substr(last_slash);
+		}
 		button.Create(folder);
 		button.SetTooltip(editor->recentFolders[editor->recentFolders.size() - 1 - i]); // full folder name!
 		button.SetLocalizationEnabled(false);


### PR DESCRIPTION
This can happen on Windows when the file is loaded from the root of drive, eg. "E:/"