### PR TITLE
editor: crash fix for export to c++ header file dialog

### DIFF
--- a/Editor/MeshWindow.cpp
+++ b/Editor/MeshWindow.cpp
@@ -598,7 +598,7 @@ void MeshWindow::Create(EditorComponent* _editor)
 		params.extensions.push_back("h");
 		params.type = wi::helper::FileDialogParams::TYPE::SAVE;
 		wi::helper::FileDialog(params, [&](std::string filename) {
-			wi::eventhandler::Subscribe_Once(wi::eventhandler::EVENT_THREAD_SAFE_POINT, [&](uint64_t userdata) {
+			wi::eventhandler::Subscribe_Once(wi::eventhandler::EVENT_THREAD_SAFE_POINT, [=](uint64_t userdata) {
 
 				wi::scene::Scene& scene = editor->GetCurrentScene();
 				wi::vector<XMFLOAT3> vertices;


### PR DESCRIPTION
If you select an object, open the mesh subwindow and click "Export to C++ Header" the editor will crash. Inspecting the code, I found that a `std::string` on the stack was reference captured by a lambda event handler. I think the only objects that need to be captured are the string and a pointer to `editor`, so I just made it to capture by value.