### PR TITLE
reset profiler on test change

### DIFF
--- a/Samples/Tests/Tests.cpp
+++ b/Samples/Tests/Tests.cpp
@@ -164,6 +164,7 @@ void TestsRenderer::Load()
 
 		// Reset all state that tests might have modified:
 		wi::eventhandler::SetVSync(true);
+        wi::profiler::SetEnabled(false);
 		wi::renderer::SetToDrawGridHelper(false);
 		wi::renderer::SetTemporalAAEnabled(false);
 		wi::renderer::ClearWorld(wi::scene::GetScene());


### PR DESCRIPTION
Set wi::profiler::SetEnabled(false) on test change of Samples/Tests build target so it gets disabled again after enabling it on 65k instance test.