### PR TITLE
gh actions: don't fail fast

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -83,6 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     name: linux (${{ matrix.cc }})
     strategy:
+      fail-fast: false
       matrix:
         include:
         - cc: gcc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     name: linux (${{ matrix.cc }})
     strategy:
+      fail-fast: false
       matrix:
         include:
         - cc: gcc


### PR DESCRIPTION
by default, if any run of a matrix strategy fails, the others are stopped immediately. In our case it means that if gcc fails, the clang build will also fail, which is not what we want.

Change fail-fast to false so that if gcc fails, we can still see if clang also fails or if it is a gcc specific problem or vice versa.