### PR TITLE
cmake: handle (non)existance of wiShaderDump.h automatically

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Recompile with shader dump
       run: |
         cd build
-        make -B -j $(nproc)
+        make -j $(nproc)
         
     - name: Move files
       run: |

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -6,9 +6,8 @@ on:
 env:
   CCACHE_VERSION: 4.11.3
   CCACHE_MAXSIZE: 500Mi
-  # needed because wiRenderer uses conditional include via __hasinclude
-  CCACHE_NODIRECT: 1
-
+  # see https://ccache.dev/manual/latest.html#_precompiled_headers
+  CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
 jobs:
 
   windows:
@@ -122,7 +121,7 @@ jobs:
 
     - name: Recompile with shader dump
       run: |
-        make -C build -B -j$(nproc)
+        make -C build -j$(nproc)
 
     - name: Save Ccache database
       id: save-ccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ on:
 env:
   CCACHE_VERSION: 4.11.3
   CCACHE_MAXSIZE: 500Mi
-  # needed because wiRenderer uses conditional include via __hasinclude
-  CCACHE_NODIRECT: 1
+  # see https://ccache.dev/manual/latest.html#_precompiled_headers
+  CCACHE_SLOPPINESS: pch_defines,time_macros,include_file_mtime,include_file_ctime
 
 jobs:
 
@@ -125,7 +125,7 @@ jobs:
     - name: Recompile with shader dump
       run: |
         cd build
-        make -B -j $(nproc)
+        make -j $(nproc)
 
     - name: Save Ccache database
       id: save-ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
         -Wno-nullability-completeness
         -Wno-unused-private-field
+
+        # Increase Ccache hit rate, note that you also need to set config options
+        # in your Ccache config, see https://ccache.dev/manual/latest.html#_precompiled_headers
+        "SHELL:-Xclang -fno-pch-timestamp"
     )
     if (USE_LIBCXX)
         add_compile_options(

--- a/WickedEngine/CMakeLists.txt
+++ b/WickedEngine/CMakeLists.txt
@@ -76,6 +76,8 @@ set_target_properties(Jolt PROPERTIES
 )
 add_compile_definitions(Jolt JPH_DEBUG_RENDERER)
 
+# Note: if you remove this glob, the wiShaderDump.h hack
+# will stop working, see below for more information
 file(GLOB HEADER_FILES CONFIGURE_DEPENDS *.h)
 
 file(GLOB SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
@@ -162,6 +164,21 @@ elseif ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR "${CMAKE_SYSTEM_PROCESS
 endif()
 
 target_compile_definitions(${TARGET_NAME} PUBLIC WICKED_CMAKE_BUILD)
+
+# wiRenderer.cpp gets compiled differently depending on whether or not
+# wiShaderDump.h exists. If it does, it includes it and defines
+# SHADERDUMP_ENABLED. CMake doesn't support optional dependencies,
+# so we check if the file exists and define it ourselves if it does,
+# this will cause the file to be recompiled if necessary.
+# IMPORTANT: this only works because we are using GLOB on header files
+# and therefore CMake will re-run if those change. Without a GLOB
+# the check will only be done once and stop working reliably.
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/wiShaderDump.h)
+    set_property(
+        SOURCE wiRenderer.cpp
+        PROPERTY COMPILE_DEFINITIONS "SHADERDUMP_ENABLED="
+    )
+endif()
 
 if (WIN32)
 	target_compile_definitions(${TARGET_NAME} PUBLIC


### PR DESCRIPTION
We set SHADERDUMP_ENABLED on wiRenderer depending on whether or not
wiShaderDump.h exists. This will cause a recompile if necessary, even
though normally the build system cannot see the has_includes.

Since the compiler flags are different, this will even work with CCache
in direct mode.

This commit also configures CCache to have better hit rate for
precompiled headers as well as re-enabling the (much faster) direct
mode.