### PR TITLE
github actions: use offical UPX, update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,7 @@ indent_size = 4
 
 [*.py]
 indent_style = space
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron:  '0 0 * * *'
 
+env:
+  UPX_VERSION: 4.2.4
+
 jobs:
   
   windows:
@@ -34,9 +37,11 @@ jobs:
         move Editor\languages .\
         move Editor\fonts .\
         
-    - name: Install UPX
+    - name: Install official UPX
       shell: cmd
-      run: choco install --no-progress upx
+      run: |
+        curl -sOSL https://github.com/upx/upx/releases/download/v%UPX_VERSION%/upx-%UPX_VERSION%-win64.zip
+        unzip -qj upx-%UPX_VERSION%-win64.zip upx-%UPX_VERSION%-win64/upx.exe
 
     - name: Compress Editor with UPX
       shell: cmd
@@ -90,8 +95,13 @@ jobs:
         mv Editor/languages ./
         mv Editor/fonts ./
         
+    - name: Install official UPX
+      run: |
+        curl -sOSL https://github.com/upx/upx/releases/download/v$UPX_VERSION/upx-$UPX_VERSION-amd64_linux.tar.xz
+        tar xf upx-$UPX_VERSION-amd64_linux.tar.xz upx-$UPX_VERSION-amd64_linux/upx
+
     - name: Compress Editor with UPX
-      run: upx --best Editor_Linux
+      run: upx-$UPX_VERSION-amd64_linux/upx --best Editor_Linux
 
     - name: Package Editor
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -7,21 +7,27 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  UPX_VERSION: 4.2.4
+
 jobs:
 
   windows:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
+
     - name: Initial compile
       shell: cmd
       run: |
         "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe" WickedEngine.sln /t:OfflineShaderCompiler /m /p:Configuration=Release /p:Platform=x64
+
     - name: Generate shader dump
       shell: cmd
       run: |
         cd "WickedEngine"
         "../BUILD/x64/Release/OfflineShaderCompiler/OfflineShaderCompiler.exe" hlsl6 spirv shaderdump strip_reflection
+
     - name: Recompile with shader dump
       shell: cmd
       run: |
@@ -37,9 +43,11 @@ jobs:
         move Editor\languages .\
         move Editor\fonts .\
 
-    - name: Install UPX
+    - name: Install official UPX
       shell: cmd
-      run: choco install --no-progress upx
+      run: |
+        curl -sOSL https://github.com/upx/upx/releases/download/v%UPX_VERSION%/upx-%UPX_VERSION%-win64.zip
+        unzip -qj upx-%UPX_VERSION%-win64.zip upx-%UPX_VERSION%-win64/upx.exe
 
     - name: Compress Editor with UPX
       shell: cmd
@@ -109,8 +117,13 @@ jobs:
         mv Editor/languages ./
         mv Editor/fonts ./
 
+    - name: Install official UPX
+      run: |
+        curl -sOSL https://github.com/upx/upx/releases/download/v$UPX_VERSION/upx-$UPX_VERSION-amd64_linux.tar.xz
+        tar xf upx-$UPX_VERSION-amd64_linux.tar.xz upx-$UPX_VERSION-amd64_linux/upx
+
     - name: Compress Editor with UPX
-      run: upx --best Editor_Linux
+      run: upx-$UPX_VERSION-amd64_linux/upx --best Editor_Linux
 
     - name: Package Editor
       uses: actions/upload-artifact@v4
@@ -122,6 +135,7 @@ jobs:
           config.ini
           startup.lua
           Editor_Linux
+
 
   content:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ master ]
 
+env:
+  UPX_VERSION: 4.2.4
+
 jobs:
 
   windows:
@@ -34,9 +37,11 @@ jobs:
         move Editor\languages .\
         move Editor\fonts .\
 
-    - name: Install UPX
+    - name: Install official UPX
       shell: cmd
-      run: choco install --no-progress upx
+      run: |
+        curl -sOSL https://github.com/upx/upx/releases/download/v%UPX_VERSION%/upx-%UPX_VERSION%-win64.zip
+        unzip -qj upx-%UPX_VERSION%-win64.zip upx-%UPX_VERSION%-win64/upx.exe
 
     - name: Compress Editor with UPX
       shell: cmd
@@ -106,8 +111,13 @@ jobs:
         mv Editor/languages ./
         mv Editor/fonts ./
 
+    - name: Install official UPX
+      run: |
+        curl -sOSL https://github.com/upx/upx/releases/download/v$UPX_VERSION/upx-$UPX_VERSION-amd64_linux.tar.xz
+        tar xf upx-$UPX_VERSION-amd64_linux.tar.xz upx-$UPX_VERSION-amd64_linux/upx
+
     - name: Compress Editor with UPX
-      run: upx --best Editor_Linux
+      run: upx-$UPX_VERSION-amd64_linux/upx --best Editor_Linux
 
     - name: Package Editor
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
* Update .editorconfig so my Emacs doesn't add tabs into the YAML files anymore

* The UPX version in ubuntu doesn't use the NRV library and seems to be a bit buggier. Furthermore, UPX is GPL and they allow an exception only if the binary is compressed with the official build. The latter is not really a problem, nobody will care, but the worse compression and potential crashes are. So just use the official build for Linux. Windows was already using it, but to keep it consistent with UPX_VERSION we now also download it instead of using Chocolatey.