### PR TITLE
backlog: fix deadlock and an wi_assert logic error, add deprecation

### DIFF
--- a/WickedEngine/wiBacklog.h
+++ b/WickedEngine/wiBacklog.h
@@ -13,7 +13,7 @@
 #define wilog_warning(str,...) {wilog_level(str, wi::backlog::LogLevel::Warning, ## __VA_ARGS__);}
 #define wilog_error(str,...) {wilog_level(str, wi::backlog::LogLevel::Error, ## __VA_ARGS__);}
 #define wilog(str,...) {wilog_level(str, wi::backlog::LogLevel::Default, ## __VA_ARGS__);}
-#define wilog_assert(cond,str,...) {if(!cond){wilog_error(str, ## __VA_ARGS__); assert(cond);}}
+#define wilog_assert(cond,str,...) {if(!(cond)){wilog_error(str, ## __VA_ARGS__); assert(cond);}}
 
 namespace wi::backlog
 {
@@ -66,7 +66,7 @@ namespace wi::backlog
 	LogLevel GetUnseenLogLevelMax();
 
 	// These are no longer used, but kept here to not break user code:
-	inline void input(const char input) {}
-	inline void acceptInput() {}
-	inline void deletefromInput() {}
+	[[deprecated("does nothing")]] inline void input(const char input) {}
+	[[deprecated("does nothing")]] inline void acceptInput() {}
+	[[deprecated("does nothing")]] inline void deletefromInput() {}
 };


### PR DESCRIPTION
* When rendering the backlog, a GPU call might fail, causing wilog_assert to write to the backlog. This would then try to acquire the `entriesLock` (formerly `logLock`) but deadlock since the thread already holds it. Fix it by replacing SpinLock with std::recursive_lock.

  Reduce the time for how long the lock is held to only apply to when `entries` is accessed.

  Ensure we will not hang on destruction of LogWriter, even if the program aborts while another thread holds the entriesLock.

* wi_assert: Add parenthesis around if condition to ensure it works correctly in edge cases, like `i >= 0`

* add deprecation attribute to `input`, `acceptInput`, `deleteFromInput` so people who still reference them can remove the now pointless calls.