### PR TITLE
increase timeout waiting for entriesLock

### DIFF
--- a/WickedEngine/wiBacklog.cpp
+++ b/WickedEngine/wiBacklog.cpp
@@ -390,9 +390,8 @@ namespace wi::backlog
 		// It won't appear in the logfile or backlog, but will still be written to the debug output.
 		//
 		// The time to wait is kinda arbitrary, but it shouldn't be too short, as the rendering of the backlog
-		// can take some time. The value of 33ms means that we wait for 1 whole frame at 30 fps, which
-		// should be more than enough.
-		bool gotLock = entriesLock.try_lock_for(33ms);
+		// can take some time, especially during heavy load like compiling shaders.
+		bool gotLock = entriesLock.try_lock_for(100ms);
 		if (gotLock)
 		{
 			entries.push_back(entry);


### PR DESCRIPTION
Turns out 33ms aren't "more than enough", during shader compilation the timeout was often reached. Increasing it to 100ms seems to solve the issue, and it's still short enough to avoid blocking the application for too long in case something goes wrong.