### PR TITLE
Fix IMGUI Demo with HDR10

### DIFF
--- a/Samples/Example_ImGui_Docking/Example_ImGui_Docking.cpp
+++ b/Samples/Example_ImGui_Docking/Example_ImGui_Docking.cpp
@@ -347,6 +347,17 @@ void Example_ImGui::Compose(wi::graphics::CommandList cmd)
 		vertexOffset += drawList->VtxBuffer.size();
 	}
 
+	// Restore Scissor
+	{
+		Rect scissor;
+		scissor.left = 0;
+		scissor.top = 0;
+		scissor.right = (int32_t)viewport.width;
+		scissor.bottom = (int32_t)viewport.height;
+		device->BindScissorRects(1, &scissor, cmd);
+
+	}
+
 	//// Update and Render additional Platform Windows
 	//if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
 	//{


### PR DESCRIPTION
When using HDR10, a normalization pass must run over the display buffer.  IMGUI leaves the scissor rectangle in a random state, preventing this from happening correctly.  Fix by restoring the Scissor Rect back to the size of the viewport.  After IMGUI is done generating command lists.


