### PR TITLE
improve Ccache hit rate

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -8,7 +8,8 @@ env:
   CCACHE_MAXSIZE: 500Mi
   # needed because wiRenderer uses conditional include via __hasinclude
   CCACHE_NODIRECT: 1
-
+  # see https://ccache.dev/manual/latest.html#_precompiled_headers
+  CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
 jobs:
 
   windows:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ env:
   CCACHE_MAXSIZE: 500Mi
   # needed because wiRenderer uses conditional include via __hasinclude
   CCACHE_NODIRECT: 1
+  # see https://ccache.dev/manual/latest.html#_precompiled_headers
+  CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
 
 jobs:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
         -Wno-nullability-completeness
         -Wno-unused-private-field
+
+        # Increase Ccache hit rate, note that you also need to set config options
+        # in your Ccache config, see https://ccache.dev/manual/latest.html#_precompiled_headers
+        "SHELL:-Xclang -fno-pch-timestamp"
     )
     if (USE_LIBCXX)
         add_compile_options(

--- a/WickedEngine/wiPlatform.h
+++ b/WickedEngine/wiPlatform.h
@@ -28,7 +28,7 @@
 #define wiGetProcAddress(handle,name) dlsym(handle, name)
 typedef void* HMODULE;
 #endif // _WIN32
-
+// dummy change
 #ifdef SDL2
 #include <SDL2/SDL.h>
 #include <SDL_vulkan.h>


### PR DESCRIPTION
Sorry, this will hopefully be the last PR regarding the build system for quite some time.

I missed that Ccache requires specific settings when PCH are used, otherwise the hit rate is pretty close to zero. Those settings can be done via environment variables. For Clang, an additional setting is required, but that setting can always be set even when Ccache is not in use, like in the nightly build.

Note that the first run after this is merged will still be slow, it's only the runs after that that will be fast again.

----

Change the Ccache config so that it has a much higher hit rate during compilation, see https://ccache.dev/manual/latest.html#_precompiled_headers for details.

For Clang, always setting -fno-pch-timestamp seems to be ok, so no need to special case this depending on whether or not Ccache is used.