### PR TITLE
show FMA3 and F16C flags when XMVerifyCPUSupport fails

### DIFF
--- a/WickedEngine/Utility/cpuinfo.hpp
+++ b/WickedEngine/Utility/cpuinfo.hpp
@@ -44,6 +44,8 @@ public:
 	inline bool    haveSSE3()          const { return mIsSSE3; }
 	inline bool    haveSSE41()         const { return mIsSSE41; }
 	inline bool    haveSSE42()         const { return mIsSSE42; }
+	inline bool    haveF16C()          const { return mIsF16C; }
+	inline bool    haveFMA3()          const { return mIsFMA3; }
 	inline bool    haveAVX()           const { return mIsAVX; }
 	inline bool    haveAVX2()          const { return mIsAVX2; }
 	inline bool    haveAVX512F()       const { return mIsAVX512F; }
@@ -57,7 +59,9 @@ private:
 	static constexpr uint32_t SSE42_POS = 0x00100000;
 	static constexpr uint32_t AVX_POS = 0x10000000;
 	static constexpr uint32_t AVX2_POS = 0x00000020;
+	static constexpr uint32_t FMA3_POS = 1u << 12;
 	static constexpr uint32_t AVX512F_POS = 1u << 15; // Bit 16
+	static constexpr uint32_t F16C_POS = 1u << 29;
 	static constexpr uint32_t LVL_NUM = 0x000000FF;
 	static constexpr uint32_t LVL_TYPE = 0x0000FF00;
 	static constexpr uint32_t LVL_CORES = 0x0000FFFF;
@@ -77,6 +81,8 @@ private:
 	bool   mIsAVX = false;
 	bool   mIsAVX2 = false;
 	bool   mIsAVX512F = false;
+	bool   mIsF16C = false;
+	bool   mIsFMA3 = false;
 };
 
 CPUInfo::CPUInfo()
@@ -97,6 +103,8 @@ CPUInfo::CPUInfo()
 	mIsSSE41 = cpuID1.ECX() & SSE41_POS;
 	mIsSSE42 = cpuID1.ECX() & SSE41_POS;
 	mIsAVX = cpuID1.ECX() & AVX_POS;
+	mIsF16C = cpuID1.ECX() & F16C_POS;
+	mIsFMA3 = cpuID1.ECX() & FMA3_POS;
 	// Get AVX2 instructions availability
 	CPUID cpuID7(7, 0);
 	mIsAVX2 = cpuID7.EBX() & AVX2_POS;

--- a/WickedEngine/wiInitializer.cpp
+++ b/WickedEngine/wiInitializer.cpp
@@ -75,6 +75,14 @@ namespace wi::initializer
 		{
 			cpustring.push_back("AVX; ");
 		}
+		if (cpuinfo.haveFMA3())
+		{
+			cpustring.push_back("FMA3; ");
+		}
+		if (cpuinfo.haveF16C())
+		{
+			cpustring.push_back("F16C; ");
+		}
 		if (cpuinfo.haveAVX2())
 		{
 			cpustring.push_back("AVX 2; ");
@@ -98,6 +106,12 @@ namespace wi::initializer
 #ifdef _XM_AVX_INTRINSICS_
 		cpustring.push_back("AVX; ");
 #endif // _XM_AVX_INTRINSICS_
+#ifdef _XM_FMA3_INTRINSICS_
+		cpustring.push_back("FMA3; ");
+#endif // _XM_FMA3_INTRINSICS_
+#ifdef _XM_F16C_INTRINSICS_
+		cpustring.push_back("F16C; ");
+#endif // _XM_F16C_INTRINSICS_
 #ifdef _XM_AVX2_INTRINSICS_
 		cpustring.push_back("AVX 2; ");
 #endif // _XM_AVX2_INTRINSICS_


### PR DESCRIPTION
Those are required by the official build, but not supported by older processors that do support AVX. Omitting these flags in the output can be confusing, since every required feature seems to be supported.

Closes #1178