### PR TITLE
use Zstd for wiHelper::Compress

### DIFF
--- a/WickedEngine/offlineshadercompiler.cpp
+++ b/WickedEngine/offlineshadercompiler.cpp
@@ -616,6 +616,8 @@ int main(int argc, char* argv[])
 	{
 		std::cout << "[Wicked Engine Offline Shader Compiler] Creating ShaderDump...\n";
 		timer.record();
+		size_t total_raw = 0;
+		size_t total_compressed = 0;
 		std::string ss;
 		ss += "namespace wiShaderDump {\n";
 		for (auto& x : results)
@@ -625,7 +627,11 @@ int main(int argc, char* argv[])
 
 			wi::vector<uint8_t> compressed;
 			bool success = wi::helper::Compress(output.shaderdata, output.shadersize, compressed);
-			if (!success)
+			if (success) {
+				total_raw += output.shadersize;
+				total_compressed += compressed.size();
+			}
+			else
 			{
 				wi::helper::DebugOut("Compression failed while creating shader dump!", wi::helper::DebugLevel::Error);
 				continue;
@@ -642,6 +648,7 @@ int main(int argc, char* argv[])
 			}
 			ss += "};\n";
 		}
+		std::cout << "[Wicked Engine Offline Shader Compiler] Compressed shaders: " << total_raw << " -> " << total_compressed << " (" << std::setprecision(3) << (100. * total_compressed / total_raw) << "%)" << std::endl;
 		ss += "struct ShaderDumpEntry{const uint8_t* data; size_t size;};\n";
 		ss += "static const wi::unordered_map<std::string, ShaderDumpEntry> shaderdump = {\n";
 		for (auto& x : results)

--- a/WickedEngine/wiHelper.h
+++ b/WickedEngine/wiHelper.h
@@ -182,8 +182,8 @@ namespace wi::helper
 	// Get error message from platform-specific error code, for example HRESULT on windows
 	std::string GetPlatformErrorString(wi::platform::error_type code);
 
-	// Lossless compression of byte array:
-	bool Compress(const uint8_t* src_data, size_t src_size, wi::vector<uint8_t>& dst_data);
+	// Lossless compression of byte array; level = 0 means "default compression level", currently 3
+	bool Compress(const uint8_t* src_data, size_t src_size, wi::vector<uint8_t>& dst_data, int level = 0);
 
 	// Lossless decompression of byte array that was compressed with wi::helper::Compress()
 	bool Decompress(const uint8_t* src_data, size_t src_size, wi::vector<uint8_t>& dst_data);


### PR DESCRIPTION
ZStd has better compression and is faster as well:

Before (Deflate):

Total compressed: 48927172 -> 12048973 (24%)                                                                    
[Wicked Engine Offline Shader Compiler] ShaderDump written to wiShaderDump.h in 8.864 seconds                  

Now:

Total compressed: 48927172 -> 8954159 (18%)                                                                     
[Wicked Engine Offline Shader Compiler] ShaderDump written to wiShaderDump.h in 0.7831 seconds             

(It's also possible to use a higher compression level than 3, but 3 usually works well enough. Just for fun, I tested with the extreme setting 19, it reduced it to 16%, but took a whopping 21 seconds.)
