### PR TITLE
reorder indices on metadata entry removal

### DIFF
--- a/WickedEngine/wiScene_Components.h
+++ b/WickedEngine/wiScene_Components.h
@@ -2406,6 +2406,12 @@ namespace wi::scene
 					values.erase(values.begin() + lookup[name]);
 					names.erase(names.begin() + lookup[name]);
 					lookup.erase(name);
+
+					// reorder lookup
+					for (size_t i = 0; i < names.size(); ++i)
+					{
+						lookup[names[i]] = i;
+					}
 				}
 			}
 		};


### PR DESCRIPTION
Fixes an issue where upon removing metadata fields the widgets would no longer refer to correct indices often causing crashes or widgets changing incorrect fields.