### PR TITLE
make checks for SDL2 macro consistent

### DIFF
--- a/WickedEngine/wiAudio.cpp
+++ b/WickedEngine/wiAudio.cpp
@@ -703,7 +703,7 @@ namespace wi::audio
 	}
 }
 
-#elif SDL2
+#elif defined(SDL2)
 
 //FAudio implemetation
 #include <FAudio.h>

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -2399,7 +2399,7 @@ using namespace vulkan_internal;
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
 		instanceExtensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
-#elif SDL2
+#elif defined(SDL2)
 		{
 			uint32_t extensionCount;
 			SDL_Vulkan_GetInstanceExtensions(window, &extensionCount, nullptr);
@@ -3779,7 +3779,7 @@ using namespace vulkan_internal;
 			createInfo.hinstance = GetModuleHandle(nullptr);
 
 			vulkan_check(vkCreateWin32SurfaceKHR(instance, &createInfo, nullptr, &internal_state->surface));
-#elif SDL2
+#elif defined(SDL2)
 			if (!SDL_Vulkan_CreateSurface(window, instance, &internal_state->surface))
 			{
 				throw sdl2::SDLError("Error creating a vulkan surface");

--- a/WickedEngine/wiInput.cpp
+++ b/WickedEngine/wiInput.cpp
@@ -170,7 +170,7 @@ namespace wi::input
 		mouse.position.x = (float)p.x;
 		mouse.position.y = (float)p.y;
 
-#elif SDL2
+#elif defined(SDL2)
 		wi::input::sdlinput::GetMouseState(&mouse);
 		wi::input::sdlinput::GetKeyboardState(&keyboard);
 #endif
@@ -637,7 +637,7 @@ namespace wi::input
 			}
 #if defined(_WIN32) && !defined(PLATFORM_XBOX)
 			return KEY_DOWN(keycode) || KEY_TOGGLE(keycode);
-#elif SDL2
+#elif defined(SDL2)
 			return keyboard.buttons[keycode] == 1;
 #endif
 		}
@@ -734,7 +734,7 @@ namespace wi::input
 		{
 			while (ShowCursor(true) < 0) {};
 		}
-#elif SDL2
+#elif defined(SDL2)
 		SDL_SetRelativeMouseMode(value ? SDL_TRUE : SDL_FALSE);
 #endif // _WIN32
 	}

--- a/WickedEngine/wiPlatform.h
+++ b/WickedEngine/wiPlatform.h
@@ -41,7 +41,7 @@ namespace wi::platform
 #ifdef _WIN32
 	using window_type = HWND;
 	using error_type = HRESULT;
-#elif SDL2
+#elif defined(SDL2)
 	using window_type = SDL_Window*;
 	using error_type = int;
 #else


### PR DESCRIPTION
Most of the code checks if corresponding macro is defined, but a few instances checked if it was defined and truthy.

Make this consistent and only require the macro to be defined to be considered.