### PR TITLE
cmake: don't build zstd.c

### DIFF
--- a/WickedEngine/Utility/CMakeLists.txt
+++ b/WickedEngine/Utility/CMakeLists.txt
@@ -35,6 +35,7 @@ install(FILES ${HEADER_FILES}
 file(GLOB_RECURSE DIRECTLY_INCLUDED_FILES CONFIGURE_DEPENDS
 	# included by utility_common.cpp
 	mikktspace.c
+	zstd.c
 
 	# included by volk.h
 	volk.c


### PR DESCRIPTION
it's built in utility_common.cpp