### PR TITLE
cmake: remove useless unity exception

### DIFF
--- a/WickedEngine/CMakeLists.txt
+++ b/WickedEngine/CMakeLists.txt
@@ -236,7 +236,6 @@ add_custom_command(
 set_property(SOURCE
     wiAudio.cpp
     wiOcean.cpp
-    wiPrimitive_BindLUA.cpp
     wiPhysics_Jolt.cpp
     wiGraphicsDevice_Vulkan.cpp
     wiGraphicsDevice_DX12.cpp


### PR DESCRIPTION
Due to an typo, a nonexistant file was being excluded.

wiPhysics and wiPrimitive_BindLua cannot be compiled in the same unity file,
but wiPhysics is already compiled separately, so we can just remove the
exception.