### PR TITLE
linux: add missing break to get rid of error message

### DIFF
--- a/WickedEngine/wiJobSystem.cpp
+++ b/WickedEngine/wiJobSystem.cpp
@@ -204,6 +204,7 @@ namespace wi::jobsystem
 						{
 							perror("setpriority");
 						}
+						break;
 					case Priority::Streaming:
 						if (setpriority(PRIO_PROCESS, 0, 2) != 0)
 						{


### PR DESCRIPTION
Streaming recent got its own priority, but due to the missing break, Low priority threads would fall through, causing the call to fail since processes cannot increase their priority.

Therefore, the behaviour doesn't really change except for the error going away.