### PR TITLE
Remove stack reference capture

### DIFF
--- a/Editor/SplineWindow.cpp
+++ b/Editor/SplineWindow.cpp
@@ -53,7 +53,7 @@ void SplineWindow::Create(EditorComponent* _editor)
 	};
 
 	auto forEachSelectedAndIndirectWithRefresh = [this, forEachSelectedAndIndirect] (auto func) {
-		return [this, &forEachSelectedAndIndirect, func] (auto args) {
+		return [this, forEachSelectedAndIndirect, func] (auto args) {
 			forEachSelectedAndIndirect(func);
 			editor->componentsWnd.RefreshEntityTree();
 		};


### PR DESCRIPTION
If there is any doubt about this, I recorded the backtraces to show this. Note that I am using the "Terrain modifier" slider as a demonstration. Consider the following:

During initialization
```
   55     auto forEachSelectedAndIndirectWithRefresh = [this, forEachSelectedAndIndirect] (auto func) { 
-> 56       return [this, &forEachSelectedAndIndirect, func] (auto args) {
   57         forEachSelectedAndIndirect(func);
   58         editor->componentsWnd.RefreshEntityTree();
   59       };
(lldb) bt
* thread #1, name = 'Editor', stop reason = step in
  * frame #0: 0x000055555637ab12 Editor`_ZZN12SplineWindow6CreateEP15EditorComponentENK3$_5clIZNS_6CreateES1_E3$_9EEDaT_(this=0x00007fffffff7050, func=(unnamed class) @ 0x00007fffffff6a1f) at SplineWindow.cpp:56:10
    frame #1: 0x0000555556379828 Editor`SplineWindow::Create(this=0x0000555558647b20, _editor=0x0000555557e0dd00) at SplineWindow.cpp:105:24
    frame #2: 0x0000555555e807fd Editor`ComponentsWindow::Create(this=0x0000555557e38310, _editor=0x0000555557e0dd00) at ComponentsWindow.cpp:165:12
    frame #3: 0x0000555555eea3f9 Editor`EditorComponent::Load(this=0x0000555557e0dd00) at Editor.cpp:1322:16
    frame #4: 0x0000555555ee0beb Editor`Editor::Initialize(this=0x0000555557e0d990) at Editor.cpp:344:19
    frame #5: 0x000055555647b5f0 Editor`wi::Application::Run(this=0x0000555557e0d990) at wiApplication.cpp:93:4
    frame #6: 0x000055555646905c Editor`sdl_loop() at main_SDL2.cpp:37:16
    frame #7: 0x0000555556469c4d Editor`main(argc=1, argv=0x00007fffffffe618) at main_SDL2.cpp:247:15
    frame #8: 0x00007ffff793f6b5 libc.so.6`__libc_start_call_main(main=(Editor`main at main_SDL2.cpp:185), argc=1, argv=0x00007fffffffe618) at libc_start_call_main.h:58:16
    frame #9: 0x00007ffff793f769 libc.so.6`__libc_start_main_impl(main=(Editor`main at main_SDL2.cpp:185), argc=1, argv=0x00007fffffffe618, init=<unavailable>, fini=<unavailable>, rtld_fini=<unavailable>, stack_end=0x00007fffffffe608) at libc-start.c:360:3
    frame #10: 0x0000555555e2b785 Editor`_start + 37
```
And here is where the terrain modifier is... slid... slided... moved.
```
* thread #1, name = 'Editor', stop reason = breakpoint 1.5
    frame #0: 0x000055555637e6e8 Editor`_ZZZN12SplineWindow6CreateEP15EditorComponentENK3$_5clIZNS_6CreateES1_E3$_9EEDaT_ENKUlS5_E_clIN2wi3gui9EventArgsEEEDaS5_(this=0x000055555b7724b0, args=EventArgs @ 0x00007fffffff8c80) at SplineWindow.cpp:57:4
   54
   55     auto forEachSelectedAndIndirectWithRefresh = [this, forEachSelectedAndIndirect] (auto func) {
   56       return [this, &forEachSelectedAndIndirect, func] (auto args) {
-> 57         forEachSelectedAndIndirect(func);
   58         editor->componentsWnd.RefreshEntityTree();
   59       };
   60     };
(lldb) bt
* thread #1, name = 'Editor', stop reason = breakpoint 1.5
  * frame #0: 0x000055555637e6e8 Editor`_ZZZN12SplineWindow6CreateEP15EditorComponentENK3$_5clIZNS_6CreateES1_E3$_9EEDaT_ENKUlS5_E_clIN2wi3gui9EventArgsEEEDaS5_(this=0x000055555b7724b0, args=EventArgs @ 0x00007fffffff8c80) at SplineWindow.cpp:57:4
    frame #1: 0x000055555637e652 Editor`_ZSt13__invoke_implIvRZZN12SplineWindow6CreateEP15EditorComponentENK3$_5clIZNS0_6CreateES2_E3$_9EEDaT_EUlS6_E_JN2wi3gui9EventArgsEEES6_St14__invoke_otherOT0_DpOT1_((null)=__invoke_other @ 0x00007fffffff8c7f, __f=0x000055555b7724b0, __args=0x00007fffffff8e78) at invoke.h:63:14
    frame #2: 0x000055555637e5cd Editor`_ZSt10__invoke_rIvRZZN12SplineWindow6CreateEP15EditorComponentENK3$_5clIZNS0_6CreateES2_E3$_9EEDaT_EUlS6_E_JN2wi3gui9EventArgsEEENSt9enable_ifIX16is_invocable_r_vIS6_T0_DpT1_EES6_E4typeEOSD_DpOSE_(__fn=0x000055555b7724b0, __args=0x00007fffffff8e78) at invoke.h:113:2
    frame #3: 0x000055555637e4b5 Editor`_ZNSt17_Function_handlerIFvN2wi3gui9EventArgsEEZZN12SplineWindow6CreateEP15EditorComponentENK3$_5clIZNS4_6CreateES6_E3$_9EEDaT_EUlSA_E_E9_M_invokeERKSt9_Any_dataOS2_(__functor=0x0000555558665f18, __args=0x00007fffffff8e78) at std_function.h:292:9
    frame #4: 0x00005555564ff0ea Editor`std::function<void (wi::gui::EventArgs)>::operator()(this=0x0000555558665f18, __args=EventArgs @ 0x00007fffffff8e78) const at std_function.h:593:9
    frame #5: 0x00005555564da7eb Editor`wi::gui::Slider::Update(this=0x0000555558664d20, canvas=0x0000555557e0dd00, dt=0.0167855825) at wiGUI.cpp:2192:5
    frame #6: 0x00005555564e33b5 Editor`wi::gui::Window::Update(this=0x0000555558647b20, canvas=0x0000555557e0dd00, dt=0.0167855825) at wiGUI.cpp:3782:12
    frame #7: 0x00005555564e33b5 Editor`wi::gui::Window::Update(this=0x0000555557e38310, canvas=0x0000555557e0dd00, dt=0.0167855825) at wiGUI.cpp:3782:12
    frame #8: 0x00005555564cfa5b Editor`wi::gui::GUI::Update(this=0x0000555557e0df80, canvas=0x0000555557e0dd00, dt=0.0167855825) at wiGUI.cpp:82:12
    frame #9: 0x00005555566e1ffd Editor`wi::RenderPath2D::Update(this=0x0000555557e0dd00, dt=0.0167855825) at wiRenderPath2D.cpp:94:12
    frame #10: 0x0000555555ef68a9 Editor`EditorComponent::Update(this=0x0000555557e0dd00, dt=0.0167855825) at Editor.cpp:2919:16
    frame #11: 0x000055555647cebf Editor`wi::Application::Update(this=0x0000555557e0d990, dt=0.0167855825) at wiApplication.cpp:406:16
    frame #12: 0x000055555647c77b Editor`wi::Application::Run(this=0x0000555557e0d990) at wiApplication.cpp:323:3
    frame #13: 0x000055555646905c Editor`sdl_loop() at main_SDL2.cpp:37:16
    frame #14: 0x0000555556469c4d Editor`main(argc=1, argv=0x00007fffffffe618) at main_SDL2.cpp:247:15
    frame #15: 0x00007ffff793f6b5 libc.so.6`__libc_start_call_main(main=(Editor`main at main_SDL2.cpp:185), argc=1, argv=0x00007fffffffe618) at libc_start_call_main.h:58:16
    frame #16: 0x00007ffff793f769 libc.so.6`__libc_start_main_impl(main=(Editor`main at main_SDL2.cpp:185), argc=1, argv=0x00007fffffffe618, init=<unavailable>, fini=<unavailable>, rtld_fini=<unavailable>, stack_end=0x00007fffffffe608) at libc-start.c:360:3
    frame #17: 0x0000555555e2b785 Editor`_start + 37
(lldb) print forEachSelectedAndIndirect
((unnamed class)) {
  this = 0x0000555558647b20
}
```

So, it looks like the stack address is pretty far up there which is probably why there isn't an easily reproduced crash.