### PR TITLE
reduce code duplication

### DIFF
--- a/Editor/RigidBodyWindow.cpp
+++ b/Editor/RigidBodyWindow.cpp
@@ -25,6 +25,27 @@ void RigidBodyWindow::Create(EditorComponent* _editor)
 		editor->componentsWnd.RefreshEntityTree();
 	});
 
+	auto forEachSelectedPhysicsComponent = [&](auto /* void(RigidBodyPhysicsComponent*, wi::gui::EventArgs) */ func) {
+		return [&](wi::gui::EventArgs args) {
+			wi::scene::Scene& scene = editor->GetCurrentScene();
+			for (auto& x : editor->translator.selected)
+			{
+				RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
+				if (physicscomponent != nullptr)
+				{
+					func(physicscomponent, args);
+				}
+			}
+		};
+	};
+
+	auto forEachSelectedPhysicsComponentWithRefresh = [&](auto /* void(RigidBodyPhysicsComponent*, wi::gui::EventArgs) */ func) {
+		return forEachSelectedPhysicsComponent([&](auto physicscomponent, auto args) {
+			func(physicscomponent, args);
+			physicscomponent->SetRefreshParametersNeeded();
+		});
+	};
+
 	collisionShapeComboBox.Create("Collision Shape: ");
 	collisionShapeComboBox.AddItem("Box", RigidBodyPhysicsComponent::CollisionShape::BOX);
 	collisionShapeComboBox.AddItem("Sphere", RigidBodyPhysicsComponent::CollisionShape::SPHERE);
@@ -34,319 +55,174 @@ void RigidBodyWindow::Create(EditorComponent* _editor)
 	collisionShapeComboBox.AddItem("Triangle Mesh", RigidBodyPhysicsComponent::CollisionShape::TRIANGLE_MESH);
 	collisionShapeComboBox.AddItem("Height Field", RigidBodyPhysicsComponent::CollisionShape::HEIGHTFIELD);
 	collisionShapeComboBox.OnSelect([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
+		forEachSelectedPhysicsComponent([&](auto physicscomponent, auto args) {
+			RigidBodyPhysicsComponent::CollisionShape shape = (RigidBodyPhysicsComponent::CollisionShape)args.userdata;
+			if (physicscomponent->shape != shape)
 			{
-				RigidBodyPhysicsComponent::CollisionShape shape = (RigidBodyPhysicsComponent::CollisionShape)args.userdata;
-				if (physicscomponent->shape != shape)
-				{
-					physicscomponent->physicsobject = nullptr;
-					physicscomponent->shape = shape;
-				}
+				physicscomponent->physicsobject = nullptr;
+				physicscomponent->shape = shape;
 			}
-		}
+		});
 		RefreshShapeType();
 	});
+
 	collisionShapeComboBox.SetSelected(0);
 	collisionShapeComboBox.SetEnabled(true);
 	collisionShapeComboBox.SetTooltip("Set rigid body collision shape.");
 	AddWidget(&collisionShapeComboBox);
 
 	XSlider.Create(0, 10, 1, 100000, "XSlider");
-	XSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
+	XSlider.OnSlide(forEachSelectedPhysicsComponent([&](auto physicscomponent, auto args) {
+		switch (physicscomponent->shape)
 		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				switch (physicscomponent->shape)
-				{
-				default:
-				case RigidBodyPhysicsComponent::CollisionShape::BOX:
-					physicscomponent->box.halfextents.x = args.fValue;
-					break;
-				case RigidBodyPhysicsComponent::CollisionShape::SPHERE:
-					physicscomponent->sphere.radius = args.fValue;
-					break;
-				case RigidBodyPhysicsComponent::CollisionShape::CAPSULE:
-				case RigidBodyPhysicsComponent::CollisionShape::CYLINDER:
-					physicscomponent->capsule.height = args.fValue;
-					break;
-				}
-				physicscomponent->physicsobject = nullptr;
-			}
+		default:
+		case RigidBodyPhysicsComponent::CollisionShape::BOX:
+			physicscomponent->box.halfextents.x = args.fValue;
+			break;
+		case RigidBodyPhysicsComponent::CollisionShape::SPHERE:
+			physicscomponent->sphere.radius = args.fValue;
+			break;
+		case RigidBodyPhysicsComponent::CollisionShape::CAPSULE:
+		case RigidBodyPhysicsComponent::CollisionShape::CYLINDER:
+			physicscomponent->capsule.height = args.fValue;
+			break;
 		}
-	});
+		physicscomponent->physicsobject = nullptr;
+	}));
+
 	ZSlider.SetLocalizationEnabled(false);
 	AddWidget(&XSlider);
 
 	YSlider.Create(0, 10, 1, 100000, "YSlider");
-	YSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
+	YSlider.OnSlide(forEachSelectedPhysicsComponent([&](auto physicsComponent, auto args) {
+		switch (physicsComponent->shape)
 		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				switch (physicscomponent->shape)
-				{
-				default:
-				case RigidBodyPhysicsComponent::CollisionShape::BOX:
-					physicscomponent->box.halfextents.y = args.fValue;
-					break;
-				case RigidBodyPhysicsComponent::CollisionShape::CAPSULE:
-				case RigidBodyPhysicsComponent::CollisionShape::CYLINDER:
-					physicscomponent->capsule.radius = args.fValue;
-					break;
-				}
-				physicscomponent->physicsobject = nullptr;
-			}
+		default:
+		case RigidBodyPhysicsComponent::CollisionShape::BOX:
+			physicsComponent->box.halfextents.y = args.fValue;
+			break;
+		case RigidBodyPhysicsComponent::CollisionShape::CAPSULE:
+		case RigidBodyPhysicsComponent::CollisionShape::CYLINDER:
+			physicsComponent->capsule.radius = args.fValue;
+			break;
 		}
-	});
+		physicsComponent->physicsobject = nullptr;
+	}));
 	ZSlider.SetLocalizationEnabled(false);
 	AddWidget(&YSlider);
 
 	ZSlider.Create(0, 10, 1, 100000, "ZSlider");
-	ZSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
+	ZSlider.OnSlide(forEachSelectedPhysicsComponent([&](auto physicscomponent, auto args) {
+		switch (physicscomponent->shape)
 		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				switch (physicscomponent->shape)
-				{
-				default:
-				case RigidBodyPhysicsComponent::CollisionShape::BOX:
-				case RigidBodyPhysicsComponent::CollisionShape::CYLINDER:
-					physicscomponent->box.halfextents.z = args.fValue;
-					break;
-				}
-				physicscomponent->physicsobject = nullptr;
-			}
+		default:
+		case RigidBodyPhysicsComponent::CollisionShape::BOX:
+		case RigidBodyPhysicsComponent::CollisionShape::CYLINDER:
+			physicscomponent->box.halfextents.z = args.fValue;
+			break;
 		}
-	});
+		physicscomponent->physicsobject = nullptr;
+	}));
 	ZSlider.SetLocalizationEnabled(false);
 	AddWidget(&ZSlider);
 
 	massSlider.Create(0, 10, 1, 100000, "Mass: ");
 	massSlider.SetTooltip("Set the mass amount for the physics engine.");
-	massSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->mass = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	massSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->mass = args.fValue;
+	}));
 	AddWidget(&massSlider);
 
 	frictionSlider.Create(0, 1, 0.5f, 100000, "Friction: ");
 	frictionSlider.SetTooltip("Set the friction amount for the physics engine.");
-	frictionSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->friction = args.fValue;
-			}
-		}
-	});
+	frictionSlider.OnSlide(forEachSelectedPhysicsComponent([&](auto physicscomponent, auto args) {
+		physicscomponent->friction = args.fValue;
+	}));
 	AddWidget(&frictionSlider);
 
 	restitutionSlider.Create(0, 1, 0, 100000, "Restitution: ");
 	restitutionSlider.SetTooltip("Set the restitution amount for the physics engine.");
-	restitutionSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->restitution = args.fValue;
-			}
-		}
-	});
+	restitutionSlider.OnSlide(forEachSelectedPhysicsComponent([&](auto physicscomponent, auto args) {
+		physicscomponent->restitution = args.fValue;
+	}));
 	AddWidget(&restitutionSlider);
 
 	lineardampingSlider.Create(0, 1, 0, 100000, "Linear Damping: ");
 	lineardampingSlider.SetTooltip("Set the linear damping amount for the physics engine.");
-	lineardampingSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->damping_linear = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	lineardampingSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->damping_linear = args.fValue;
+	}));
 	AddWidget(&lineardampingSlider);
 
 	angulardampingSlider.Create(0, 1, 0, 100000, "Angular Damping: ");
 	angulardampingSlider.SetTooltip("Set the angular damping amount for the physics engine.");
-	angulardampingSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->damping_angular = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	angulardampingSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->damping_angular = args.fValue;
+	}));
 	AddWidget(&angulardampingSlider);
 
 	buoyancySlider.Create(0, 2, 0, 1000, "Buoyancy: ");
 	buoyancySlider.SetTooltip("Higher buoyancy will make the bodies float up faster in water.");
-	buoyancySlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->buoyancy = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	buoyancySlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->buoyancy = args.fValue;
+	}));
 	AddWidget(&buoyancySlider);
 
 	physicsMeshLODSlider.Create(0, 6, 0, 6, "Use Mesh LOD: ");
 	physicsMeshLODSlider.SetTooltip("Specify which LOD to use for triangle mesh physics.");
-	physicsMeshLODSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
+	physicsMeshLODSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		if (physicscomponent->mesh_lod != uint32_t(args.iValue))
 		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				if (physicscomponent->mesh_lod != uint32_t(args.iValue))
-				{
-					physicscomponent->physicsobject = nullptr; // will be recreated automatically
-					physicscomponent->mesh_lod = uint32_t(args.iValue);
-				}
-				physicscomponent->mesh_lod = uint32_t(args.iValue);
-				physicscomponent->SetRefreshParametersNeeded();
-			}
+			physicscomponent->physicsobject = nullptr; // will be recreated automatically
+			physicscomponent->mesh_lod = uint32_t(args.iValue);
 		}
-	});
+		physicscomponent->mesh_lod = uint32_t(args.iValue);
+	}));
 	AddWidget(&physicsMeshLODSlider);
 
 	kinematicCheckBox.Create("Kinematic: ");
 	kinematicCheckBox.SetTooltip("Toggle kinematic behaviour.");
 	kinematicCheckBox.SetCheck(false);
-	kinematicCheckBox.OnClick([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->SetKinematic(args.bValue);
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	kinematicCheckBox.OnClick(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->SetKinematic(args.bValue);
+	}));
 	AddWidget(&kinematicCheckBox);
 
 	disabledeactivationCheckBox.Create("Disable Deactivation: ");
 	disabledeactivationCheckBox.SetTooltip("Toggle kinematic behaviour.");
 	disabledeactivationCheckBox.SetCheck(false);
-	disabledeactivationCheckBox.OnClick([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->SetDisableDeactivation(args.bValue);
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	disabledeactivationCheckBox.OnClick(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->SetDisableDeactivation(args.bValue);
+	}));
 	AddWidget(&disabledeactivationCheckBox);
 
 	startDeactivatedCheckBox.Create("Start deactivated: ");
 	startDeactivatedCheckBox.SetTooltip("If enabled, the rigid body will start in a deactivated state.\nEven if the body is dynamic (non-kinematic, mass > 0), it will not fall unless interacted with.");
 	startDeactivatedCheckBox.SetCheck(false);
-	startDeactivatedCheckBox.OnClick([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->SetStartDeactivated(args.bValue);
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	startDeactivatedCheckBox.OnClick(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->SetStartDeactivated(args.bValue);
+	}));
 	AddWidget(&startDeactivatedCheckBox);
-
-
 
 	offsetXSlider.Create(-10, 10, 0, 100000, "Local Offset X: ");
 	offsetXSlider.SetTooltip("Set a local offset relative to the object transform");
-	offsetXSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->local_offset.x = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	offsetXSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->local_offset.x = args.fValue;
+	}));
 	AddWidget(&offsetXSlider);
 
 	offsetYSlider.Create(-10, 10, 0, 100000, "Local Offset Y: ");
 	offsetYSlider.SetTooltip("Set a local offset relative to the object transform");
-	offsetYSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->local_offset.y = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	offsetYSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->local_offset.y = args.fValue;
+	}));
 	AddWidget(&offsetYSlider);
 
 	offsetZSlider.Create(-10, 10, 0, 100000, "Local Offset Z: ");
 	offsetZSlider.SetTooltip("Set a local offset relative to the object transform");
-	offsetZSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->local_offset.z = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	offsetZSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->local_offset.z = args.fValue;
+	}));
 	AddWidget(&offsetZSlider);
 
 	physicsDebugCheckBox.Create(ICON_EYE " Physics visualizer: ");
@@ -363,18 +239,9 @@ void RigidBodyWindow::Create(EditorComponent* _editor)
 
 	characterCheckBox.Create(ICON_PHYSICS_CHARACTER " Character physics: ");
 	characterCheckBox.SetTooltip("Enable physics-driven character");
-	characterCheckBox.OnClick([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
+	characterCheckBox.OnClick(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
 				physicscomponent->SetCharacterPhysics(args.bValue);
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	}));
 	AddWidget(&characterCheckBox);
 
 	characterLabel.Create("CharacterLabel");
@@ -384,34 +251,16 @@ void RigidBodyWindow::Create(EditorComponent* _editor)
 
 	characterSlopeSlider.Create(0, 90, 50, 90, "Max slope angle: ");
 	characterSlopeSlider.SetTooltip("Specify the slope angle that the character can stand on.");
-	characterSlopeSlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->character.maxSlopeAngle = wi::math::DegreesToRadians(args.fValue);
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	characterSlopeSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->character.maxSlopeAngle = wi::math::DegreesToRadians(args.fValue);
+	}));
 	AddWidget(&characterSlopeSlider);
 
 	characterGravitySlider.Create(0, 4, 1, 100, "Gravity factor: ");
 	characterGravitySlider.SetTooltip("Specify the strength of gravity acting on the character.");
-	characterGravitySlider.OnSlide([&](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->character.gravityFactor = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	characterGravitySlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->character.gravityFactor = args.fValue;
+	}));
 	AddWidget(&characterGravitySlider);
 
 
@@ -432,18 +281,9 @@ void RigidBodyWindow::Create(EditorComponent* _editor)
 	vehicleCombo.AddItem("None", (uint64_t)RigidBodyPhysicsComponent::Vehicle::Type::None);
 	vehicleCombo.AddItem("Car", (uint64_t)RigidBodyPhysicsComponent::Vehicle::Type::Car);
 	vehicleCombo.AddItem("Motorcycle", (uint64_t)RigidBodyPhysicsComponent::Vehicle::Type::Motorcycle);
-	vehicleCombo.OnSelect([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.type = (RigidBodyPhysicsComponent::Vehicle::Type)args.userdata;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	vehicleCombo.OnSelect(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.type = (RigidBodyPhysicsComponent::Vehicle::Type)args.userdata;
+	}));
 	AddWidget(&vehicleCombo);
 
 
@@ -451,379 +291,156 @@ void RigidBodyWindow::Create(EditorComponent* _editor)
 	vehicleCollisionCombo.AddItem("Ray", (uint64_t)RigidBodyPhysicsComponent::Vehicle::CollisionMode::Ray);
 	vehicleCollisionCombo.AddItem("Sphere", (uint64_t)RigidBodyPhysicsComponent::Vehicle::CollisionMode::Sphere);
 	vehicleCollisionCombo.AddItem("Cylinder", (uint64_t)RigidBodyPhysicsComponent::Vehicle::CollisionMode::Cylinder);
-	vehicleCollisionCombo.OnSelect([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.collision_mode = (RigidBodyPhysicsComponent::Vehicle::CollisionMode)args.userdata;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	vehicleCollisionCombo.OnSelect(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.collision_mode = (RigidBodyPhysicsComponent::Vehicle::CollisionMode)args.userdata;
+	}));
 	AddWidget(&vehicleCollisionCombo);
 
 
 	wheelRadiusSlider.Create(0.001f, 10, 1, 1000, "Wheel radius: ");
-	wheelRadiusSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.wheel_radius = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	wheelRadiusSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.wheel_radius = args.fValue;
+	}));
 	AddWidget(&wheelRadiusSlider);
 
 	wheelWidthSlider.Create(0.001f, 10, 1, 1000, "Wheel width: ");
-	wheelWidthSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.wheel_width = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	wheelWidthSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.wheel_width = args.fValue;
+	}));
 	AddWidget(&wheelWidthSlider);
 
 	chassisHalfWidthSlider.Create(0, 10, 1, 1000, "Chassis width: ");
-	chassisHalfWidthSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.chassis_half_width = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	chassisHalfWidthSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.chassis_half_width = args.fValue;
+	}));
 	AddWidget(&chassisHalfWidthSlider);
 
 	chassisHalfHeightSlider.Create(-10, 10, 1, 1000, "Chassis height: ");
-	chassisHalfHeightSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.chassis_half_height = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	chassisHalfHeightSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.chassis_half_height = args.fValue;
+	}));
 	AddWidget(&chassisHalfHeightSlider);
 
 	chassisHalfLengthSlider.Create(0, 10, 1, 1000, "Chassis length: ");
-	chassisHalfLengthSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.chassis_half_length = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	chassisHalfLengthSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.chassis_half_length = args.fValue;
+	}));
 	AddWidget(&chassisHalfLengthSlider);
 
 	frontWheelOffsetSlider.Create(-10, 10, 0, 1000, "Front wheel offset: ");
-	frontWheelOffsetSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.front_wheel_offset = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	frontWheelOffsetSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.front_wheel_offset = args.fValue;
+	}));
 	AddWidget(&frontWheelOffsetSlider);
 
 	rearWheelOffsetSlider.Create(-10, 10, 0, 1000, "Rear wheel offset: ");
-	rearWheelOffsetSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.rear_wheel_offset = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	rearWheelOffsetSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.rear_wheel_offset = args.fValue;
+	}));
 	AddWidget(&rearWheelOffsetSlider);
 
 	maxTorqueSlider.Create(0, 1000, 0, 1000, "Max Torque: ");
-	maxTorqueSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.max_engine_torque = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	maxTorqueSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.max_engine_torque = args.fValue;
+	}));
 	AddWidget(&maxTorqueSlider);
 
 	clutchStrengthSlider.Create(0, 100, 0, 1000, "Clutch Strength: ");
-	clutchStrengthSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.clutch_strength = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	clutchStrengthSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.clutch_strength = args.fValue;
+	}));
 	AddWidget(&clutchStrengthSlider);
 
 	maxRollAngleSlider.Create(0, 180, 0, 180, "Max Roll Angle: ");
-	maxRollAngleSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.max_roll_angle = wi::math::DegreesToRadians(args.fValue);
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	maxRollAngleSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.max_roll_angle = wi::math::DegreesToRadians(args.fValue);
+	}));
 	AddWidget(&maxRollAngleSlider);
 
 	maxSteeringAngleSlider.Create(0, 90, 0, 90, "Max Steering Angle: ");
-	maxSteeringAngleSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.max_steering_angle = wi::math::DegreesToRadians(args.fValue);
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	maxSteeringAngleSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.max_steering_angle = wi::math::DegreesToRadians(args.fValue);
+	}));
 	AddWidget(&maxSteeringAngleSlider);
 
 	fSuspensionMinSlider.Create(0, 2, 0, 200, "F. Susp. Min Length: ");
-	fSuspensionMinSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.front_suspension.min_length = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	fSuspensionMinSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.front_suspension.min_length = args.fValue;
+	}));
 	AddWidget(&fSuspensionMinSlider);
 
 	fSuspensionMaxSlider.Create(0, 2, 0, 200, "F. Susp. Max Length: ");
-	fSuspensionMaxSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.front_suspension.max_length = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	fSuspensionMaxSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.front_suspension.max_length = args.fValue;
+		physicscomponent->SetRefreshParametersNeeded();
+	}));
 	AddWidget(&fSuspensionMaxSlider);
 
 	fSuspensionFrequencySlider.Create(0, 2, 0, 200, "F. Susp. Frequency: ");
-	fSuspensionFrequencySlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.front_suspension.frequency = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	fSuspensionFrequencySlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.front_suspension.frequency = args.fValue;
+	}));
 	AddWidget(&fSuspensionFrequencySlider);
 
 	fSuspensionDampingSlider.Create(0, 2, 0, 200, "F. Susp. Damping: ");
-	fSuspensionDampingSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.front_suspension.damping = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	fSuspensionDampingSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.front_suspension.damping = args.fValue;
+	}));
 	AddWidget(&fSuspensionDampingSlider);
 
 	rSuspensionMinSlider.Create(0, 2, 0, 200, "R. Susp. Min Length: ");
-	rSuspensionMinSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.rear_suspension.min_length = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	rSuspensionMinSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.rear_suspension.min_length = args.fValue;
+	}));
 	AddWidget(&rSuspensionMinSlider);
 
 	rSuspensionMaxSlider.Create(0, 2, 0, 200, "R. Susp. Max Length: ");
-	rSuspensionMaxSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.rear_suspension.max_length = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	rSuspensionMaxSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.rear_suspension.max_length = args.fValue;
+	}));
 	AddWidget(&rSuspensionMaxSlider);
 
 	rSuspensionFrequencySlider.Create(0, 2, 0, 200, "R. Susp. Frequency: ");
-	rSuspensionFrequencySlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.rear_suspension.frequency = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	rSuspensionFrequencySlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.rear_suspension.frequency = args.fValue;
+	}));
 	AddWidget(&rSuspensionFrequencySlider);
 
 	rSuspensionDampingSlider.Create(0, 2, 0, 200, "R. Susp. Damping: ");
-	rSuspensionDampingSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.rear_suspension.damping = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	rSuspensionDampingSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.rear_suspension.damping = args.fValue;
+	}));
 	AddWidget(&rSuspensionDampingSlider);
 
 	motorcycleFBrakeSuspensionAngleSlider.Create(0, 90, 0, 90, "F. Brake Susp. Angle: ");
-	motorcycleFBrakeSuspensionAngleSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.motorcycle.front_suspension_angle = wi::math::DegreesToRadians(args.fValue);
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	motorcycleFBrakeSuspensionAngleSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.motorcycle.front_suspension_angle = wi::math::DegreesToRadians(args.fValue);
+	}));
 	AddWidget(&motorcycleFBrakeSuspensionAngleSlider);
 
 	motorcycleFBrakeTorqueSlider.Create(0, 2000, 0, 2000, "F. Brake Torque: ");
-	motorcycleFBrakeTorqueSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.motorcycle.front_brake_torque = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	motorcycleFBrakeTorqueSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.motorcycle.front_brake_torque = args.fValue;
+	}));
 	AddWidget(&motorcycleFBrakeTorqueSlider);
 
 	motorcycleRBrakeTorqueSlider.Create(0, 2000, 0, 2000, "R. Brake Torque: ");
-	motorcycleRBrakeTorqueSlider.OnSlide([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.motorcycle.rear_brake_torque = args.fValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-		});
+	motorcycleRBrakeTorqueSlider.OnSlide(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.motorcycle.rear_brake_torque = args.fValue;
+	}));
 	AddWidget(&motorcycleRBrakeTorqueSlider);
 
 	fourwheelCheckbox.Create("4-wheel drive: ");
-	fourwheelCheckbox.OnClick([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.car.four_wheel_drive = args.bValue;
-				physicscomponent->SetRefreshParametersNeeded();
-			}
-		}
-	});
+	fourwheelCheckbox.OnClick(forEachSelectedPhysicsComponentWithRefresh([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.car.four_wheel_drive = args.bValue;
+	}));
 	AddWidget(&fourwheelCheckbox);
 
 	motorleanCheckbox.Create("Motorcycle lean control: ");
-	motorleanCheckbox.OnClick([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.motorcycle.lean_control = args.bValue;
-				// Here we don't need to recreate physics!!
-			}
-		}
-	});
+	// Here we don't need to recreate physics!!
+	motorleanCheckbox.OnClick(forEachSelectedPhysicsComponent([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.motorcycle.lean_control = args.bValue;
+	}));
 	AddWidget(&motorleanCheckbox);
 
 	driveCheckbox.Create(ICON_VEHICLE " Drive in Editor: ");
@@ -843,62 +460,30 @@ void RigidBodyWindow::Create(EditorComponent* _editor)
 
 	wheelEntityFrontLeftCombo.Create("Front Left Wheel: ");
 	wheelEntityFrontLeftCombo.SetTooltip("Map an entity transform to this wheel, so the wheel graphics can be animated by physics (optional).\nThe entity name must contain the word wheel to be displayed here.");
-	wheelEntityFrontLeftCombo.OnSelect([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.wheel_entity_front_left = args.userdata;
-			}
-		}
-	});
+	wheelEntityFrontLeftCombo.OnSelect(forEachSelectedPhysicsComponent([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.wheel_entity_front_left = args.userdata;
+	}));
 	AddWidget(&wheelEntityFrontLeftCombo);
 
 	wheelEntityFrontRightCombo.Create("Front Right Wheel: ");
 	wheelEntityFrontRightCombo.SetTooltip("Map an entity transform to this wheel, so the wheel graphics can be animated by physics (optional).\nThe entity name must contain the word wheel to be displayed here.");
-	wheelEntityFrontRightCombo.OnSelect([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.wheel_entity_front_right = args.userdata;
-			}
-		}
-		});
+	wheelEntityFrontRightCombo.OnSelect(forEachSelectedPhysicsComponent([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.wheel_entity_front_right = args.userdata;
+	}));
 	AddWidget(&wheelEntityFrontRightCombo);
 
 	wheelEntityRearLeftCombo.Create("Rear Left Wheel: ");
 	wheelEntityRearLeftCombo.SetTooltip("Map an entity transform to this wheel, so the wheel graphics can be animated by physics (optional).\nThe entity name must contain the word wheel to be displayed here.");
-	wheelEntityRearLeftCombo.OnSelect([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.wheel_entity_rear_left = args.userdata;
-			}
-		}
-		});
+	wheelEntityRearLeftCombo.OnSelect(forEachSelectedPhysicsComponent([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.wheel_entity_rear_left = args.userdata;
+	}));
 	AddWidget(&wheelEntityRearLeftCombo);
 
 	wheelEntityRearRightCombo.Create("Rear Right Wheel: ");
 	wheelEntityRearRightCombo.SetTooltip("Map an entity transform to this wheel, so the wheel graphics can be animated by physics (optional).\nThe entity name must contain the word wheel to be displayed here.");
-	wheelEntityRearRightCombo.OnSelect([=](wi::gui::EventArgs args) {
-		wi::scene::Scene& scene = editor->GetCurrentScene();
-		for (auto& x : editor->translator.selected)
-		{
-			RigidBodyPhysicsComponent* physicscomponent = scene.rigidbodies.GetComponent(x.entity);
-			if (physicscomponent != nullptr)
-			{
-				physicscomponent->vehicle.wheel_entity_rear_right = args.userdata;
-			}
-		}
-		});
+	wheelEntityRearRightCombo.OnSelect(forEachSelectedPhysicsComponent([&](auto physicscomponent, auto args) {
+		physicscomponent->vehicle.wheel_entity_rear_right = args.userdata;
+	}));
 	AddWidget(&wheelEntityRearRightCombo);
 
 


### PR DESCRIPTION
use lambdas to reduce the amount of copy pasted code. This makes it easier to see what happens in each handler.