### PR TITLE
stop gcc warning

### DIFF
--- a/WickedEngine/wiECS.h
+++ b/WickedEngine/wiECS.h
@@ -227,7 +227,8 @@ namespace wi::ecs
 				entities.resize(prev_count + count);
 				for (size_t i = 0; i < count; ++i)
 				{
-					Entity entity;
+					// assign value to make GCC happy
+					Entity entity = INVALID_ENTITY;
 					SerializeEntity(archive, entity, seri);
 					entities[prev_count + i] = entity;
 					lookup[entity] = prev_count + i;


### PR DESCRIPTION
#1190 will take more time to figure out what exactly triggers the build failures, so a separate PR for the GCC warning it is.