### PR TITLE
Add to README.md missing Linux dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you have questions or stuck, please use the `windows` communication channel o
 <img align="right" src="https://github.com/turanszkij/wickedengine-gifs/raw/main/character_grass.gif" width="320px"/>
 
 #### Linux
-To build the engine for Linux, use Cmake. You can find a sample build script for Ubuntu [here](.github/workflows/build.yml) (in the linux section). On the Linux operating system, you will need to ensure some additional dependencies are installed, such as Cmake (3.7 or newer), g++ compiler (C++ 17 compliant version) and SDL2. For Ubuntu 20.04, you can use the following commands to install dependencies:
+To build the engine for Linux, use Cmake. You can find a sample build script for Ubuntu [here](.github/workflows/build.yml) (in the linux section). On the Linux operating system, you will need to ensure some additional dependencies are installed, such as Cmake (3.7 or newer), g++ compiler (C++ 17 compliant version), zenity and SDL2. For Ubuntu 20.04, you can use the following commands to install dependencies:
 
 <img align="right" src="https://github.com/turanszkij/wickedengine-gifs/raw/main/inverse_kinematics.gif" width="320px"/>
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ If you have questions or stuck, please use the `windows` communication channel o
 <img align="right" src="https://github.com/turanszkij/wickedengine-gifs/raw/main/character_grass.gif" width="320px"/>
 
 #### Linux
-To build the engine for Linux, use Cmake. You can find a sample build script for Ubuntu [here](.github/workflows/build.yml) (in the linux section). On the Linux operating system, you will need to ensure some additional dependencies are installed, such as Cmake (3.7 or newer), g++ compiler (C++ 17 compliant version), zenity and SDL2. For Ubuntu 20.04, you can use the following commands to install dependencies:
+To build the engine for Linux, use Cmake. You can find a sample build script for Ubuntu [here](.github/workflows/build.yml) (in the linux section). On the Linux operating system, you will need to ensure some additional dependencies are installed, such as Cmake (3.7 or newer), g++ compiler (C++ 17 compliant version) and SDL2. For Ubuntu 20.04, you can use the following commands to install dependencies:
 
 <img align="right" src="https://github.com/turanszkij/wickedengine-gifs/raw/main/inverse_kinematics.gif" width="320px"/>
+
+(If you're not on a GNOME-based Linux setup, also ensure installation of the [zenity](https://gitlab.gnome.org/GNOME/zenity) package if you'd like to actually see any message-box alerts WickedEngine Editor might try to bring to your attention under certain error conditions.)
 
 ```bash
 sudo apt update


### PR DESCRIPTION
I was wondering why on my system, `SDL_ShowSimpleMessageBox` (and thus `wi::helper::messageBox`) was a total no-op returning `-1`. This had me perplexed since SDL's docs on the function state:

> On X11, SDL rolls its own dialog box with X11 primitives instead of a formal toolkit like GTK+ or Qt.

Well, `SDL_GetError` informed me that "zenity failed to start" and a quick check affirmed that this wasn't already installed on my KDE system, zenity being a GNOME project (and apparently SDL2 won't try for `kdialog` if no `zenity` :grin: — either of which I wouldn't call "X11 primitives" but rather "external-program dependencies").

Well not all Linux users are on Ubuntu or are GNOME-using, so in the interest of completeness, this nano PR  =)

It's kind of an optional rather than hard "dependency" this way, given that things keep working without message boxes — OTOH usually one does not want to miss them when they have sth to say.