### PR TITLE
use correct __has_include

### DIFF
--- a/WickedEngine/wiMath.h
+++ b/WickedEngine/wiMath.h
@@ -10,7 +10,7 @@
   #define _XM_FMA3_INTRINSICS_
 #endif
 
-#if __has_include("DirectXMath.h")
+#if __has_include(<DirectXMath.h>)
 // In this case, DirectXMath is coming from Windows SDK.
 //	It is better to use this on Windows as some Windows libraries could depend on the same
 //	DirectXMath headers

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -16,7 +16,7 @@
 #include "shaders/ShaderInterop_SurfelGI.h"
 #include "shaders/ShaderInterop_DDGI.h"
 
-#if __has_include("sanitizer/asan_interface.h")
+#if __has_include(<sanitizer/asan_interface.h>)
 #include <sanitizer/asan_interface.h>
 #else
 #define ASAN_UNPOISON_MEMORY_REGION(ptr,size)

--- a/WickedEngine/wiXInput.cpp
+++ b/WickedEngine/wiXInput.cpp
@@ -1,6 +1,6 @@
 #include "wiXInput.h"
 
-#if __has_include("xinput.h")
+#if __has_include(<xinput.h>)
 
 #if defined(PLATFORM_WINDOWS_DESKTOP)
 #include <xinput.h>
@@ -121,4 +121,4 @@ namespace wi::input::xinput
 	bool GetControllerState(wi::input::ControllerState* state, int index) { return false; }
 	void SetControllerFeedback(const wi::input::ControllerFeedback& data, int index) {}
 }
-#endif // __has_include("xinput.h")
+#endif // __has_include(<xinput.h>)


### PR DESCRIPTION
__has_include should use the same form as the #include, otherwise search paths might differ. It probably doesn't matter in practice, but better safe than sorry.