### PR TITLE
main_sdl2: don't allocate Editor object on stack

### DIFF
--- a/Editor/main_SDL2.cpp
+++ b/Editor/main_SDL2.cpp
@@ -8,7 +8,9 @@
 
 using namespace std;
 
-int sdl_loop(Editor &editor)
+Editor editor;
+
+int sdl_loop()
 {
     bool quit = false;
     while (!quit)
@@ -92,8 +94,6 @@ void set_window_icon(SDL_Window *window) {
 
 int main(int argc, char *argv[])
 {
-    Editor editor;
-
     wi::arguments::Parse(argc, argv);
 
     sdl2::sdlsystem_ptr_t system = sdl2::make_sdlsystem(SDL_INIT_EVERYTHING | SDL_INIT_EVENTS);
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
 
     editor.SetWindow(window.get());
 
-    int ret = sdl_loop(editor);
+    int ret = sdl_loop();
 
     return ret;
 }

--- a/Samples/Example_ImGui/main_SDL2.cpp
+++ b/Samples/Example_ImGui/main_SDL2.cpp
@@ -5,12 +5,14 @@
 #include "sdl2.h"
 #include "ImGui/imgui_impl_sdl.h"
 
-int sdl_loop(Example_ImGui &tests)
+Example_ImGui exampleImGui;
+
+int sdl_loop()
 {
     bool quit = false;
     while (!quit)
     {
-        tests.Run();
+        exampleImGui.Run();
         SDL_Event event;
         while(SDL_PollEvent(&event)){
             switch(event.type){
@@ -24,13 +26,13 @@ int sdl_loop(Example_ImGui &tests)
                             break;
                         case SDL_WINDOWEVENT_RESIZED:
                             // Tells the engine to reload window configuration (size and dpi)
-                            tests.SetWindow(tests.window);
+                            exampleImGui.SetWindow(exampleImGui.window);
                             break;
                         case SDL_WINDOWEVENT_FOCUS_LOST: //TODO
-                            tests.is_window_active = false;
+                            exampleImGui.is_window_active = false;
                             break;
                         case SDL_WINDOWEVENT_FOCUS_GAINED:
-                            tests.is_window_active = true;
+                            exampleImGui.is_window_active = true;
                             if (wi::shadercompiler::GetRegisteredShaderCount() > 0)
                             {
                                 std::thread([] {
@@ -65,7 +67,6 @@ int sdl_loop(Example_ImGui &tests)
 
 int main(int argc, char *argv[])
 {
-    Example_ImGui exampleImGui;
     // TODO: Place code here.
 
     wi::arguments::Parse(argc, argv);
@@ -86,7 +87,7 @@ int main(int argc, char *argv[])
 
     exampleImGui.SetWindow(window.get());
 
-    int ret = sdl_loop(exampleImGui);
+    int ret = sdl_loop();
 
     SDL_Quit();
     return ret;

--- a/Samples/Example_ImGui_Docking/main_SDL2.cpp
+++ b/Samples/Example_ImGui_Docking/main_SDL2.cpp
@@ -1,16 +1,15 @@
-// WickedEngineTests.cpp : Defines the entry point for the application.
-//
-
 #include "stdafx.h"
 #include "sdl2.h"
 #include "ImGui/imgui_impl_sdl.h"
 
-int sdl_loop(Example_ImGui &tests)
+Example_ImGui exampleImGui;
+
+int sdl_loop()
 {
     bool quit = false;
     while (!quit)
     {
-        tests.Run();
+        exampleImGui.Run();
         SDL_Event event;
         while(SDL_PollEvent(&event)){
             switch(event.type){
@@ -24,13 +23,13 @@ int sdl_loop(Example_ImGui &tests)
                             break;
                         case SDL_WINDOWEVENT_RESIZED:
                             // Tells the engine to reload window configuration (size and dpi)
-                            tests.SetWindow(tests.window);
+                            exampleImGui.SetWindow(exampleImGui.window);
                             break;
                         case SDL_WINDOWEVENT_FOCUS_LOST: //TODO
-                            tests.is_window_active = false;
+                            exampleImGui.is_window_active = false;
                             break;
                         case SDL_WINDOWEVENT_FOCUS_GAINED:
-                            tests.is_window_active = true;
+                            exampleImGui.is_window_active = true;
                             if (wi::shadercompiler::GetRegisteredShaderCount() > 0)
                             {
                                 std::thread([] {
@@ -65,7 +64,6 @@ int sdl_loop(Example_ImGui &tests)
 
 int main(int argc, char *argv[])
 {
-    Example_ImGui exampleImGui;
     // TODO: Place code here.
 
     wi::arguments::Parse(argc, argv);
@@ -86,7 +84,7 @@ int main(int argc, char *argv[])
 
     exampleImGui.SetWindow(window.get());
 
-    int ret = sdl_loop(exampleImGui);
+    int ret = sdl_loop();
 
     SDL_Quit();
     return ret;

--- a/Samples/Tests/main_SDL2.cpp
+++ b/Samples/Tests/main_SDL2.cpp
@@ -4,7 +4,9 @@
 #include "stdafx.h"
 #include "sdl2.h"
 
-int sdl_loop(Tests &tests)
+Tests tests;
+
+int sdl_loop()
 {
     bool quit = false;
     while (!quit)
@@ -63,7 +65,6 @@ int sdl_loop(Tests &tests)
 
 int main(int argc, char *argv[])
 {
-    Tests tests;
     // TODO: Place code here.
 
     wi::arguments::Parse(argc, argv);
@@ -84,7 +85,7 @@ int main(int argc, char *argv[])
 
     tests.SetWindow(window.get());
 
-    int ret = sdl_loop(tests);
+    int ret = sdl_loop();
 
     SDL_Quit();
     return ret;


### PR DESCRIPTION
It became too big for the stack, causing segmentation faults.

Also fix this for the samples and tests.