### PR TITLE
github build: fix ccache not being updated, limit size

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   CCACHE_VERSION: 4.11.3
+  CCACHE_MAXSIZE: 500Mi
   # needed because wiRenderer uses conditional include via __hasinclude
   CCACHE_NODIRECT: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CCACHE_VERSION: 4.11.3
+  CCACHE_MAXSIZE: 500Mi
   # needed because wiRenderer uses conditional include via __hasinclude
   CCACHE_NODIRECT: 1
 
@@ -21,8 +22,8 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: C:\Users\runneradmin\AppData\Local\ccache
-        key: win-ccache-${{ github.run_id }}
-        restore-keys: win-ccache-
+        key: ccache-win-${{ github.run_id }}
+        restore-keys: ccache-win-
 
     - name: Install Ccache
       run: |
@@ -80,10 +81,19 @@ jobs:
 
 
   linux:
-    name: linux (gcc)
     runs-on: ubuntu-latest
-    steps:
+    name: linux (${{ matrix.cc }})
+    strategy:
+      matrix:
+        include:
+        - cc: gcc
+          cxx: g++
+          package_bins: true
+        - cc: clang
+          cxx: clang++
+          package_bins: false
 
+    steps:
     - uses: actions/checkout@v4
 
     - name: Restore Ccache database
@@ -91,8 +101,8 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ~/.cache/ccache
-        key: ccache-gcc-${{ github.run_id }}
-        restore-keys: ccache-
+        key: ccache-${{ matrix.cc }}-${{ github.run_id }}
+        restore-keys: ccache-${{ matrix.cc }}-
 
     - name: Install dependencies
       run: |
@@ -125,6 +135,7 @@ jobs:
         key: ${{ steps.restore-ccache.outputs.cache-primary-key }}
 
     - name: Move files
+      if: matrix.package_bins
       run: |
         mv build/Editor/Editor ./Editor_Linux
         mv Editor/config.ini ./
@@ -132,6 +143,7 @@ jobs:
         mv Editor/fonts ./
 
     - name: Package Editor
+      if: matrix.package_bins
       uses: actions/upload-artifact@v4
       with:
         name: Editor (Linux)


### PR DESCRIPTION
GitHub has the weird restriction that builders in a branch can only access their own cache as well as the one from "master". Which means PRs cannot use each others CCache. Therefore the master build was also updating the cache.

This also means we'll have to compile clang there as well, just so that the cache can get updated. As with the PR build, the resulting binaries aren't packaged.

I've also fixed the name for the windows cache, build-pr was using ccache-win, but build.yml was using win-ccache.

This commit also reduces the maximum size to 500MiB, otherwise the caches can become too big and get deleted by GitHub before they can be used (the windows one was over 4GiB, and a new one was created for every PR, quickly exceeding the 10 GB limit)