### PR TITLE
copy imgui docking example fonts to build dir

### DIFF
--- a/Samples/Example_ImGui_Docking/CMakeLists.txt
+++ b/Samples/Example_ImGui_Docking/CMakeLists.txt
@@ -53,11 +53,13 @@ else()
 		Threads::Threads
 	)
 
-	# Copy shaders to build and source folders just to be safe:
+	# Copy shaders and font to build and source folders just to be safe:
 	add_custom_command(
 		TARGET Example_ImGui_Docking POST_BUILD
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/ImGuiPS.hlsl ${CMAKE_CURRENT_BINARY_DIR}
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/ImGuiVS.hlsl ${CMAKE_CURRENT_BINARY_DIR}
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Roboto-Medium.ttf ${CMAKE_CURRENT_BINARY_DIR}
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/MaterialIcons-Regular.ttf ${CMAKE_CURRENT_BINARY_DIR}
 	)
 
 	set(LIB_DXCOMPILER "libdxcompiler.so")


### PR DESCRIPTION
Roboto-Medium.ttf expected in current/search directory: 
[https://github.com/turanszkij/WickedEngine/blob/
0a21fb5c612b161358d94c88edfe083f42006d6b/Samples/Example_ImGui_Docking/Example_ImGui_Docking.cpp#L171](https://github.com/turanszkij/WickedEngine/blob/0a21fb5c612b161358d94c88edfe083f42006d6b/Samples/Example_ImGui_Docking/Example_ImGui_Docking.cpp#L171)

FONT_ICON_FILE_NAME_MD defined as "MaterialIcons-Regular.ttf" expected in current/search directory:
[https://github.com/turanszkij/WickedEngine/blob/
0a21fb5c612b161358d94c88edfe083f42006d6b/Samples/Example_ImGui_Docking/Example_ImGui_Docking.cpp#L1605](https://github.com/turanszkij/WickedEngine/blob/0a21fb5c612b161358d94c88edfe083f42006d6b/Samples/Example_ImGui_Docking/Example_ImGui_Docking.cpp#L1605)

without these fonts present, debug build of Example_ImGui_Docking fails asserts:
[https://github.com/turanszkij/WickedEngine/blob/
0a21fb5c612b161358d94c88edfe083f42006d6b/Samples/Example_ImGui_Docking/ ImGui/imgui_draw.cpp#L2151](https://github.com/turanszkij/WickedEngine/blob/0a21fb5c612b161358d94c88edfe083f42006d6b/Samples/Example_ImGui_Docking/ImGui/imgui_draw.cpp#L2151)

Not sure if this is the desired solution, but this allows debug build of Example_ImGui_Docking to run without failing asserts on start.