### PR TITLE
get rid of compiler warning

### DIFF
--- a/Editor/ContentBrowserWindow.h
+++ b/Editor/ContentBrowserWindow.h
@@ -32,7 +32,7 @@ public:
 	void AddItems(const std::string& folder, const std::string& extension, const std::string& icon);
 	void AddItem(const std::string& filename, const std::string& icon);
 
-	void Update(const wi::Canvas& canvas, float dt);
+	void Update(const wi::Canvas& canvas, float dt) override;
 	void Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const override;
 	void ResizeLayout() override;
 };


### PR DESCRIPTION
clang 14 is unhappy about inconsistent override (Window has it, ContentBrowserWindow doesn't) 