### PR TITLE
Don't call UnregisterTypes() in ~JoltDestroyer

### DIFF
--- a/WickedEngine/wiPhysics_Jolt.cpp
+++ b/WickedEngine/wiPhysics_Jolt.cpp
@@ -191,11 +191,12 @@ namespace wi::physics
 		{
 			~JoltDestroyer()
 			{
-				UnregisterTypes();
+				// we don't call UnregisterTypes() here, this is intentional
+				// see #945 and jrouwe/JoltPhysics#1458 for more information
 				delete Factory::sInstance;
 				Factory::sInstance = nullptr;
 			}
-		} jolt_destroyer; 
+		} jolt_destroyer;
 
 		struct PhysicsScene
 		{


### PR DESCRIPTION
Closes #945

see jrouwe/JoltPhysics#1458