### PR TITLE
dx12: root signature desc life extender to allow recompiling pso whil…

### DIFF
--- a/WickedEngine/wiGraphicsDevice_DX12.cpp
+++ b/WickedEngine/wiGraphicsDevice_DX12.cpp
@@ -1439,6 +1439,7 @@ namespace dx12_internal
 
 		ComPtr<ID3D12VersionedRootSignatureDeserializer> rootsig_deserializer;
 		const D3D12_VERSIONED_ROOT_SIGNATURE_DESC* rootsig_desc = nullptr;
+		std::shared_ptr<void> rootsig_desc_lifetime_extender;
 		RootSignatureOptimizer rootsig_optimizer;
 
 		struct PSO_STREAM
@@ -4060,6 +4061,7 @@ std::mutex queue_locker;
 			{
 				internal_state->rootSignature = shader_internal->rootSignature;
 				internal_state->rootsig_desc = shader_internal->rootsig_desc;
+				internal_state->rootsig_desc_lifetime_extender = pso->desc.vs->internal_state;
 				stream.stream1.ROOTSIG = internal_state->rootSignature.Get();
 			}
 		}
@@ -4071,6 +4073,7 @@ std::mutex queue_locker;
 			{
 				internal_state->rootSignature = shader_internal->rootSignature;
 				internal_state->rootsig_desc = shader_internal->rootsig_desc;
+				internal_state->rootsig_desc_lifetime_extender = pso->desc.hs->internal_state;
 				stream.stream1.ROOTSIG = internal_state->rootSignature.Get();
 			}
 		}
@@ -4082,6 +4085,7 @@ std::mutex queue_locker;
 			{
 				internal_state->rootSignature = shader_internal->rootSignature;
 				internal_state->rootsig_desc = shader_internal->rootsig_desc;
+				internal_state->rootsig_desc_lifetime_extender = pso->desc.ds->internal_state;
 				stream.stream1.ROOTSIG = internal_state->rootSignature.Get();
 			}
 		}
@@ -4093,6 +4097,7 @@ std::mutex queue_locker;
 			{
 				internal_state->rootSignature = shader_internal->rootSignature;
 				internal_state->rootsig_desc = shader_internal->rootsig_desc;
+				internal_state->rootsig_desc_lifetime_extender = pso->desc.gs->internal_state;
 				stream.stream1.ROOTSIG = internal_state->rootSignature.Get();
 			}
 		}
@@ -4104,6 +4109,7 @@ std::mutex queue_locker;
 			{
 				internal_state->rootSignature = shader_internal->rootSignature;
 				internal_state->rootsig_desc = shader_internal->rootsig_desc;
+				internal_state->rootsig_desc_lifetime_extender = pso->desc.ps->internal_state;
 				stream.stream1.ROOTSIG = internal_state->rootSignature.Get();
 			}
 		}
@@ -4116,6 +4122,7 @@ std::mutex queue_locker;
 			{
 				internal_state->rootSignature = shader_internal->rootSignature;
 				internal_state->rootsig_desc = shader_internal->rootsig_desc;
+				internal_state->rootsig_desc_lifetime_extender = pso->desc.ms->internal_state;
 				stream.stream1.ROOTSIG = internal_state->rootSignature.Get();
 			}
 		}
@@ -4127,6 +4134,7 @@ std::mutex queue_locker;
 			{
 				internal_state->rootSignature = shader_internal->rootSignature;
 				internal_state->rootsig_desc = shader_internal->rootsig_desc;
+				internal_state->rootsig_desc_lifetime_extender = pso->desc.as->internal_state;
 				stream.stream1.ROOTSIG = internal_state->rootSignature.Get();
 			}
 		}

--- a/WickedEngine/wiVersion.cpp
+++ b/WickedEngine/wiVersion.cpp
@@ -9,7 +9,7 @@ namespace wi::version
 	// minor features, major updates, breaking compatibility changes
 	const int minor = 71;
 	// minor bug fixes, alterations, refactors, updates
-	const int revision = 793;
+	const int revision = 794;
 
 	const std::string version_string = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(revision);
 


### PR DESCRIPTION
…e old one is used for rendering