### PR TITLE
Github actions: Add Ccache to Windows build

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -9,6 +9,9 @@ concurrency:
 
 env:
   UPX_VERSION: 4.2.4
+  CCACHE_VERSION: 4.10.2
+  # needed because wiRenderer uses conditional include via __hasinclude
+  CCACHE_NODIRECT: 1
 
 jobs:
 
@@ -17,10 +20,26 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Restore Ccache database
+      id: restore-ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: C:\Users\runneradmin\AppData\Local\ccache
+        key: win-ccache-${{ github.run_id }}
+        restore-keys: win-ccache-
+
+    - name: Install Ccache
+      run: |
+        curl -sOSL https://github.com/ccache/ccache/releases/download/v$Env:CCACHE_VERSION/ccache-$Env:CCACHE_VERSION-windows-x86_64.zip
+        unzip -qj ccache-$Env:CCACHE_VERSION-windows-x86_64.zip ccache-$Env:CCACHE_VERSION-windows-x86_64/ccache.exe
+        mv ccache.exe cl.exe
+        mv Directory.Build.props.ghbuild Directory.Build.props
+
     - name: Initial compile
       shell: cmd
       run: |
-        "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe" WickedEngine.sln /t:OfflineShaderCompiler /m /p:Configuration=Release /p:Platform=x64
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+        MSBuild WickedEngine.sln /t:OfflineShaderCompiler /m /p:Configuration=Release /p:Platform=x64
 
     - name: Generate shader dump
       shell: cmd
@@ -31,8 +50,17 @@ jobs:
     - name: Recompile with shader dump
       shell: cmd
       run: |
-        "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe" WickedEngine.sln /t:clean /m /p:Configuration=Release /p:Platform=x64
-        "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe" WickedEngine.sln /t:Editor_Windows /m /p:Configuration=Release /p:Platform=x64
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+        MSBuild WickedEngine.sln /t:clean /m /p:Configuration=Release /p:Platform=x64
+        MSBuild WickedEngine.sln /t:Editor_Windows /m /p:Configuration=Release /p:Platform=x64
+
+    - name: Save Ccache database
+      id: save-ccache
+      if: always() && steps.restore-ccache.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: C:\Users\runneradmin\AppData\Local\ccache
+        key: ${{ steps.restore-ccache.outputs.cache-primary-key }}
 
     - name: Move files
       shell: cmd
@@ -70,13 +98,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Restore CCache database
+    - name: Restore Ccache database
       id: restore-ccache
       uses: actions/cache/restore@v4
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.run_id }}
-        restore-keys: ccache
+        restore-keys: ccache-
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
 
 env:
   UPX_VERSION: 4.2.4
+  CCACHE_VERSION: 4.10.2
+  CCACHE_NODIRECT: 1
 
 jobs:
 
@@ -13,20 +15,48 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
+
+    - name: Restore Ccache database
+      id: restore-ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: C:\Users\runneradmin\AppData\Local\ccache
+        key: win-ccache-${{ github.run_id }}
+        restore-keys: win-ccache-
+
+    - name: Install Ccache
+      run: |
+        curl -sOSL https://github.com/ccache/ccache/releases/download/v$Env:CCACHE_VERSION/ccache-$Env:CCACHE_VERSION-windows-x86_64.zip
+        unzip -qj ccache-$Env:CCACHE_VERSION-windows-x86_64.zip ccache-$Env:CCACHE_VERSION-windows-x86_64/ccache.exe
+        mv ccache.exe cl.exe
+        mv Directory.Build.props.ghbuild Directory.Build.props
+
     - name: Initial compile
       shell: cmd
       run: |
-        "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe" WickedEngine.sln /t:OfflineShaderCompiler /m /p:Configuration=Release /p:Platform=x64
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+        MSBuild WickedEngine.sln /t:OfflineShaderCompiler /m /p:Configuration=Release /p:Platform=x64
+
     - name: Generate shader dump
       shell: cmd
       run: |
         cd "WickedEngine"
         "../BUILD/x64/Release/OfflineShaderCompiler/OfflineShaderCompiler.exe" hlsl6 spirv shaderdump strip_reflection
+
     - name: Recompile with shader dump
       shell: cmd
       run: |
-        "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe" WickedEngine.sln /t:clean /m /p:Configuration=Release /p:Platform=x64
-        "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/MSBuild/Current/Bin/MSBuild.exe" WickedEngine.sln /t:Editor_Windows /m /p:Configuration=Release /p:Platform=x64
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+        MSBuild WickedEngine.sln /t:clean /m /p:Configuration=Release /p:Platform=x64
+        MSBuild WickedEngine.sln /t:Editor_Windows /m /p:Configuration=Release /p:Platform=x64
+
+    - name: Save Ccache database
+      id: save-ccache
+      if: always() && steps.restore-ccache.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: C:\Users\runneradmin\AppData\Local\ccache
+        key: ${{ steps.restore-ccache.outputs.cache-primary-key }}
 
     - name: Move files
       shell: cmd
@@ -65,13 +95,13 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Restore CCache database
+    - name: Restore Ccache database
       id: restore-ccache
       uses: actions/cache/restore@v4
       with:
         path: ~/.cache/ccache
         key: ccache-${{ github.run_id }}
-        restore-keys: ccache
+        restore-keys: ccache-
 
     - name: Install dependencies
       run: |

--- a/Directory.Build.props.ghbuild
+++ b/Directory.Build.props.ghbuild
@@ -1,0 +1,18 @@
+<!-- This file is only needed for Ccache compilation in GitHub actions, it can safely be ignored otherwise -->
+<Project>
+  <PropertyGroup>
+    <CLToolPath>D:\a\WickedEngine\WickedEngine</CLToolPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <UseMultiToolTask>true</UseMultiToolTask>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <ForcedIncludeFiles />
+      <ObjectFileName>$(IntDir)%(FileName).obj</ObjectFileName>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>


### PR DESCRIPTION
Using Ccache on windows as well seems to improve build times significantly.

In case of a cold cache, it's around 1m30s faster, for a warm cache it's around 3-6m faster.

Similar to Linux, the nightly build is done without Ccache.