### PR TITLE
github actions: cancel superseded PR build actions

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -3,6 +3,10 @@ name: Pull Request Verification
 on:
   pull_request
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   windows:


### PR DESCRIPTION
When a PR is updated while the build action hasn't finished yet, the old action is not automatically cancelled. That build is of very limited usefulness since its results will not be shown and are not relevant anymore, so it just wastes resources.

This commit fixes that, now an older build will get cancelled.