### PR TITLE
github actions: cleanup runner cache on closed pull requests

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,0 +1,29 @@
+name: Cleanup github runner caches on closed pull requests
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cleanup
+        run: |
+          echo "Fetching list of cache keys"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge


### PR DESCRIPTION
The script was taken directly from [the official GitHub docs](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manage-caches#force-deleting-cache-entries), it deletes caches from PR that have been closed and are not useful anymore.

While GitHub will delete older caches automatically, if there are a lot of parallel PRs open, those could be enough to cause the "master" cache to be evicted, which is the only cross-PR cache, leading to longer build times. Also, it's nicer if we clean up garbage ourselves instead of relying on others to do it.

But this PR is completely optional, nothing will break without it (except maybe some longer compilation time in rare cases)