### PR TITLE
Fix Lua stack overflow vulnerability

### DIFF
--- a/WickedEngine/LUA/ldebug.c
+++ b/WickedEngine/LUA/ldebug.c
@@ -634,11 +634,15 @@ l_noret luaG_runerror (lua_State *L, const char *fmt, ...) {
   CallInfo *ci = L->ci;
   const char *msg;
   va_list argp;
+  luaC_checkGC(L);  /* error message uses memory */
   va_start(argp, fmt);
   msg = luaO_pushvfstring(L, fmt, argp);  /* format message */
   va_end(argp);
-  if (isLua(ci))  /* if Lua function, add source:line information */
+  if (isLua(ci)) {  /* if Lua function, add source:line information */
     luaG_addinfo(L, msg, ci_func(ci)->p->source, currentline(ci));
+    setobjs2s(L, L->top - 2, L->top - 1);  /* remove 'msg' from the stack */
+    L->top--;
+  }
   luaG_errormsg(L);
 }
 


### PR DESCRIPTION
**Description**
This PR fixes a Lua stack overflow vulnerability (CVE-2020-15889) in the error handling code.
The vulnerability occurs when C stack overflows while handling an error, causing Lua to consume excessive stack space. This can lead to denial of service conditions.
The fix implements the same solution as the official Lua repository in commit 42d40581dd919fb134c07027ca1ce0844c670daf, which removes redundant messages from the stack to conserve stack space during error handling.

**Reference:**
- CVE-2020-15889
- Original fix: https://github.com/lua/lua/commit/42d40581dd919fb134c07027ca1ce0844c670daf