### PR TITLE
cmake: use precompiled headers

### DIFF
--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -5,6 +5,7 @@ string(REGEX REPLACE "([.+?*])" "\\\\\\1" SDIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
 file(GLOB SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
 list(FILTER SOURCE_FILES EXCLUDE REGEX ${SDIR}/main_.*)
+list(FILTER SOURCE_FILES EXCLUDE REGEX ${SDIR}/stdafx.*)
 list(APPEND SOURCE_FILES main_${PLATFORM}.cpp)
 
 
@@ -36,6 +37,8 @@ else ()
 	)
 
 endif ()
+
+target_precompile_headers(Editor PRIVATE "stdafx.h")
 
 # Needed for terrain system
 add_dependencies(Editor Content)

--- a/Samples/Example_ImGui/CMakeLists.txt
+++ b/Samples/Example_ImGui/CMakeLists.txt
@@ -3,11 +3,11 @@ if (NOT WIN32)
 	find_package(Threads REQUIRED)
 endif ()
 
-set (SOURCE_FILES
-	stdafx.cpp
+set(SOURCE_FILES
 	Example_ImGui.cpp
 	Example_ImGui.h
-	stdafx.h
+)
+set(IMGUI_FILES
 	ImGui/imconfig.h
 	ImGui/imgui.cpp
 	ImGui/imgui.h
@@ -22,32 +22,47 @@ set (SOURCE_FILES
 )
 
 if (WIN32)
-	list (APPEND SOURCE_FILES
+	list(APPEND SOURCE_FILES
 		main_Windows.cpp
 		main_Windows.h
 		Tests.rc
+	)
+	list(APPEND IMGUI_FILES
 		ImGui/imgui_impl_win32.cpp
 		ImGui/imgui_impl_win32.h
 	)
+	add_library(Example_ImGui_Lib OBJECT ${IMGUI_FILES})
 
 	add_executable(Example_ImGui WIN32 ${SOURCE_FILES})
 
-	target_link_libraries(Example_ImGui PUBLIC
+	target_link_libraries(Example_ImGui
+		PUBLIC
 		WickedEngine_Windows
+
+		PRIVATE
+		Example_ImGui_Lib
 	)
 	set(LIB_DXCOMPILER "dxcompiler.dll")
 else()
-	list (APPEND SOURCE_FILES
+	list(APPEND SOURCE_FILES
 		main_SDL2.cpp
+	)
+	list(APPEND IMGUI_FILES
 		ImGui/imgui_impl_sdl.cpp
 		ImGui/imgui_impl_sdl.h
 	)
-
+	add_library(Example_ImGui_Lib OBJECT ${IMGUI_FILES})
+	find_package(SDL2 REQUIRED)
+	target_link_libraries(Example_ImGui_Lib PRIVATE SDL2::SDL2)
 	add_executable(Example_ImGui ${SOURCE_FILES})
 
-	target_link_libraries(Example_ImGui PUBLIC
+	target_link_libraries(Example_ImGui
+		PUBLIC
 		WickedEngine
 		Threads::Threads
+
+		PRIVATE
+		Example_ImGui_Lib
 	)
 
 	# Copy shaders to build and source folders just to be safe:

--- a/Samples/Example_ImGui_Docking/CMakeLists.txt
+++ b/Samples/Example_ImGui_Docking/CMakeLists.txt
@@ -3,11 +3,12 @@ if (NOT WIN32)
 	find_package(Threads REQUIRED)
 endif ()
 
-set (SOURCE_FILES
-	stdafx.cpp
+set(SOURCE_FILES
 	Example_ImGui_Docking.cpp
 	Example_ImGui_Docking.h
-	stdafx.h
+	../../Editor/ModelImporter_GLTF.cpp
+)
+set(IMGUI_FILES
 	ImGui/imconfig.h
 	ImGui/imgui.cpp
 	ImGui/imgui.h
@@ -22,36 +23,50 @@ set (SOURCE_FILES
 	ImGui/ImGuizmo.cpp
 	ImGui/ImGuizmo.h
 	ImGui/IconsMaterialDesign.h
-	../../Editor/ModelImporter_GLTF.cpp
 )
 
 if (WIN32)
-	list (APPEND SOURCE_FILES
+	list(APPEND SOURCE_FILES
 		main_Windows.cpp
 		main_Windows.h
 		Tests.rc
+	)
+	list(APPEND IMGUI_FILES
 		ImGui/imgui_impl_win32.cpp
 		ImGui/imgui_impl_win32.h
 	)
+	add_library(Example_ImGui_Docking_Lib OBJECT ${IMGUI_FILES})
 
 	add_executable(Example_ImGui_Docking WIN32 ${SOURCE_FILES})
 
-	target_link_libraries(Example_ImGui_Docking PUBLIC
+	target_link_libraries(Example_ImGui_Docking
+		PUBLIC
 		WickedEngine_Windows
+
+		PRIVATE
+		Example_ImGui_Docking_Lib
 	)
 	set(LIB_DXCOMPILER "dxcompiler.dll")
 else()
-	list (APPEND SOURCE_FILES
+	list(APPEND SOURCE_FILES
 		main_SDL2.cpp
+	)
+	list(APPEND IMGUI_FILES
 		ImGui/imgui_impl_sdl.cpp
 		ImGui/imgui_impl_sdl.h
 	)
-
+	add_library(Example_ImGui_Docking_Lib OBJECT ${IMGUI_FILES})
+	find_package(SDL2 REQUIRED)
+	target_link_libraries(Example_ImGui_Docking_Lib PRIVATE SDL2::SDL2)
 	add_executable(Example_ImGui_Docking ${SOURCE_FILES})
 
-	target_link_libraries(Example_ImGui_Docking PUBLIC
+	target_link_libraries(Example_ImGui_Docking
+		PUBLIC
 		WickedEngine
 		Threads::Threads
+
+		PRIVATE
+		Example_ImGui_Docking_Lib
 	)
 
 	# Copy shaders and font to build and source folders just to be safe:
@@ -65,6 +80,8 @@ else()
 
 	set(LIB_DXCOMPILER "libdxcompiler.so")
 endif ()
+
+target_precompile_headers(Example_ImGui_Docking PRIVATE stdafx.h)
 
 if (MSVC)
 	set_property(TARGET Example_ImGui_Docking PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/Samples/Tests/CMakeLists.txt
+++ b/Samples/Tests/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.19)
 set (SOURCE_FILES
-	stdafx.cpp
 	Tests.cpp
 	Tests.h
-	stdafx.h
 )
 
 if (WIN32)
@@ -33,6 +31,8 @@ else()
 
 	set(LIB_DXCOMPILER "libdxcompiler.so")
 endif ()
+
+target_precompile_headers(Tests PRIVATE stdafx.h)
 
 if (MSVC)
 	set_property(TARGET Tests PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/WickedEngine/CMakeLists.txt
+++ b/WickedEngine/CMakeLists.txt
@@ -86,6 +86,8 @@ add_library(${TARGET_NAME} ${WICKED_LIBRARY_TYPE}
 	${HEADER_FILES}
 )
 
+target_precompile_headers(${TARGET_NAME} PRIVATE WickedEngine.h)
+
 add_library(WickedEngine ALIAS ${TARGET_NAME})
 set_target_properties(${TARGET_NAME} PROPERTIES
 	PUBLIC_HEADER "${HEADER_FILES}"


### PR DESCRIPTION
Preliminary results on my laptop without ccache

| engine | editor | total time |
| ---  | --- | --- |
| no pch | no pch | 4:21 |
| no pch | stdafx.h | 3:33 |
| commoninclude.h | stdafx.h | 3:30 |
| wickedengine.h | stdafx.h | 2:54 |

With the recent changes regarding warnings, PCH on GCC work as well, and compilation is faster for GCC as well with PCH enabled, although only slightly. The difference is a lot larger on Clang.

It also works for cmake on windows, even when using MSVC and CMake, PCH give significant better performance.

See [this run](https://github.com/turanszkij/WickedEngine/actions/runs/16604892363/usage) for example; ccache was disabled and "ON/OFF" refers to the state of PCH.

Therefore, I think we can always use PCH and don't need a flag for it.
