### PR TITLE
linux: don't use getText() in crash handler

### DIFF
--- a/Editor/main_SDL2.cpp
+++ b/Editor/main_SDL2.cpp
@@ -168,8 +168,10 @@ void crash_handler(int sig)
 		fflush(logfile);
 		backtrace_symbols_fd(btbuf, size, fileno(logfile));
 		fputs("\nBacklog:\n", logfile);
-		fflush(logfile);
-		fputs(wi::backlog::getText().c_str(), logfile);
+		wi::backlog::_forEachLogEntry_unsafe([&] (auto&& entry) {
+			fputs(entry.text.c_str(), logfile);
+			fflush(logfile);
+		});
 		fclose(logfile);
 		char cwdbuf[200];
 		fprintf(stderr, "\e[1mcrash log written to %s/%s\e[m\n", getcwd(cwdbuf, sizeof(cwdbuf)), filename);

--- a/WickedEngine/wiBacklog.cpp
+++ b/WickedEngine/wiBacklog.cpp
@@ -23,11 +23,6 @@ namespace wi::backlog
 {
 	bool enabled = false;
 	bool was_ever_enabled = enabled;
-	struct LogEntry
-	{
-		std::string text;
-		LogLevel level = LogLevel::Default;
-	};
 	const float speed = 4000.0f;
 	const size_t deletefromline = 500;
 	float pos = 5;
@@ -58,11 +53,15 @@ namespace wi::backlog
 		{
 			std::scoped_lock lck(entriesLock);
 			std::string retval;
-			for (auto& x : entries)
-			{
-				retval += x.text;
-			}
+			_forEachLogEntry_unsafe([&](auto&& entry) {retval += entry.text;});
 			return retval;
+		}
+		inline void _forEachLogEntry_unsafe(std::function<void(const LogEntry&)> cb)
+		{
+			for (auto& entry : entries)
+			{
+				cb(entry);
+			}
 		}
 		void writeLogfile()
 		{
@@ -346,6 +345,11 @@ namespace wi::backlog
 	std::string getText()
 	{
 		return internal_state.getText();
+	}
+	// You generally don't want to use this. See notes in header
+	void _forEachLogEntry_unsafe(std::function<void(const LogEntry&)> cb)
+	{
+		internal_state._forEachLogEntry_unsafe(cb);
 	}
 	void clear()
 	{

--- a/WickedEngine/wiBacklog.h
+++ b/WickedEngine/wiBacklog.h
@@ -25,7 +25,6 @@ namespace wi::backlog
 		Warning,
 		Error,
 	};
-
 	void Toggle();
 	void Scroll(int direction);
 	void Update(const wi::Canvas& canvas, float dt = 1.0f / 60.0f);
@@ -64,6 +63,20 @@ namespace wi::backlog
 	void SetLogLevel(LogLevel newLevel);
 
 	LogLevel GetUnseenLogLevelMax();
+
+
+	struct LogEntry
+	{
+		std::string text;
+		LogLevel level = LogLevel::Default;
+	};
+	// this function is intended to be used only in crash handlers to write the current
+	// backlog, but without locking or any mallocs. It might iterate over complete garbage,
+	// so it should only be used as a last resort.
+	// It's also not considered part of the API and can change at any time.
+	//
+	// Use getText() instead, unless absolutely necessary.
+	void _forEachLogEntry_unsafe(std::function<void(const LogEntry&)> cb);
 
 	// These are no longer used, but kept here to not break user code:
 	[[deprecated("does nothing")]] inline void input(const char input) {}


### PR DESCRIPTION
getText() allocates memory which is a big no no in a signal handler. Instead, use an internal function that calls us for each entry so we can write it to the crash log.

This is ugly, but I can't think of a better solution atm.