### PR TITLE
Prevent accidental reference captures in Editor

### DIFF
--- a/Editor/AnimationWindow.cpp
+++ b/Editor/AnimationWindow.cpp
@@ -43,7 +43,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	modeComboBox.AddItem("Step", AnimationComponent::AnimationSampler::Mode::STEP);
 	modeComboBox.AddItem("Linear", AnimationComponent::AnimationSampler::Mode::LINEAR);
 	modeComboBox.AddItem("Cubic spline", AnimationComponent::AnimationSampler::Mode::CUBICSPLINE);
-	modeComboBox.OnSelect([&](wi::gui::EventArgs args) {
+	modeComboBox.OnSelect([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -77,7 +77,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	loopTypeButton.SetDescription("Loop type: ");
 	loopTypeButton.SetSize(XMFLOAT2(hei, hei));
 	loopTypeButton.SetPos(XMFLOAT2(x, y += step));
-	loopTypeButton.OnClick([&](wi::gui::EventArgs args) {
+	loopTypeButton.OnClick([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -103,7 +103,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	backwardsButton.SetTooltip("Play the animation backwards from the current position.");
 	backwardsButton.SetSize(XMFLOAT2(30, hei));
 	backwardsButton.SetPos(XMFLOAT2(loopTypeButton.GetPos().x + loopTypeButton.GetSize().x + padding, y));
-	backwardsButton.OnClick([&](wi::gui::EventArgs args) {
+	backwardsButton.OnClick([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -121,7 +121,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	backwardsFromEndButton.SetTooltip("Play the animation backwards starting from the end.");
 	backwardsFromEndButton.SetSize(backwardsButton.GetSize());
 	backwardsFromEndButton.SetPos(XMFLOAT2(backwardsButton.GetPos().x + backwardsButton.GetSize().x + padding, y));
-	backwardsFromEndButton.OnClick([&](wi::gui::EventArgs args) {
+	backwardsFromEndButton.OnClick([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -137,7 +137,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	stopButton.SetTooltip("Stop.");
 	stopButton.SetSize(backwardsButton.GetSize());
 	stopButton.SetPos(XMFLOAT2(backwardsButton.GetPos().x + backwardsButton.GetSize().x * 2 + padding * 2, y));
-	stopButton.OnClick([&](wi::gui::EventArgs args) {
+	stopButton.OnClick([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -158,7 +158,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	playFromStartButton.SetTooltip("Play the animation from the beginning.");
 	playFromStartButton.SetSize(backwardsButton.GetSize());
 	playFromStartButton.SetPos(XMFLOAT2(backwardsButton.GetPos().x + backwardsButton.GetSize().x * 3 + padding * 3, y));
-	playFromStartButton.OnClick([&](wi::gui::EventArgs args) {
+	playFromStartButton.OnClick([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -175,7 +175,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	playButton.SetTooltip("Play the animation from the current position.");
 	playButton.SetSize(backwardsButton.GetSize());
 	playButton.SetPos(XMFLOAT2(backwardsButton.GetPos().x + backwardsButton.GetSize().x * 4 + padding * 4, y));
-	playButton.OnClick([&](wi::gui::EventArgs args) {
+	playButton.OnClick([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -191,7 +191,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	timerSlider.Create(0, 1, 0, 100000, "Timer: ");
 	timerSlider.SetSize(XMFLOAT2(wid, hei));
 	timerSlider.SetPos(XMFLOAT2(x, y += step));
-	timerSlider.OnSlide([&](wi::gui::EventArgs args) {
+	timerSlider.OnSlide([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -205,7 +205,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	amountSlider.Create(0, 1, 1, 100000, "Amount: ");
 	amountSlider.SetSize(XMFLOAT2(wid, hei));
 	amountSlider.SetPos(XMFLOAT2(x, y += step));
-	amountSlider.OnSlide([&](wi::gui::EventArgs args) {
+	amountSlider.OnSlide([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -219,7 +219,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	speedSlider.Create(0, 4, 1, 100000, "Speed: ");
 	speedSlider.SetSize(XMFLOAT2(wid, hei));
 	speedSlider.SetPos(XMFLOAT2(x, y += step));
-	speedSlider.OnSlide([&](wi::gui::EventArgs args) {
+	speedSlider.OnSlide([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -236,7 +236,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	startInput.SetDescription("Start time: ");
 	startInput.SetSize(XMFLOAT2(wid, hei));
 	startInput.SetPos(XMFLOAT2(x, y += step));
-	startInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	startInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -250,7 +250,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	endInput.SetDescription("End time: ");
 	endInput.SetSize(XMFLOAT2(wid, hei));
 	endInput.SetPos(XMFLOAT2(x, y += step));
-	endInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	endInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -295,7 +295,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	recordCombo.AddItem("Material [reflectance] " ICON_MATERIAL);
 	recordCombo.AddItem("Material [texmuladd] " ICON_MATERIAL);
 	recordCombo.AddItem("Close loop " ICON_LOOP, ~0ull);
-	recordCombo.OnSelect([&](wi::gui::EventArgs args) {
+	recordCombo.OnSelect([this](wi::gui::EventArgs args) {
 		wi::scene::Scene& scene = editor->GetCurrentScene();
 
 		AnimationComponent* animation = scene.animations.GetComponent(entity);
@@ -1007,7 +1007,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	rootMotionCheckBox.SetTooltip("Toggle root bone animation.");
 	rootMotionCheckBox.SetSize(XMFLOAT2(hei, hei));
 	//rootMotionCheckBox.SetPos(XMFLOAT2(x, y += step));
-	rootMotionCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	rootMotionCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{
@@ -1026,7 +1026,7 @@ void AnimationWindow::Create(EditorComponent* _editor)
 	rootBoneComboBox.SetSize(XMFLOAT2(wid, hei));
 	rootBoneComboBox.SetPos(XMFLOAT2(x, y));
 	rootBoneComboBox.SetEnabled(false);
-	rootBoneComboBox.OnSelect([&](wi::gui::EventArgs args) {
+	rootBoneComboBox.OnSelect([this](wi::gui::EventArgs args) {
 		AnimationComponent* animation = editor->GetCurrentScene().animations.GetComponent(entity);
 		if (animation != nullptr)
 		{

--- a/Editor/CameraWindow.cpp
+++ b/Editor/CameraWindow.cpp
@@ -68,7 +68,7 @@ void CameraWindow::Create(EditorComponent* _editor)
 		editor->GetCurrentEditorScene().camera.zFarP = editor->main->config.GetSection("camera").GetFloat("far");
 	}
 	farPlaneSlider.SetValue(editor->GetCurrentEditorScene().camera.zFarP);
-	farPlaneSlider.OnSlide(updateCamera([&](CameraComponent& camera, auto args) {
+	farPlaneSlider.OnSlide(updateCamera([this](CameraComponent& camera, auto args) {
 		camera.zFarP = args.fValue;
 		editor->main->config.GetSection("camera").Set("far", args.fValue);
 		editor->main->config.Commit();
@@ -84,7 +84,7 @@ void CameraWindow::Create(EditorComponent* _editor)
 		editor->GetCurrentEditorScene().camera.zNearP = editor->main->config.GetSection("camera").GetFloat("near");
 	}
 	nearPlaneSlider.SetValue(editor->GetCurrentEditorScene().camera.zNearP);
-	nearPlaneSlider.OnSlide(updateCamera([&](CameraComponent& camera, auto args) {
+	nearPlaneSlider.OnSlide(updateCamera([this](CameraComponent& camera, auto args) {
 		camera.zNearP = args.fValue;
 		editor->main->config.GetSection("camera").Set("near", args.fValue);
 		editor->main->config.Commit();
@@ -100,7 +100,7 @@ void CameraWindow::Create(EditorComponent* _editor)
 		editor->GetCurrentEditorScene().camera.fov = editor->main->config.GetSection("camera").GetFloat("fov") / 180.f * XM_PI;
 	}
 	fovSlider.SetValue(editor->GetCurrentEditorScene().camera.fov / XM_PI * 180.f);
-	fovSlider.OnSlide(updateCamera([&](CameraComponent& camera, auto args) {
+	fovSlider.OnSlide(updateCamera([this](CameraComponent& camera, auto args) {
 		camera.fov = args.fValue / 180.f * XM_PI;
 		editor->main->config.GetSection("camera").Set("fov", args.fValue);
 		editor->main->config.Commit();
@@ -111,7 +111,7 @@ void CameraWindow::Create(EditorComponent* _editor)
 	focalLengthSlider.SetTooltip("Controls the depth of field effect's focus distance.\nYou can also refocus by holding the C key and picking in the scene with the left mouse button.");
 	focalLengthSlider.SetSize(XMFLOAT2(wid, hei));
 	focalLengthSlider.SetPos(XMFLOAT2(x, y += step));
-	focalLengthSlider.OnSlide(updateCamera([&](CameraComponent& camera, auto args) {
+	focalLengthSlider.OnSlide(updateCamera([](CameraComponent& camera, auto args) {
 		camera.focal_length = args.fValue;
 	}));
 	AddWidget(&focalLengthSlider);
@@ -120,7 +120,7 @@ void CameraWindow::Create(EditorComponent* _editor)
 	apertureSizeSlider.SetTooltip("Controls the depth of field effect's strength");
 	apertureSizeSlider.SetSize(XMFLOAT2(wid, hei));
 	apertureSizeSlider.SetPos(XMFLOAT2(x, y += step));
-	apertureSizeSlider.OnSlide(updateCamera([&](CameraComponent& camera, auto args) {
+	apertureSizeSlider.OnSlide(updateCamera([](CameraComponent& camera, auto args) {
 		camera.aperture_size = args.fValue;
 	}));
 	AddWidget(&apertureSizeSlider);
@@ -129,7 +129,7 @@ void CameraWindow::Create(EditorComponent* _editor)
 	apertureShapeXSlider.SetTooltip("Controls the depth of field effect's bokeh shape");
 	apertureShapeXSlider.SetSize(XMFLOAT2(wid, hei));
 	apertureShapeXSlider.SetPos(XMFLOAT2(x, y += step));
-	apertureShapeXSlider.OnSlide(updateCamera([&](CameraComponent& camera, auto args) {
+	apertureShapeXSlider.OnSlide(updateCamera([](CameraComponent& camera, auto args) {
 		camera.aperture_shape.x = args.fValue;
 	}));
 	AddWidget(&apertureShapeXSlider);
@@ -138,7 +138,7 @@ void CameraWindow::Create(EditorComponent* _editor)
 	apertureShapeYSlider.SetTooltip("Controls the depth of field effect's bokeh shape");
 	apertureShapeYSlider.SetSize(XMFLOAT2(wid, hei));
 	apertureShapeYSlider.SetPos(XMFLOAT2(x, y += step));
-	apertureShapeYSlider.OnSlide(updateCamera([&](CameraComponent& camera, auto args) {
+	apertureShapeYSlider.OnSlide(updateCamera([](CameraComponent& camera, auto args) {
 		camera.aperture_shape.y = args.fValue;
 	}));
 	AddWidget(&apertureShapeYSlider);
@@ -185,7 +185,7 @@ void CameraWindow::Create(EditorComponent* _editor)
 	resetButton.Create("Reset Camera");
 	resetButton.SetSize(XMFLOAT2(wid, hei));
 	resetButton.SetPos(XMFLOAT2(x, y += step));
-	resetButton.OnClick([&](wi::gui::EventArgs args) {
+	resetButton.OnClick([this](wi::gui::EventArgs args) {
 		ResetCam();
 
 		CameraComponent& camera = editor->GetCurrentEditorScene().camera;
@@ -204,7 +204,7 @@ void CameraWindow::Create(EditorComponent* _editor)
 	{
 		fpsCheckBox.SetCheck(editor->main->config.GetSection("camera").GetBool("fps"));
 	}
-	fpsCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	fpsCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		editor->main->config.GetSection("camera").Set("fps", args.bValue);
 		editor->main->config.Commit();
 		});
@@ -214,7 +214,7 @@ void CameraWindow::Create(EditorComponent* _editor)
 	orthoCheckBox.SetSize(XMFLOAT2(hei, hei));
 	orthoCheckBox.SetPos(XMFLOAT2(x, y += step));
 	orthoCheckBox.SetCheck(editor->GetCurrentEditorScene().camera.IsOrtho());
-	orthoCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	orthoCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		Scene& scene = editor->GetCurrentScene();
 		CameraComponent& camera = editor->GetCurrentEditorScene().camera;
 		camera.SetOrtho(args.bValue);

--- a/Editor/ComponentsWindow.cpp
+++ b/Editor/ComponentsWindow.cpp
@@ -54,7 +54,7 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 	filterCombo.AddItem(ICON_SPLINE, (uint64_t)Filter::Spline);
 	filterCombo.SetTooltip("Apply filtering to the Entities by components");
 	filterCombo.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
-	filterCombo.OnSelect([&](wi::gui::EventArgs args) {
+	filterCombo.OnSelect([this](wi::gui::EventArgs args) {
 		filter = (Filter)args.userdata;
 		RefreshEntityTree();
 		});

--- a/Editor/ContentBrowserWindow.h
+++ b/Editor/ContentBrowserWindow.h
@@ -1,4 +1,5 @@
 #pragma once
+
 class EditorComponent;
 
 class ContentBrowserWindow : public wi::gui::Window
@@ -22,7 +23,7 @@ public:
 	};
 	SELECTION current_selection = SELECTION_COUNT;
 	wi::gui::Button folderButtons[SELECTION_COUNT];
-	wi::vector<wi::gui::Button> itemButtons;
+  std::deque<wi::gui::Button> itemButtons;
 
 	wi::gui::Button openFolderButton;
 

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -568,7 +568,7 @@ void EditorComponent::Load()
 	newSceneButton.Create("+");
 	newSceneButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
 	newSceneButton.SetTooltip("New scene");
-	newSceneButton.OnClick([&](wi::gui::EventArgs args) {
+	newSceneButton.OnClick([this](wi::gui::EventArgs args) {
 		NewScene();
 		});
 	topmenuWnd.AddWidget(&newSceneButton);
@@ -883,7 +883,7 @@ void EditorComponent::Load()
 		scaleButton.SetShadowRadius(2);
 		scaleButton.SetTooltip("Scale\nHotkey: 3");
 		scaleButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
-		scaleButton.OnClick([&](wi::gui::EventArgs args) {
+		scaleButton.OnClick([this](wi::gui::EventArgs args) {
 			translator.isScalator = true;
 			translator.isTranslator = false;
 			translator.isRotator = false;
@@ -893,7 +893,7 @@ void EditorComponent::Load()
 		rotateButton.SetShadowRadius(2);
 		rotateButton.SetTooltip("Rotate\nHotkey: 2");
 		rotateButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
-		rotateButton.OnClick([&](wi::gui::EventArgs args) {
+		rotateButton.OnClick([this](wi::gui::EventArgs args) {
 			translator.isRotator = true;
 			translator.isScalator = false;
 			translator.isTranslator = false;
@@ -903,7 +903,7 @@ void EditorComponent::Load()
 		translateButton.SetShadowRadius(2);
 		translateButton.SetTooltip("Translate/Move (Ctrl + T)\nHotkey: 1");
 		translateButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
-		translateButton.OnClick([&](wi::gui::EventArgs args) {
+		translateButton.OnClick([this](wi::gui::EventArgs args) {
 			translator.isTranslator = true;
 			translator.isScalator = false;
 			translator.isRotator = false;
@@ -918,7 +918,7 @@ void EditorComponent::Load()
 	{
 		wi::physics::SetSimulationEnabled(main->config.GetSection("options").GetBool("physics"));
 	}
-	physicsButton.OnClick([&](wi::gui::EventArgs args) {
+	physicsButton.OnClick([this](wi::gui::EventArgs args) {
 		if (wi::input::Down(wi::input::KEYBOARD_BUTTON_LCONTROL))
 		{
 			wi::physics::ResetPhysicsObjects(GetCurrentScene());
@@ -936,7 +936,7 @@ void EditorComponent::Load()
 	dummyButton.SetShadowRadius(2);
 	dummyButton.SetTooltip("Toggle reference dummy visualizer\n - Use the reference dummy to get an idea about object sizes compared to a human character size.\n - Position the dummy by clicking on something with the middle mouse button while the dummy is active.\n - Pressing this button while Ctrl key is held down will reset dummy position to the origin.\n - Pressing this button while the Shift key is held down will switch between male and female dummies.");
 	dummyButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
-	dummyButton.OnClick([&](wi::gui::EventArgs args) {
+	dummyButton.OnClick([this](wi::gui::EventArgs args) {
 		if (wi::input::Down(wi::input::KEYBOARD_BUTTON_LCONTROL) || wi::input::Down(wi::input::KEYBOARD_BUTTON_RCONTROL))
 		{
 			dummy_pos = XMFLOAT3(0, 0, 0);
@@ -956,7 +956,7 @@ void EditorComponent::Load()
 	navtestButton.SetShadowRadius(2);
 	navtestButton.SetTooltip("Toggle navigation testing. When enabled, you can visualize path finding results.\nYou can put down START and GOAL waypoints inside voxel grids to test path finding.\nControls:\n----------\nF5 + middle click: put START to surface\nF6 + middle click: put GOAL to surface\nF7 + middle click: put START to air\nF8 + middle click: put GOAL to air");
 	navtestButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
-	navtestButton.OnClick([&](wi::gui::EventArgs args) {
+	navtestButton.OnClick([this](wi::gui::EventArgs args) {
 		navtest_enabled = !navtest_enabled;
 	});
 	GetGUI().AddWidget(&navtestButton);
@@ -966,7 +966,7 @@ void EditorComponent::Load()
 	playButton.SetShadowRadius(2);
 	playButton.SetLocalizationEnabled(wi::gui::LocalizationEnabled::Tooltip);
 	playButton.SetTooltip("Execute the last used (standalone) script.\nTo use a new script, use the Open button.");
-	playButton.OnClick([&](wi::gui::EventArgs args) {
+	playButton.OnClick([this](wi::gui::EventArgs args) {
 		if (last_script_path.empty() || !wi::helper::FileExists(last_script_path))
 		{
 			contentBrowserWnd.RefreshContent();
@@ -995,7 +995,7 @@ void EditorComponent::Load()
 	stopButton.SetShadowRadius(2);
 	stopButton.SetTooltip("Stops every script background processes that are still running.");
 	stopButton.SetScriptTip("killProcesses()");
-	stopButton.OnClick([&](wi::gui::EventArgs args) {
+	stopButton.OnClick([](wi::gui::EventArgs args) {
 		wi::lua::KillProcesses();
 	});
 	topmenuWnd.AddWidget(&stopButton);
@@ -1006,7 +1006,7 @@ void EditorComponent::Load()
 	projectCreatorButton.font.params.shadowColor = wi::Color::Transparent();
 	projectCreatorButton.SetShadowRadius(2);
 	projectCreatorButton.SetTooltip("Create a new project.");
-	projectCreatorButton.OnClick([&](wi::gui::EventArgs args) {
+	projectCreatorButton.OnClick([this](wi::gui::EventArgs args) {
 		projectCreatorWnd.SetVisible(!projectCreatorWnd.IsVisible());
 	});
 	topmenuWnd.AddWidget(&projectCreatorButton);
@@ -1020,7 +1020,7 @@ void EditorComponent::Load()
 	saveButton.SetTooltip("Save the current scene to a new file (Ctrl + Shift + S)\nBy default, the scene will be saved into .wiscene, but you can specify .gltf or .glb extensions to export into GLTF.\nYou can also use Ctrl + S to quicksave, without browsing.");
 	saveButton.SetColor(wi::Color(50, 180, 100, 180), wi::gui::WIDGETSTATE::IDLE);
 	saveButton.SetColor(wi::Color(50, 220, 140, 255), wi::gui::WIDGETSTATE::FOCUS);
-	saveButton.OnClick([&](wi::gui::EventArgs args) {
+	saveButton.OnClick([this](wi::gui::EventArgs args) {
 		SaveAs();
 		});
 	topmenuWnd.AddWidget(&saveButton);
@@ -1036,7 +1036,7 @@ void EditorComponent::Load()
 #endif // PLATFORM_WINDOWS_DESKTOP
 	openButton.SetColor(wi::Color(50, 100, 255, 180), wi::gui::WIDGETSTATE::IDLE);
 	openButton.SetColor(wi::Color(120, 160, 255, 255), wi::gui::WIDGETSTATE::FOCUS);
-	openButton.OnClick([&](wi::gui::EventArgs args) {
+	openButton.OnClick([this](wi::gui::EventArgs args) {
 		wi::helper::FileDialogParams params;
 		params.type = wi::helper::FileDialogParams::OPEN;
 		params.description = ".wiscene, .obj, .gltf, .glb, .vrm, .fbx, .lua, .mp4, .png, ...";
@@ -1064,7 +1064,7 @@ void EditorComponent::Load()
 		{
 			params.extensions.push_back(x);
 		}
-		wi::helper::FileDialog(params, [&](std::string fileName) {
+		wi::helper::FileDialog(params, [this](std::string fileName) {
 			wi::eventhandler::Subscribe_Once(wi::eventhandler::EVENT_THREAD_SAFE_POINT, [=](uint64_t userdata) {
 				Open(fileName);
 				});
@@ -1080,7 +1080,7 @@ void EditorComponent::Load()
 	contentBrowserButton.SetTooltip("Browse content.");
 	contentBrowserButton.SetColor(wi::Color(50, 100, 255, 180), wi::gui::WIDGETSTATE::IDLE);
 	contentBrowserButton.SetColor(wi::Color(120, 160, 255, 255), wi::gui::WIDGETSTATE::FOCUS);
-	contentBrowserButton.OnClick([&](wi::gui::EventArgs args) {
+	contentBrowserButton.OnClick([this](wi::gui::EventArgs args) {
 		contentBrowserWnd.SetVisible(!contentBrowserWnd.IsVisible());
 		if (contentBrowserWnd.IsVisible())
 		{
@@ -1097,7 +1097,7 @@ void EditorComponent::Load()
 	logButton.SetTooltip("Open the backlog (toggle with HOME button)");
 	logButton.SetColor(wi::Color(50, 160, 200, 180), wi::gui::WIDGETSTATE::IDLE);
 	logButton.SetColor(wi::Color(120, 200, 200, 255), wi::gui::WIDGETSTATE::FOCUS);
-	logButton.OnClick([&](wi::gui::EventArgs args) {
+	logButton.OnClick([](wi::gui::EventArgs args) {
 		wi::backlog::Toggle();
 		});
 	topmenuWnd.AddWidget(&logButton);
@@ -1110,7 +1110,7 @@ void EditorComponent::Load()
 	profilerButton.SetTooltip("View the profiler frame timings");
 	profilerButton.SetColor(wi::Color(50, 160, 200, 180), wi::gui::WIDGETSTATE::IDLE);
 	profilerButton.SetColor(wi::Color(120, 200, 200, 255), wi::gui::WIDGETSTATE::FOCUS);
-	profilerButton.OnClick([&](wi::gui::EventArgs args) {
+	profilerButton.OnClick([this](wi::gui::EventArgs args) {
 		profilerWnd.SetVisible(!wi::profiler::IsEnabled());
 		wi::profiler::SetEnabled(!wi::profiler::IsEnabled());
 	});
@@ -1124,7 +1124,7 @@ void EditorComponent::Load()
 	cinemaButton.SetTooltip("Enter cinema mode (all HUD disabled). Press ESC to return to normal.");
 	cinemaButton.SetColor(wi::Color(50, 160, 200, 180), wi::gui::WIDGETSTATE::IDLE);
 	cinemaButton.SetColor(wi::Color(120, 200, 200, 255), wi::gui::WIDGETSTATE::FOCUS);
-	cinemaButton.OnClick([&](wi::gui::EventArgs args) {
+	cinemaButton.OnClick([this](wi::gui::EventArgs args) {
 		if (renderPath != nullptr)
 		{
 			renderPath->GetGUI().SetVisible(false);
@@ -1143,7 +1143,7 @@ void EditorComponent::Load()
 	fullscreenButton.SetTooltip("Toggle full screen");
 	fullscreenButton.SetColor(wi::Color(50, 160, 200, 180), wi::gui::WIDGETSTATE::IDLE);
 	fullscreenButton.SetColor(wi::Color(120, 200, 200, 255), wi::gui::WIDGETSTATE::FOCUS);
-	fullscreenButton.OnClick([&](wi::gui::EventArgs args) {
+	fullscreenButton.OnClick([this](wi::gui::EventArgs args) {
 		bool fullscreen = main->config.GetBool("fullscreen");
 		fullscreen = !fullscreen;
 		main->config.Set("fullscreen", fullscreen);
@@ -1178,7 +1178,7 @@ void EditorComponent::Load()
 	aboutButton.SetTooltip("About...");
 	aboutButton.SetColor(wi::Color(50, 160, 200, 180), wi::gui::WIDGETSTATE::IDLE);
 	aboutButton.SetColor(wi::Color(120, 200, 200, 255), wi::gui::WIDGETSTATE::FOCUS);
-	aboutButton.OnClick([&](wi::gui::EventArgs args) {
+	aboutButton.OnClick([this](wi::gui::EventArgs args) {
 		aboutWindow.SetVisible(!aboutWindow.IsVisible());
 		});
 	topmenuWnd.AddWidget(&aboutButton);
@@ -1267,7 +1267,7 @@ void EditorComponent::Load()
 		aboutWindow.OnResize([this]() {
 			aboutLabel.SetSize(XMFLOAT2(aboutWindow.GetWidgetAreaSize().x - 20, aboutLabel.GetSize().y));
 		});
-		aboutWindow.OnCollapse([&](wi::gui::EventArgs args) {
+		aboutWindow.OnCollapse([this](wi::gui::EventArgs args) {
 			for (int i = 0; i < arraysize(wi::gui::Widget::sprites); ++i)
 			{
 				aboutWindow.sprites[i].params.enableCornerRounding();

--- a/Editor/EmitterWindow.cpp
+++ b/Editor/EmitterWindow.cpp
@@ -146,7 +146,7 @@ void EmitterWindow::Create(EditorComponent* _editor)
 	debugCheckBox.Create("DEBUG: ");
 	debugCheckBox.SetPos(XMFLOAT2(x, y += step));
 	debugCheckBox.SetSize(XMFLOAT2(itemheight, itemheight));
-	debugCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	debugCheckBox.OnClick([](wi::gui::EventArgs args) {
 		wi::renderer::SetToDrawDebugEmitters(args.bValue);
 	});
 	debugCheckBox.SetCheck(wi::renderer::GetToDrawDebugEmitters());

--- a/Editor/ExpressionWindow.cpp
+++ b/Editor/ExpressionWindow.cpp
@@ -12,7 +12,7 @@ void ExpressionWindow::Create(EditorComponent* _editor)
 	SetSize(XMFLOAT2(670, 580));
 
 	closeButton.SetTooltip("Delete ExpressionComponent");
-	OnClose([&](wi::gui::EventArgs args) {
+	OnClose([this](wi::gui::EventArgs args) {
 
 		wi::Archive& archive = editor->AdvanceHistory();
 		archive << EditorComponent::HISTORYOP_COMPONENT_DATA;
@@ -42,45 +42,45 @@ void ExpressionWindow::Create(EditorComponent* _editor)
 
 	talkCheckBox.Create("Force Talking: ");
 	talkCheckBox.SetTooltip("Force continuous talking animation, even if no voice is playing");
-	talkCheckBox.OnClick(handleExpr([&] (auto expression_mastering, auto args) {
+	talkCheckBox.OnClick(handleExpr([] (auto expression_mastering, auto args) {
 		expression_mastering->SetForceTalkingEnabled(args.bValue);
 	}));
 	AddWidget(&talkCheckBox);
 
 	blinkFrequencySlider.Create(0, 1, 0, 1000, "Blinks: ");
 	blinkFrequencySlider.SetTooltip("Specifies the number of blinks per second.");
-	blinkFrequencySlider.OnSlide(handleExpr([&] (auto expression_mastering, auto args) {
+	blinkFrequencySlider.OnSlide(handleExpr([] (auto expression_mastering, auto args) {
 		expression_mastering->blink_frequency = args.fValue;
 	}));
 	AddWidget(&blinkFrequencySlider);
 
 	blinkLengthSlider.Create(0, 1, 0, 1000, "Blink Length: ");
-	blinkLengthSlider.OnSlide(handleExpr([&] (auto expression_mastering, auto args) {
+	blinkLengthSlider.OnSlide(handleExpr([] (auto expression_mastering, auto args) {
 		expression_mastering->blink_length = args.fValue;
 	}));
 	AddWidget(&blinkLengthSlider);
 
 	blinkCountSlider.Create(1, 4, 2, 3, "Blink Count: ");
-	blinkCountSlider.OnSlide(handleExpr([&] (auto expression_mastering, auto args) {
+	blinkCountSlider.OnSlide(handleExpr([] (auto expression_mastering, auto args) {
 		expression_mastering->blink_count = args.iValue;
 	}));
 	AddWidget(&blinkCountSlider);
 
 	lookFrequencySlider.Create(0, 1, 0, 1000, "Looks: ");
 	lookFrequencySlider.SetTooltip("Specifies the number of look-aways per second.");
-	lookFrequencySlider.OnSlide(handleExpr([&] (auto expression_mastering, auto args) {
+	lookFrequencySlider.OnSlide(handleExpr([] (auto expression_mastering, auto args) {
 		expression_mastering->look_frequency = args.fValue;
 	}));
 	AddWidget(&lookFrequencySlider);
 
 	lookLengthSlider.Create(0, 1, 0, 1000, "Look Length: ");
-	lookLengthSlider.OnSlide(handleExpr([&] (auto expression_mastering, auto args) {
+	lookLengthSlider.OnSlide(handleExpr([] (auto expression_mastering, auto args) {
 		expression_mastering->look_length = args.fValue;
 	}));
 	AddWidget(&lookLengthSlider);
 
 	expressionList.Create("Expressions: ");
-	expressionList.OnSelect(handleExpr([&] (auto expression_mastering, auto args) {
+	expressionList.OnSelect(handleExpr([this] (auto expression_mastering, auto args) {
 		if (args.iValue >= expression_mastering->expressions.size())
 			return;
 
@@ -93,8 +93,8 @@ void ExpressionWindow::Create(EditorComponent* _editor)
 	}));
 	AddWidget(&expressionList);
 
-	auto handleExprList = [&] (auto func, const bool checkExprSize = true) {
-		return handleExpr([&] (auto expression_mastering, auto args) {
+	auto handleExprList = [=] (auto func, const bool checkExprSize = true) {
+		return handleExpr([=] (auto expression_mastering, auto args) {
 			if (checkExprSize && args.iValue >= expression_mastering->expressions.size())
 				return;
 
@@ -114,13 +114,13 @@ void ExpressionWindow::Create(EditorComponent* _editor)
 	};
 
 	binaryCheckBox.Create("Binary: ");
-	binaryCheckBox.OnClick(handleExprList([&] (auto expression, auto args) {
+	binaryCheckBox.OnClick(handleExprList([] (auto expression, auto args) {
 		expression.SetBinary(args.bValue);
 	}, false));
 	AddWidget(&binaryCheckBox);
 
 	weightSlider.Create(0, 1, 0, 100000, "Weight: ");
-	weightSlider.OnSlide(handleExprList([&] (auto expression, auto args) {
+	weightSlider.OnSlide(handleExprList([] (auto expression, auto args) {
 		expression.weight = args.fValue;
 	}));
 	AddWidget(&weightSlider);
@@ -130,7 +130,7 @@ void ExpressionWindow::Create(EditorComponent* _editor)
 	overrideMouthCombo.AddItem("None", (uint64_t)ExpressionComponent::Override::None);
 	overrideMouthCombo.AddItem("Block", (uint64_t)ExpressionComponent::Override::Block);
 	overrideMouthCombo.AddItem("Blend", (uint64_t)ExpressionComponent::Override::Blend);
-	overrideMouthCombo.OnSelect(handleExprList([&] (auto expression, auto args) {
+	overrideMouthCombo.OnSelect(handleExprList([] (auto expression, auto args) {
 		expression.override_mouth = (ExpressionComponent::Override)args.userdata;
 	}));
 	AddWidget(&overrideMouthCombo);
@@ -140,7 +140,7 @@ void ExpressionWindow::Create(EditorComponent* _editor)
 	overrideBlinkCombo.AddItem("None", (uint64_t)ExpressionComponent::Override::None);
 	overrideBlinkCombo.AddItem("Block", (uint64_t)ExpressionComponent::Override::Block);
 	overrideBlinkCombo.AddItem("Blend", (uint64_t)ExpressionComponent::Override::Blend);
-	overrideBlinkCombo.OnSelect(handleExprList([&] (auto expression, auto args) {
+	overrideBlinkCombo.OnSelect(handleExprList([] (auto expression, auto args) {
 		expression.override_blink = (ExpressionComponent::Override)args.userdata;
 	}));
 	AddWidget(&overrideBlinkCombo);
@@ -150,7 +150,7 @@ void ExpressionWindow::Create(EditorComponent* _editor)
 	overrideLookCombo.AddItem("None", (uint64_t)ExpressionComponent::Override::None);
 	overrideLookCombo.AddItem("Block", (uint64_t)ExpressionComponent::Override::Block);
 	overrideLookCombo.AddItem("Blend", (uint64_t)ExpressionComponent::Override::Blend);
-	overrideLookCombo.OnSelect(handleExprList([&] (auto expression, auto args) {
+	overrideLookCombo.OnSelect(handleExprList([] (auto expression, auto args) {
 		expression.override_look = (ExpressionComponent::Override)args.userdata;
 	}));
 	AddWidget(&overrideLookCombo);

--- a/Editor/FontWindow.cpp
+++ b/Editor/FontWindow.cpp
@@ -12,7 +12,7 @@ void FontWindow::Create(EditorComponent* _editor)
 	SetSize(XMFLOAT2(670, 1020));
 
 	closeButton.SetTooltip("Delete Font");
-	OnClose([&](wi::gui::EventArgs args) {
+	OnClose([this](wi::gui::EventArgs args) {
 
 		wi::Archive& archive = editor->AdvanceHistory();
 		archive << EditorComponent::HISTORYOP_COMPONENT_DATA;
@@ -52,13 +52,13 @@ void FontWindow::Create(EditorComponent* _editor)
 	AddWidget(&textInput);
 
 	fileButton.Create("From file...");
-	fileButton.OnClick([&](wi::gui::EventArgs args) {
+	fileButton.OnClick([this](wi::gui::EventArgs args) {
 
 		wi::helper::FileDialogParams params;
 		params.type = wi::helper::FileDialogParams::OPEN;
 		params.description = "Text (*.txt)";
 		params.extensions = { "txt" };
-		wi::helper::FileDialog(params, [&](std::string fileName) {
+		wi::helper::FileDialog(params, [this](std::string fileName) {
 			wi::vector<uint8_t> filedata;
 			wi::helper::FileRead(fileName, filedata);
 			std::string fileText;
@@ -101,7 +101,7 @@ void FontWindow::Create(EditorComponent* _editor)
 			params.type = wi::helper::FileDialogParams::OPEN;
 			params.description = "Font (*.TTF)";
 			params.extensions = wi::resourcemanager::GetSupportedFontStyleExtensions();
-			wi::helper::FileDialog(params, [&](std::string fileName) {
+			wi::helper::FileDialog(params, [=](std::string fileName) {
 				font->fontStyleResource = wi::resourcemanager::Load(fileName);
 				font->fontStyleName = fileName;
 				fontStyleButton.SetText(wi::helper::GetFileNameFromPath(font->fontStyleName));

--- a/Editor/ForceFieldWindow.cpp
+++ b/Editor/ForceFieldWindow.cpp
@@ -33,7 +33,7 @@ void ForceFieldWindow::Create(EditorComponent* _editor)
 	typeComboBox.Create("Type: ");
 	typeComboBox.SetPos(XMFLOAT2(x, y));
 	typeComboBox.SetSize(XMFLOAT2(wid, hei));
-	typeComboBox.OnSelect([&](wi::gui::EventArgs args) {
+	typeComboBox.OnSelect([this](wi::gui::EventArgs args) {
 		wi::scene::Scene& scene = editor->GetCurrentScene();
 		for (auto& x : editor->translator.selected)
 		{

--- a/Editor/GeneralWindow.cpp
+++ b/Editor/GeneralWindow.cpp
@@ -192,7 +192,7 @@ void GeneralWindow::Create(EditorComponent* _editor)
 	{
 		focusModeCheckBox.SetCheck(editor->main->config.GetSection("options").GetBool("focus_mode"));
 	}
-	focusModeCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	focusModeCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		editor->main->config.GetSection("options").Set("focus_mode", args.bValue);
 		// trigger themeCombo's OnSelect handler, which will enable/disable shadow highlighting
 		// according to this checkbox's state
@@ -204,7 +204,7 @@ void GeneralWindow::Create(EditorComponent* _editor)
 	versionCheckBox.SetTooltip("Toggle the engine version display text in top left corner.");
 	editor->main->infoDisplay.watermark = editor->main->config.GetSection("options").GetBool("version");
 	versionCheckBox.SetCheck(editor->main->infoDisplay.watermark);
-	versionCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	versionCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		editor->main->infoDisplay.watermark = args.bValue;
 		editor->main->config.GetSection("options").Set("version", args.bValue);
 		editor->main->config.Commit();
@@ -216,7 +216,7 @@ void GeneralWindow::Create(EditorComponent* _editor)
 	fpsCheckBox.SetTooltip("Toggle the FPS display text in top left corner.");
 	editor->main->infoDisplay.fpsinfo = editor->main->config.GetSection("options").GetBool("fps");
 	fpsCheckBox.SetCheck(editor->main->infoDisplay.fpsinfo);
-	fpsCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	fpsCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		editor->main->infoDisplay.fpsinfo = args.bValue;
 		editor->main->config.GetSection("options").Set("fps", args.bValue);
 		editor->main->config.Commit();
@@ -235,7 +235,7 @@ void GeneralWindow::Create(EditorComponent* _editor)
 	editor->main->infoDisplay.logical_size = info;
 	editor->main->infoDisplay.pipeline_count = info;
 	otherinfoCheckBox.SetCheck(info);
-	otherinfoCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	otherinfoCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		editor->main->infoDisplay.heap_allocation_counter = args.bValue;
 		editor->main->infoDisplay.vram_usage = args.bValue;
 		editor->main->infoDisplay.device_name = args.bValue;
@@ -268,7 +268,7 @@ void GeneralWindow::Create(EditorComponent* _editor)
 	{
 		saveCompressionCheckBox.SetCheck(editor->main->config.GetSection("options").GetBool("save_compressed"));
 	}
-	saveCompressionCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	saveCompressionCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		editor->main->config.GetSection("options").Set("save_compressed", args.bValue);
 		editor->main->config.Commit();
 	});
@@ -322,7 +322,7 @@ void GeneralWindow::Create(EditorComponent* _editor)
 	localizationButton.Create(ICON_LANGUAGE " Create Localization Template");
 	localizationButton.SetTooltip("Generate a file that can be used to edit localization for the Editor.\nThe template will be created from the currently selected language.");
 	localizationButton.SetSize(XMFLOAT2(100, 18));
-	localizationButton.OnClick([&](wi::gui::EventArgs args) {
+	localizationButton.OnClick([this](wi::gui::EventArgs args) {
 		wi::helper::FileDialogParams params;
 		params.type = wi::helper::FileDialogParams::SAVE;
 		params.description = "XML file (.xml)";
@@ -376,7 +376,7 @@ void GeneralWindow::Create(EditorComponent* _editor)
 	themeEditorButton.SetText(ICON_THEME_EDITOR);
 	themeEditorButton.SetTooltip("Open the theme editor.");
 	themeEditorButton.SetSize(XMFLOAT2(themeEditorButton.GetSize().y, themeEditorButton.GetSize().y));
-	themeEditorButton.OnClick([&](wi::gui::EventArgs args) {
+	themeEditorButton.OnClick([this](wi::gui::EventArgs args) {
 		editor->themeEditorWnd.nameInput.SetText(currentTheme);
 		editor->themeEditorWnd.SetVisible(!editor->themeEditorWnd.IsVisible());
 	});

--- a/Editor/GraphicsWindow.cpp
+++ b/Editor/GraphicsWindow.cpp
@@ -77,7 +77,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 	renderPathComboBox.SetPos(XMFLOAT2(x, y += step));
 	renderPathComboBox.AddItem("Default", RENDERPATH_DEFAULT);
 	renderPathComboBox.AddItem("Path Tracing", RENDERPATH_PATHTRACING);
-	renderPathComboBox.OnSelect([&](wi::gui::EventArgs args) {
+	renderPathComboBox.OnSelect([this](wi::gui::EventArgs args) {
 		ChangeRenderPath((RENDERPATH)args.userdata);
 		});
 	renderPathComboBox.SetEnabled(true);
@@ -244,7 +244,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 	ddgiRayCountSlider.SetSize(XMFLOAT2(wid, itemheight));
 	ddgiRayCountSlider.SetPos(XMFLOAT2(x, y += step));
 	ddgiRayCountSlider.SetValue((float)wi::renderer::GetDDGIRayCount());
-	ddgiRayCountSlider.OnSlide([&](wi::gui::EventArgs args) {
+	ddgiRayCountSlider.OnSlide([](wi::gui::EventArgs args) {
 		wi::renderer::SetDDGIRayCount((uint32_t)args.iValue);
 		});
 	AddWidget(&ddgiRayCountSlider);
@@ -254,7 +254,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 	ddgiBlendSpeedSlider.SetSize(XMFLOAT2(wid, itemheight));
 	ddgiBlendSpeedSlider.SetPos(XMFLOAT2(x, y += step));
 	ddgiBlendSpeedSlider.SetValue(wi::renderer::GetDDGIBlendSpeed());
-	ddgiBlendSpeedSlider.OnSlide([&](wi::gui::EventArgs args) {
+	ddgiBlendSpeedSlider.OnSlide([](wi::gui::EventArgs args) {
 		wi::renderer::SetDDGIBlendSpeed(args.fValue);
 		});
 	AddWidget(&ddgiBlendSpeedSlider);
@@ -360,7 +360,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 	vxgiVoxelSizeSlider.SetTooltip("Adjust the voxel size for VXGI calculations.");
 	vxgiVoxelSizeSlider.SetSize(XMFLOAT2(wid, itemheight));
 	vxgiVoxelSizeSlider.SetPos(XMFLOAT2(x, y += step));
-	vxgiVoxelSizeSlider.OnSlide([&](wi::gui::EventArgs args) {
+	vxgiVoxelSizeSlider.OnSlide([this](wi::gui::EventArgs args) {
 		wi::scene::Scene& scene = editor->GetCurrentScene();
 		scene.vxgi.clipmaps[0].voxelsize = args.fValue;
 	});
@@ -370,7 +370,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 	vxgiRayStepSizeSlider.SetTooltip("Adjust the precision of ray marching for [reflection] cone tracing step. Lower values = more precision but slower performance.");
 	vxgiRayStepSizeSlider.SetSize(XMFLOAT2(wid, itemheight));
 	vxgiRayStepSizeSlider.SetPos(XMFLOAT2(x, y += step));
-	vxgiRayStepSizeSlider.OnSlide([&](wi::gui::EventArgs args) {
+	vxgiRayStepSizeSlider.OnSlide([this](wi::gui::EventArgs args) {
 		wi::scene::Scene& scene = editor->GetCurrentScene();
 		scene.vxgi.rayStepSize = args.fValue;
 	});
@@ -380,7 +380,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 	vxgiMaxDistanceSlider.SetTooltip("Adjust max raymarching distance for VXGI.");
 	vxgiMaxDistanceSlider.SetSize(XMFLOAT2(wid, itemheight));
 	vxgiMaxDistanceSlider.SetPos(XMFLOAT2(x, y += step));
-	vxgiMaxDistanceSlider.OnSlide([&](wi::gui::EventArgs args) {
+	vxgiMaxDistanceSlider.OnSlide([this](wi::gui::EventArgs args) {
 		wi::scene::Scene& scene = editor->GetCurrentScene();
 		scene.vxgi.maxDistance = args.fValue;
 	});
@@ -451,7 +451,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 	speedMultiplierSlider.SetSize(XMFLOAT2(wid, itemheight));
 	speedMultiplierSlider.SetPos(XMFLOAT2(x, y += step));
 	speedMultiplierSlider.SetValue(wi::renderer::GetGameSpeed());
-	speedMultiplierSlider.OnSlide([&](wi::gui::EventArgs args) {
+	speedMultiplierSlider.OnSlide([](wi::gui::EventArgs args) {
 		wi::renderer::SetGameSpeed(args.fValue);
 	});
 	AddWidget(&speedMultiplierSlider);
@@ -469,7 +469,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 			wi::renderer::SetRaytracedShadowsEnabled(editor->main->config.GetSection("graphics").GetBool("raytraced_shadows"));
 		}
 	}
-	shadowTypeComboBox.OnSelect([&](wi::gui::EventArgs args) {
+	shadowTypeComboBox.OnSelect([this](wi::gui::EventArgs args) {
 
 		switch (args.iValue)
 		{
@@ -500,7 +500,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 	shadowProps2DComboBox.AddItem("1024");
 	shadowProps2DComboBox.AddItem("2048");
 	shadowProps2DComboBox.AddItem("4096");
-	shadowProps2DComboBox.OnSelect([&](wi::gui::EventArgs args) {
+	shadowProps2DComboBox.OnSelect([this](wi::gui::EventArgs args) {
 
 		switch (args.iValue)
 		{
@@ -552,7 +552,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 	shadowPropsCubeComboBox.AddItem("512");
 	shadowPropsCubeComboBox.AddItem("1024");
 	shadowPropsCubeComboBox.AddItem("2048");
-	shadowPropsCubeComboBox.OnSelect([&](wi::gui::EventArgs args) {
+	shadowPropsCubeComboBox.OnSelect([this](wi::gui::EventArgs args) {
 		switch (args.iValue)
 		{
 		case 0:
@@ -643,7 +643,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 	textureQualityComboBox.AddItem("Bilinear");
 	textureQualityComboBox.AddItem("Trilinear");
 	textureQualityComboBox.AddItem("Anisotropic");
-	textureQualityComboBox.OnSelect([&](wi::gui::EventArgs args) {
+	textureQualityComboBox.OnSelect([this](wi::gui::EventArgs args) {
 		wi::graphics::SamplerDesc desc = wi::renderer::GetSampler(wi::enums::SAMPLER_OBJECTSHADER)->GetDesc();
 
 		switch (args.iValue)
@@ -679,7 +679,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 	mipLodBiasSlider.SetSize(XMFLOAT2(wid, itemheight));
 	mipLodBiasSlider.SetPos(XMFLOAT2(x, y += step));
 	mipLodBiasSlider.SetValue(editor->main->config.GetSection("graphics").GetFloat("mip_lod_bias"));
-	mipLodBiasSlider.OnSlide([&](wi::gui::EventArgs args) {
+	mipLodBiasSlider.OnSlide([this](wi::gui::EventArgs args) {
 		wi::graphics::SamplerDesc desc = wi::renderer::GetSampler(wi::enums::SAMPLER_OBJECTSHADER)->GetDesc();
 		desc.mip_lod_bias = wi::math::Clamp(args.fValue, -15.9f, 15.9f);
 		wi::renderer::ModifyObjectSampler(desc);
@@ -697,7 +697,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 		wi::renderer::SetRaytraceBounceCount(editor->main->config.GetSection("graphics").GetInt("raytracing_bounce_count"));
 	}
 	raytraceBounceCountSlider.SetValue((float)wi::renderer::GetRaytraceBounceCount());
-	raytraceBounceCountSlider.OnSlide([&](wi::gui::EventArgs args) {
+	raytraceBounceCountSlider.OnSlide([this](wi::gui::EventArgs args) {
 		wi::renderer::SetRaytraceBounceCount((uint32_t)args.iValue);
 		editor->main->config.GetSection("graphics").Set("raytracing_bounces", args.iValue);
 		editor->main->config.Commit();

--- a/Editor/HairParticleWindow.cpp
+++ b/Editor/HairParticleWindow.cpp
@@ -161,7 +161,7 @@ void HairParticleWindow::Create(EditorComponent* _editor)
 	AddWidget(&uniformitySlider);
 
 	addSpriteButton.Create("Select sprite rect");
-	addSpriteButton.OnClick([&](wi::gui::EventArgs args) {
+	addSpriteButton.OnClick([this](wi::gui::EventArgs args) {
 
 		Scene& scene = editor->GetCurrentScene();
 		if (!scene.materials.Contains(entity))

--- a/Editor/HairParticleWindow.h
+++ b/Editor/HairParticleWindow.h
@@ -35,9 +35,9 @@ public:
 	wi::gui::Slider uniformitySlider;
 
 	wi::gui::Button addSpriteButton;
-	wi::vector<wi::gui::Button> sprites;
-	wi::vector<wi::gui::Button> spriteRemoveButtons;
-	wi::vector<wi::gui::Slider> spriteSizeSliders;
+  std::deque<wi::gui::Button> sprites;
+	std::deque<wi::gui::Button> spriteRemoveButtons;
+	std::deque<wi::gui::Slider> spriteSizeSliders;
 
 	SpriteRectWindow spriterectwnd;
 

--- a/Editor/HierarchyWindow.cpp
+++ b/Editor/HierarchyWindow.cpp
@@ -35,7 +35,7 @@ void HierarchyWindow::Create(EditorComponent* _editor)
 	parentCombo.Create("Parent: ");
 	parentCombo.SetSize(XMFLOAT2(wid, hei));
 	parentCombo.SetPos(XMFLOAT2(x, y));
-	parentCombo.OnSelect([&](wi::gui::EventArgs args) {
+	parentCombo.OnSelect([this](wi::gui::EventArgs args) {
 		Scene& scene = editor->GetCurrentScene();
 		for (auto& x : editor->translator.selected)
 		{

--- a/Editor/HumanoidWindow.cpp
+++ b/Editor/HumanoidWindow.cpp
@@ -13,7 +13,7 @@ void HumanoidWindow::Create(EditorComponent* _editor)
 	SetSize(XMFLOAT2(670, 620));
 
 	closeButton.SetTooltip("Delete HumanoidComponent");
-	OnClose([&](wi::gui::EventArgs args) {
+	OnClose([this](wi::gui::EventArgs args) {
 
 		wi::Archive& archive = editor->AdvanceHistory();
 		archive << EditorComponent::HISTORYOP_COMPONENT_DATA;
@@ -164,7 +164,7 @@ void HumanoidWindow::Create(EditorComponent* _editor)
 	AddWidget(&legSpacingSlider);
 
 	boneList.Create("Bones: ");
-	boneList.OnSelect([&](wi::gui::EventArgs args) {
+	boneList.OnSelect([this](wi::gui::EventArgs args) {
 
 		if (args.iValue < 0)
 			return;

--- a/Editor/LightWindow.cpp
+++ b/Editor/LightWindow.cpp
@@ -359,8 +359,6 @@ void LightWindow::RefreshCascades()
 	if (light == nullptr || light->type != LightComponent::DIRECTIONAL)
 		return;
 
-	cascades.reserve(light->cascade_distances.size());
-
 	int counter = 0;
 	for (auto& x : light->cascade_distances)
 	{

--- a/Editor/LightWindow.h
+++ b/Editor/LightWindow.h
@@ -40,7 +40,7 @@ public:
 		wi::gui::Slider distanceSlider;
 		wi::gui::Button removeButton;
 	};
-	wi::vector<CascadeConfig> cascades;
+  std::deque<CascadeConfig> cascades;
 	wi::gui::Button addCascadeButton;
 	void RefreshCascades();
 

--- a/Editor/MaterialPickerWindow.h
+++ b/Editor/MaterialPickerWindow.h
@@ -8,7 +8,7 @@ public:
 
 	EditorComponent* editor = nullptr;
 
-	wi::vector<wi::gui::Button> buttons;
+  std::deque<wi::gui::Button> buttons;
 
 	wi::gui::Slider zoomSlider;
 

--- a/Editor/MeshWindow.cpp
+++ b/Editor/MeshWindow.cpp
@@ -29,7 +29,7 @@ void MeshWindow::Create(EditorComponent* _editor)
 	SetSize(XMFLOAT2(580, 880));
 
 	closeButton.SetTooltip("Delete MeshComponent");
-	OnClose([&](wi::gui::EventArgs args) {
+	OnClose([this](wi::gui::EventArgs args) {
 
 		wi::Archive& archive = editor->AdvanceHistory();
 		archive << EditorComponent::HISTORYOP_COMPONENT_DATA;
@@ -49,7 +49,7 @@ void MeshWindow::Create(EditorComponent* _editor)
 
 	subsetComboBox.Create("Select subset: ");
 	subsetComboBox.SetEnabled(false);
-	subsetComboBox.OnSelect([&](wi::gui::EventArgs args) {
+	subsetComboBox.OnSelect([this](wi::gui::EventArgs args) {
 		Scene& scene = editor->GetCurrentScene();
 		MeshComponent* mesh = scene.meshes.GetComponent(entity);
 		if (mesh != nullptr)
@@ -184,7 +184,7 @@ void MeshWindow::Create(EditorComponent* _editor)
 
 	impostorCreateButton.Create("Create Impostor");
 	impostorCreateButton.SetTooltip("Create an impostor image of the mesh. The mesh will be replaced by this image when far away, to render faster.");
-	impostorCreateButton.OnClick([&](wi::gui::EventArgs args) {
+	impostorCreateButton.OnClick([this](wi::gui::EventArgs args) {
 		Scene& scene = editor->GetCurrentScene();
 		ImpostorComponent* impostor = scene.impostors.GetComponent(entity);
 		if (impostor == nullptr)
@@ -202,7 +202,7 @@ void MeshWindow::Create(EditorComponent* _editor)
 
 	impostorDistanceSlider.Create(0, 1000, 100, 10000, "Impostor Dist: ");
 	impostorDistanceSlider.SetTooltip("Assign the distance where the mesh geometry should be switched to the impostor image.");
-	impostorDistanceSlider.OnSlide([&](wi::gui::EventArgs args) {
+	impostorDistanceSlider.OnSlide([this](wi::gui::EventArgs args) {
 		ImpostorComponent* impostor = editor->GetCurrentScene().impostors.GetComponent(entity);
 		if (impostor != nullptr)
 		{
@@ -220,7 +220,7 @@ void MeshWindow::Create(EditorComponent* _editor)
 
 	instanceSelectButton.Create("Select instances");
 	instanceSelectButton.SetTooltip("Select all instances that use this mesh.");
-	instanceSelectButton.OnClick([&](wi::gui::EventArgs args) {
+	instanceSelectButton.OnClick([this](wi::gui::EventArgs args) {
 		wi::scene::Scene& scene = editor->GetCurrentScene();
 		wi::vector<Entity> sel;
 		wi::unordered_set<const ObjectComponent*> visited_objects; // fix double visit (straight mesh + object->mesh)
@@ -258,28 +258,28 @@ void MeshWindow::Create(EditorComponent* _editor)
 
 	flipCullingButton.Create("Flip Culling");
 	flipCullingButton.SetTooltip("Flip faces to reverse triangle culling order.");
-	flipCullingButton.OnClick(changeSelectedMesh([&] (auto mesh) {
+	flipCullingButton.OnClick(changeSelectedMesh([] (auto mesh) {
 		mesh->FlipCulling();
 	}));
 	AddWidget(&flipCullingButton);
 
 	flipNormalsButton.Create("Flip Normals");
 	flipNormalsButton.SetTooltip("Flip surface normals.");
-	flipNormalsButton.OnClick(changeSelectedMesh([&] (auto mesh) {
+	flipNormalsButton.OnClick(changeSelectedMesh([] (auto mesh) {
 		mesh->FlipNormals();
 	}));
 	AddWidget(&flipNormalsButton);
 
 	computeNormalsSmoothButton.Create("Compute Normals [SMOOTH]");
 	computeNormalsSmoothButton.SetTooltip("Compute surface normals of the mesh. Resulting normals will be unique per vertex. This can reduce vertex count, but is slow.");
-	computeNormalsSmoothButton.OnClick(changeSelectedMesh([&] (auto mesh) {
+	computeNormalsSmoothButton.OnClick(changeSelectedMesh([] (auto mesh) {
 		mesh->ComputeNormals(MeshComponent::COMPUTE_NORMALS_SMOOTH);
 	}));
 	AddWidget(&computeNormalsSmoothButton);
 
 	computeNormalsHardButton.Create("Compute Normals [HARD]");
 	computeNormalsHardButton.SetTooltip("Compute surface normals of the mesh. Resulting normals will be unique per face. This can increase vertex count.");
-	computeNormalsHardButton.OnClick(changeSelectedMesh([&] (auto mesh) {
+	computeNormalsHardButton.OnClick(changeSelectedMesh([] (auto mesh) {
 		mesh->ComputeNormals(MeshComponent::COMPUTE_NORMALS_HARD);
 
 	}));
@@ -287,14 +287,14 @@ void MeshWindow::Create(EditorComponent* _editor)
 
 	recenterButton.Create("Recenter");
 	recenterButton.SetTooltip("Recenter mesh to AABB center.");
-	recenterButton.OnClick(changeSelectedMesh([&] (auto mesh) {
+	recenterButton.OnClick(changeSelectedMesh([] (auto mesh) {
 		mesh->Recenter();
 	}));
 	AddWidget(&recenterButton);
 
 	recenterToBottomButton.Create("RecenterToBottom");
 	recenterToBottomButton.SetTooltip("Recenter mesh to AABB bottom.");
-	recenterToBottomButton.OnClick(changeSelectedMesh([&] (auto mesh) {
+	recenterToBottomButton.OnClick(changeSelectedMesh([] (auto mesh) {
 		mesh->RecenterToBottom();
 	}));
 	AddWidget(&recenterToBottomButton);
@@ -592,12 +592,12 @@ void MeshWindow::Create(EditorComponent* _editor)
 
 	exportHeaderButton.Create("Export to C++ header");
 	exportHeaderButton.SetTooltip("Export vertex positions and index buffer into a C++ header file.\n - Object transformation (if selected through object picking) and Skinning pose will be applied.\n - Only LOD0 will be exported.\n - The generated vertex positions and indices will be reordered and optimized without considering other vertex attributes.");
-	exportHeaderButton.OnClick([&](wi::gui::EventArgs args) {
+	exportHeaderButton.OnClick([this](wi::gui::EventArgs args) {
 		wi::helper::FileDialogParams params;
 		params.description = ".h (C++ header file)";
 		params.extensions.push_back("h");
 		params.type = wi::helper::FileDialogParams::TYPE::SAVE;
-		wi::helper::FileDialog(params, [&](std::string filename) {
+		wi::helper::FileDialog(params, [this](std::string filename) {
 			wi::eventhandler::Subscribe_Once(wi::eventhandler::EVENT_THREAD_SAFE_POINT, [=](uint64_t userdata) {
 
 				wi::scene::Scene& scene = editor->GetCurrentScene();
@@ -716,7 +716,7 @@ void MeshWindow::Create(EditorComponent* _editor)
 
 	subsetMaterialComboBox.Create("Material: ");
 	subsetMaterialComboBox.SetEnabled(false);
-	subsetMaterialComboBox.OnSelect([&](wi::gui::EventArgs args) {
+	subsetMaterialComboBox.OnSelect([this](wi::gui::EventArgs args) {
 		Scene& scene = editor->GetCurrentScene();
 		MeshComponent* mesh = scene.meshes.GetComponent(entity);
 		if (mesh != nullptr && subset >= 0 && subset < mesh->subsets.size())
@@ -736,7 +736,7 @@ void MeshWindow::Create(EditorComponent* _editor)
 
 
 	morphTargetCombo.Create("Morph Target:");
-	morphTargetCombo.OnSelect([&](wi::gui::EventArgs args) {
+	morphTargetCombo.OnSelect([this](wi::gui::EventArgs args) {
 		MeshComponent* mesh = editor->GetCurrentScene().meshes.GetComponent(entity);
 		if (mesh != nullptr && args.iValue < (int)mesh->morph_targets.size())
 		{

--- a/Editor/MetadataWindow.cpp
+++ b/Editor/MetadataWindow.cpp
@@ -140,14 +140,6 @@ void MetadataWindow::RefreshEntries()
 	if (metadata == nullptr)
 		return;
 
-	entries.reserve(
-		metadata->bool_values.size() +
-		metadata->int_values.size() +
-		metadata->float_values.size() +
-		metadata->string_values.size()
-	);
-
-
 	auto forEachSelectedWithRefresh = [this] (auto name, auto func) {
 		return [this, func, name] (auto args) {
 			wi::scene::Scene& scene = editor->GetCurrentScene();

--- a/Editor/MetadataWindow.h
+++ b/Editor/MetadataWindow.h
@@ -21,7 +21,7 @@ public:
 		wi::gui::CheckBox check;
 		bool is_bool = false;
 	};
-	wi::vector<Entry> entries;
+  std::deque<Entry> entries;
 
 	void RefreshEntries();
 

--- a/Editor/ObjectWindow.cpp
+++ b/Editor/ObjectWindow.cpp
@@ -548,7 +548,7 @@ void ObjectWindow::Create(EditorComponent* _editor)
 	lightmapResolutionSlider.SetTooltip("Set the approximate resolution for this object's lightmap. This will be packed into the larger global lightmap later.");
 	lightmapResolutionSlider.SetSize(XMFLOAT2(wid, hei));
 	lightmapResolutionSlider.SetPos(XMFLOAT2(x, y += step));
-	lightmapResolutionSlider.OnSlide([&](wi::gui::EventArgs args) {
+	lightmapResolutionSlider.OnSlide([this](wi::gui::EventArgs args) {
 		lightmapResolutionSlider.SetValue(float(wi::math::GetNextPowerOfTwo(uint32_t(args.fValue))));
 	});
 	AddWidget(&lightmapResolutionSlider);
@@ -578,7 +578,7 @@ void ObjectWindow::Create(EditorComponent* _editor)
 	generateLightmapButton.SetTooltip("Render the lightmap for only this object. It will automatically combined with the global lightmap.");
 	generateLightmapButton.SetPos(XMFLOAT2(x, y += step));
 	generateLightmapButton.SetSize(XMFLOAT2(wid, hei));
-	generateLightmapButton.OnClick([&](wi::gui::EventArgs args) {
+	generateLightmapButton.OnClick([this](wi::gui::EventArgs args) {
 
 		Scene& scene = editor->GetCurrentScene();
 
@@ -681,7 +681,7 @@ void ObjectWindow::Create(EditorComponent* _editor)
 	vertexAOButton.SetPos(XMFLOAT2(x, y += step));
 	vertexAOButton.SetSize(XMFLOAT2(wid, hei));
 	vertexAOButton.SetLocalizationEnabled(false);
-	vertexAOButton.OnClick([&](wi::gui::EventArgs args) {
+	vertexAOButton.OnClick([this](wi::gui::EventArgs args) {
 		const Scene& scene = editor->GetCurrentScene();
 
 		// Build BVHs for everything selected:
@@ -730,7 +730,8 @@ void ObjectWindow::Create(EditorComponent* _editor)
 					uint32_t groupSizePerCore = wi::jobsystem::DispatchGroupCount((uint32_t)objectcomponent->vertex_ao.size(), wi::jobsystem::GetThreadCount());
 
 					wi::jobsystem::context ctx;
-					wi::jobsystem::Dispatch(ctx, (uint32_t)objectcomponent->vertex_ao.size(), groupSizePerCore, [&](wi::jobsystem::JobArgs args) {
+					wi::jobsystem::Dispatch(ctx, (uint32_t)objectcomponent->vertex_ao.size(), groupSizePerCore, [=](wi::jobsystem::JobArgs args) {
+		        const Scene& scene = editor->GetCurrentScene();
 						XMFLOAT3 position = meshcomponent->vertex_positions[args.jobIndex];
 						XMFLOAT3 normal = meshcomponent->vertex_normals[args.jobIndex];
 						const XMMATRIX W = XMLoadFloat4x4(&scene.matrix_objects[objectcomponentIndex]);
@@ -898,7 +899,7 @@ void ObjectWindow::Create(EditorComponent* _editor)
 	colorPicker.SetPos(XMFLOAT2(5, y += step));
 	colorPicker.SetVisible(true);
 	colorPicker.SetEnabled(true);
-	colorPicker.OnColorChanged([&](wi::gui::EventArgs args) {
+	colorPicker.OnColorChanged([this](wi::gui::EventArgs args) {
 		ObjectComponent* object = editor->GetCurrentScene().objects.GetComponent(entity);
 		if (object != nullptr)
 		{

--- a/Editor/PaintToolWindow.cpp
+++ b/Editor/PaintToolWindow.cpp
@@ -32,7 +32,7 @@ void PaintToolWindow::Create(EditorComponent* _editor)
 	modeComboBox.AddItem(ICON_HAIR " Hairparticle - Length (Alpha)", MODE_HAIRPARTICLE_LENGTH);
 	modeComboBox.AddItem(ICON_MESH " Wind weight (Alpha)", MODE_WIND);
 	modeComboBox.SetSelected(0);
-	modeComboBox.OnSelect([&](wi::gui::EventArgs args) {
+	modeComboBox.OnSelect([this](wi::gui::EventArgs args) {
 		switch (args.userdata)
 		{
 		case MODE_DISABLED:

--- a/Editor/PaintToolWindow.h
+++ b/Editor/PaintToolWindow.h
@@ -92,7 +92,7 @@ public:
 		Z
 	};
 
-	wi::vector<wi::gui::Button> terrain_material_buttons;
+  std::deque<wi::gui::Button> terrain_material_buttons;
 	size_t terrain_material_layer = 0;
 
 	float texture_paint_radius = 50;

--- a/Editor/SoundWindow.cpp
+++ b/Editor/SoundWindow.cpp
@@ -62,7 +62,7 @@ void SoundWindow::Create(EditorComponent* _editor)
 	openButton.SetTooltip("Open sound file.\nSupported extensions: WAV, OGG");
 	openButton.SetPos(XMFLOAT2(x, y));
 	openButton.SetSize(XMFLOAT2(wid, hei));
-	openButton.OnClick([&](wi::gui::EventArgs args) {
+	openButton.OnClick([this](wi::gui::EventArgs args) {
 		SoundComponent* sound = editor->GetCurrentScene().sounds.GetComponent(entity);
 		if (sound != nullptr)
 		{
@@ -187,7 +187,7 @@ void SoundWindow::Create(EditorComponent* _editor)
 	reverbComboBox.Create("Reverb: ");
 	reverbComboBox.SetPos(XMFLOAT2(x, y += step));
 	reverbComboBox.SetSize(XMFLOAT2(wid, hei));
-	reverbComboBox.OnSelect([&](wi::gui::EventArgs args) {
+	reverbComboBox.OnSelect([](wi::gui::EventArgs args) {
 		wi::audio::SetReverb((wi::audio::REVERB_PRESET)args.iValue);
 	});
 	reverbComboBox.AddItem("DEFAULT");

--- a/Editor/SplineWindow.cpp
+++ b/Editor/SplineWindow.cpp
@@ -179,8 +179,6 @@ void SplineWindow::RefreshEntries()
 	if (spline == nullptr)
 		return;
 
-	entries.reserve(spline->spline_node_entities.size());
-
 	for (size_t i = 0; i < spline->spline_node_entities.size(); ++i)
 	{
 		Entity entity = spline->spline_node_entities[i];

--- a/Editor/SplineWindow.h
+++ b/Editor/SplineWindow.h
@@ -27,7 +27,7 @@ public:
 		wi::gui::Button removeButton;
 		wi::gui::Button entityButton;
 	};
-	wi::vector<Entry> entries;
+  std::deque<Entry> entries;
 
 	void RefreshEntries();
 

--- a/Editor/SpringWindow.cpp
+++ b/Editor/SpringWindow.cpp
@@ -34,7 +34,7 @@ void SpringWindow::Create(EditorComponent* _editor)
 	resetAllButton.SetTooltip("Reset all springs in the scene to initial pose.");
 	resetAllButton.SetPos(XMFLOAT2(x, y));
 	resetAllButton.SetSize(XMFLOAT2(siz, hei));
-	resetAllButton.OnClick([&](wi::gui::EventArgs args) {
+	resetAllButton.OnClick([this](wi::gui::EventArgs args) {
 		auto& scene = editor->GetCurrentScene();
 		for (size_t i = 0; i < scene.springs.GetCount(); ++i)
 		{

--- a/Editor/TransformWindow.cpp
+++ b/Editor/TransformWindow.cpp
@@ -57,7 +57,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	txInput.SetDescription("Position: ");
 	txInput.SetPos(XMFLOAT2(x, y += step));
 	txInput.SetSize(XMFLOAT2(siz, hei));
-	txInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	txInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -71,7 +71,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	tyInput.SetValue(0);
 	tyInput.SetPos(XMFLOAT2(x, y += step));
 	tyInput.SetSize(XMFLOAT2(siz, hei));
-	tyInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	tyInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -85,7 +85,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	tzInput.SetValue(0);
 	tzInput.SetPos(XMFLOAT2(x, y += step));
 	tzInput.SetSize(XMFLOAT2(siz, hei));
-	tzInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	tzInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -103,7 +103,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	sxInput.SetDescription("Scale: ");
 	sxInput.SetPos(XMFLOAT2(x, y));
 	sxInput.SetSize(XMFLOAT2(siz, hei));
-	sxInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	sxInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -117,7 +117,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	syInput.SetValue(1);
 	syInput.SetPos(XMFLOAT2(x, y += step));
 	syInput.SetSize(XMFLOAT2(siz, hei));
-	syInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	syInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -131,7 +131,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	szInput.SetValue(1);
 	szInput.SetPos(XMFLOAT2(x, y += step));
 	szInput.SetSize(XMFLOAT2(siz, hei));
-	szInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	szInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -146,7 +146,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	suInput.SetValue(1);
 	suInput.SetPos(XMFLOAT2(x, y += step));
 	suInput.SetSize(XMFLOAT2(siz, hei));
-	suInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	suInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -168,7 +168,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	rollInput.SetTooltip("Roll (in degrees)\n Note: Euler angle rotations can result in precision loss from quaternion conversion!");
 	rollInput.SetPos(XMFLOAT2(x, y += step));
 	rollInput.SetSize(XMFLOAT2(siz, hei));
-	rollInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	rollInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -188,7 +188,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	pitchInput.SetTooltip("Pitch (in degrees)\n Note: Euler angle rotations can result in precision loss from quaternion conversion!");
 	pitchInput.SetPos(XMFLOAT2(x, y += step));
 	pitchInput.SetSize(XMFLOAT2(siz, hei));
-	pitchInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	pitchInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -208,7 +208,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	yawInput.SetTooltip("Yaw (in degrees)\n Note: Euler angle rotations can result in precision loss from quaternion conversion!");
 	yawInput.SetPos(XMFLOAT2(x, y += step));
 	yawInput.SetSize(XMFLOAT2(siz, hei));
-	yawInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	yawInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -232,7 +232,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	rxInput.SetTooltip("Rotation Quaternion.X");
 	rxInput.SetPos(XMFLOAT2(x, y += step));
 	rxInput.SetSize(XMFLOAT2(siz, hei));
-	rxInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	rxInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -248,7 +248,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	ryInput.SetTooltip("Rotation Quaternion.Y");
 	ryInput.SetPos(XMFLOAT2(x, y += step));
 	ryInput.SetSize(XMFLOAT2(siz, hei));
-	ryInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	ryInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -264,7 +264,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	rzInput.SetTooltip("Rotation Quaternion.Z");
 	rzInput.SetPos(XMFLOAT2(x, y += step));
 	rzInput.SetSize(XMFLOAT2(siz, hei));
-	rzInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	rzInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{
@@ -280,7 +280,7 @@ void TransformWindow::Create(EditorComponent* _editor)
 	rwInput.SetTooltip("Rotation Quaternion.W");
 	rwInput.SetPos(XMFLOAT2(x, y += step));
 	rwInput.SetSize(XMFLOAT2(siz, hei));
-	rwInput.OnInputAccepted([&](wi::gui::EventArgs args) {
+	rwInput.OnInputAccepted([this](wi::gui::EventArgs args) {
 		TransformComponent* transform = editor->GetCurrentScene().transforms.GetComponent(entity);
 		if (transform != nullptr)
 		{

--- a/Editor/VideoWindow.cpp
+++ b/Editor/VideoWindow.cpp
@@ -50,7 +50,7 @@ void VideoWindow::Create(EditorComponent* _editor)
 
 	openButton.Create("Open File " ICON_OPEN);
 	openButton.SetTooltip("Open video file.\nSupported extensions: MP4");
-	openButton.OnClick([&](wi::gui::EventArgs args) {
+	openButton.OnClick([this](wi::gui::EventArgs args) {
 		VideoComponent* video = editor->GetCurrentScene().videos.GetComponent(entity);
 		if (video != nullptr)
 		{
@@ -78,7 +78,7 @@ void VideoWindow::Create(EditorComponent* _editor)
 
 	playpauseButton.Create(ICON_PLAY);
 	playpauseButton.SetTooltip("Play/Pause selected video instance.");
-	playpauseButton.OnClick([&](wi::gui::EventArgs args) {
+	playpauseButton.OnClick([this](wi::gui::EventArgs args) {
 		VideoComponent* video = editor->GetCurrentScene().videos.GetComponent(entity);
 		if (video != nullptr)
 		{
@@ -98,7 +98,7 @@ void VideoWindow::Create(EditorComponent* _editor)
 
 	stopButton.Create(ICON_STOP);
 	stopButton.SetTooltip("Stop selected video instance.");
-	stopButton.OnClick([&](wi::gui::EventArgs args) {
+	stopButton.OnClick([this](wi::gui::EventArgs args) {
 		VideoComponent* video = editor->GetCurrentScene().videos.GetComponent(entity);
 		if (video != nullptr)
 		{
@@ -110,7 +110,7 @@ void VideoWindow::Create(EditorComponent* _editor)
 	loopedCheckbox.Create("Looped: ");
 	loopedCheckbox.SetTooltip("Enable looping for the selected video instance.");
 	loopedCheckbox.SetCheckText(ICON_LOOP);
-	loopedCheckbox.OnClick([&](wi::gui::EventArgs args) {
+	loopedCheckbox.OnClick([this](wi::gui::EventArgs args) {
 		VideoComponent* video = editor->GetCurrentScene().videos.GetComponent(entity);
 		if (video != nullptr)
 		{
@@ -120,7 +120,7 @@ void VideoWindow::Create(EditorComponent* _editor)
 	AddWidget(&loopedCheckbox);
 
 	timerSlider.Create(0, 1, 0, 1000, "Timer: ");
-	timerSlider.OnSlide([&](wi::gui::EventArgs args) {
+	timerSlider.OnSlide([this](wi::gui::EventArgs args) {
 		VideoComponent* video = editor->GetCurrentScene().videos.GetComponent(entity);
 		video->Seek(args.fValue);
 	});

--- a/Editor/WeatherWindow.cpp
+++ b/Editor/WeatherWindow.cpp
@@ -71,7 +71,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	colorPicker.SetPos(XMFLOAT2(mod_x, y += step));
 	colorPicker.SetVisible(false);
 	colorPicker.SetEnabled(true);
-	colorPicker.OnColorChanged([&](wi::gui::EventArgs args) {
+	colorPicker.OnColorChanged([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		switch (colorComboBox.GetSelected())
 		{
@@ -120,7 +120,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	overrideFogColorCheckBox.SetTooltip("If enabled, the fog color will be always taken from Horizon Color, even if the sky is realistic");
 	overrideFogColorCheckBox.SetSize(XMFLOAT2(hei, hei));
 	overrideFogColorCheckBox.SetPos(XMFLOAT2(x, y));
-	overrideFogColorCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	overrideFogColorCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.SetOverrideFogColor(args.bValue);
 		});
@@ -129,7 +129,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	heightFogCheckBox.Create("Height fog: ");
 	heightFogCheckBox.SetSize(XMFLOAT2(hei, hei));
 	heightFogCheckBox.SetPos(XMFLOAT2(x, y));
-	heightFogCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	heightFogCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.SetHeightFog(args.bValue);
 		});
@@ -138,7 +138,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	fogStartSlider.Create(0, 5000, 0, 100000, "Fog Start: ");
 	fogStartSlider.SetSize(XMFLOAT2(wid, hei));
 	fogStartSlider.SetPos(XMFLOAT2(x, y += step));
-	fogStartSlider.OnSlide([&](wi::gui::EventArgs args) {
+	fogStartSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().fogStart = args.fValue;
 	});
 	AddWidget(&fogStartSlider);
@@ -146,7 +146,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	fogDensitySlider.Create(0, 0.05f, 0.01f, 10000, "Fog Density: ");
 	fogDensitySlider.SetSize(XMFLOAT2(wid, hei));
 	fogDensitySlider.SetPos(XMFLOAT2(x, y += step));
-	fogDensitySlider.OnSlide([&](wi::gui::EventArgs args) {
+	fogDensitySlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().fogDensity = args.fValue;
 	});
 	AddWidget(&fogDensitySlider);
@@ -154,7 +154,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	fogHeightStartSlider.Create(-100, 100, 1, 10000, "Fog Height Start: ");
 	fogHeightStartSlider.SetSize(XMFLOAT2(wid, hei));
 	fogHeightStartSlider.SetPos(XMFLOAT2(x, y += step));
-	fogHeightStartSlider.OnSlide([&](wi::gui::EventArgs args) {
+	fogHeightStartSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().fogHeightStart = args.fValue;
 		});
 	AddWidget(&fogHeightStartSlider);
@@ -162,7 +162,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	fogHeightEndSlider.Create(-100, 100, 3, 10000, "Fog Height End: ");
 	fogHeightEndSlider.SetSize(XMFLOAT2(wid, hei));
 	fogHeightEndSlider.SetPos(XMFLOAT2(x, y += step));
-	fogHeightEndSlider.OnSlide([&](wi::gui::EventArgs args) {
+	fogHeightEndSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().fogHeightEnd = args.fValue;
 		});
 	AddWidget(&fogHeightEndSlider);
@@ -171,7 +171,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	gravitySlider.SetTooltip("Set the gravity factor on Y (vertical) axis for physics.");
 	gravitySlider.SetSize(XMFLOAT2(wid, hei));
 	gravitySlider.SetPos(XMFLOAT2(x, y += step));
-	gravitySlider.OnSlide([&](wi::gui::EventArgs args) {
+	gravitySlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().gravity.y = args.fValue;
 		});
 	AddWidget(&gravitySlider);
@@ -179,7 +179,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	windSpeedSlider.Create(0.0f, 4.0f, 1.0f, 10000, "Wind Speed: ");
 	windSpeedSlider.SetSize(XMFLOAT2(wid, hei));
 	windSpeedSlider.SetPos(XMFLOAT2(x, y += step));
-	windSpeedSlider.OnSlide([&](wi::gui::EventArgs args) {
+	windSpeedSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().windSpeed = args.fValue;
 	});
 	AddWidget(&windSpeedSlider);
@@ -187,7 +187,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	windMagnitudeSlider.Create(0.0f, 0.2f, 0.0f, 10000, "Wind Magnitude: ");
 	windMagnitudeSlider.SetSize(XMFLOAT2(wid, hei));
 	windMagnitudeSlider.SetPos(XMFLOAT2(x, y += step));
-	windMagnitudeSlider.OnSlide([&](wi::gui::EventArgs args) {
+	windMagnitudeSlider.OnSlide([this](wi::gui::EventArgs args) {
 		UpdateWind();
 		});
 	AddWidget(&windMagnitudeSlider);
@@ -195,7 +195,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	windDirectionSlider.Create(0, 1, 0, 10000, "Wind Direction: ");
 	windDirectionSlider.SetSize(XMFLOAT2(wid, hei));
 	windDirectionSlider.SetPos(XMFLOAT2(x, y += step));
-	windDirectionSlider.OnSlide([&](wi::gui::EventArgs args) {
+	windDirectionSlider.OnSlide([this](wi::gui::EventArgs args) {
 		UpdateWind();
 	});
 	AddWidget(&windDirectionSlider);
@@ -203,7 +203,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	windWaveSizeSlider.Create(0, 1, 0, 10000, "Wind Wave Size: ");
 	windWaveSizeSlider.SetSize(XMFLOAT2(wid, hei));
 	windWaveSizeSlider.SetPos(XMFLOAT2(x, y += step));
-	windWaveSizeSlider.OnSlide([&](wi::gui::EventArgs args) {
+	windWaveSizeSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().windWaveSize = args.fValue;
 	});
 	AddWidget(&windWaveSizeSlider);
@@ -211,7 +211,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	windRandomnessSlider.Create(0, 10, 5, 10000, "Wind Randomness: ");
 	windRandomnessSlider.SetSize(XMFLOAT2(wid, hei));
 	windRandomnessSlider.SetPos(XMFLOAT2(x, y += step));
-	windRandomnessSlider.OnSlide([&](wi::gui::EventArgs args) {
+	windRandomnessSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().windRandomness = args.fValue;
 	});
 	AddWidget(&windRandomnessSlider);
@@ -219,7 +219,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	skyExposureSlider.Create(0, 4, 1, 10000, "Sky Exposure: ");
 	skyExposureSlider.SetSize(XMFLOAT2(wid, hei));
 	skyExposureSlider.SetPos(XMFLOAT2(x, y += step));
-	skyExposureSlider.OnSlide([&](wi::gui::EventArgs args) {
+	skyExposureSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().skyExposure = args.fValue;
 		});
 	AddWidget(&skyExposureSlider);
@@ -228,7 +228,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	starsSlider.SetTooltip("Amount of stars in the night sky (0 to disable). \nIt will only work with the realistic sky enabled. \nThey will be more visible at night time.");
 	starsSlider.SetSize(XMFLOAT2(wid, hei));
 	starsSlider.SetPos(XMFLOAT2(x, y += step));
-	starsSlider.OnSlide([&](wi::gui::EventArgs args) {
+	starsSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().stars = args.fValue;
 		});
 	AddWidget(&starsSlider);
@@ -237,7 +237,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	skyRotationSlider.SetTooltip("Rotate the sky texture horizontally. (If using a sky texture)");
 	skyRotationSlider.SetSize(XMFLOAT2(wid, hei));
 	skyRotationSlider.SetPos(XMFLOAT2(x, y += step));
-	skyRotationSlider.OnSlide([&](wi::gui::EventArgs args) {
+	skyRotationSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().sky_rotation = wi::math::DegreesToRadians(args.fValue);
 		});
 	AddWidget(&skyRotationSlider);
@@ -246,7 +246,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	rainAmountSlider.SetTooltip("Set the amount of rain effect. 0 = disabled, 1 = heavy rain");
 	rainAmountSlider.SetSize(XMFLOAT2(wid, hei));
 	rainAmountSlider.SetPos(XMFLOAT2(x, y += step));
-	rainAmountSlider.OnSlide([&](wi::gui::EventArgs args) {
+	rainAmountSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().rain_amount = args.fValue;
 		});
 	AddWidget(&rainAmountSlider);
@@ -255,7 +255,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	rainLengthSlider.SetTooltip("The elongation of rain particles in the direction of their motion.");
 	rainLengthSlider.SetSize(XMFLOAT2(wid, hei));
 	rainLengthSlider.SetPos(XMFLOAT2(x, y += step));
-	rainLengthSlider.OnSlide([&](wi::gui::EventArgs args) {
+	rainLengthSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().rain_length = args.fValue;
 		});
 	AddWidget(&rainLengthSlider);
@@ -264,7 +264,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	rainSpeedSlider.SetTooltip("The downward speed of rain particles. The final speed will be modulated by the wind direction and speed as well.");
 	rainSpeedSlider.SetSize(XMFLOAT2(wid, hei));
 	rainSpeedSlider.SetPos(XMFLOAT2(x, y += step));
-	rainSpeedSlider.OnSlide([&](wi::gui::EventArgs args) {
+	rainSpeedSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().rain_speed = args.fValue;
 		});
 	AddWidget(&rainSpeedSlider);
@@ -273,7 +273,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	rainScaleSlider.SetTooltip("The overall size of rain particles.");
 	rainScaleSlider.SetSize(XMFLOAT2(wid, hei));
 	rainScaleSlider.SetPos(XMFLOAT2(x, y += step));
-	rainScaleSlider.OnSlide([&](wi::gui::EventArgs args) {
+	rainScaleSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().rain_scale = args.fValue;
 		});
 	AddWidget(&rainScaleSlider);
@@ -282,7 +282,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	rainSplashScaleSlider.SetTooltip("The size of rain particles when they hit the ground.");
 	rainSplashScaleSlider.SetSize(XMFLOAT2(wid, hei));
 	rainSplashScaleSlider.SetPos(XMFLOAT2(x, y += step));
-	rainSplashScaleSlider.OnSlide([&](wi::gui::EventArgs args) {
+	rainSplashScaleSlider.OnSlide([this](wi::gui::EventArgs args) {
 		GetWeather().rain_splash_scale = args.fValue;
 		});
 	AddWidget(&rainSplashScaleSlider);
@@ -291,7 +291,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	realisticskyCheckBox.SetTooltip("Physically based sky rendering model.\nNote that realistic sky requires a sun (directional light) to be visible.");
 	realisticskyCheckBox.SetSize(XMFLOAT2(hei, hei));
 	realisticskyCheckBox.SetPos(XMFLOAT2(x, y += step));
-	realisticskyCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	realisticskyCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.SetRealisticSky(args.bValue);
 		});
@@ -301,7 +301,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	aerialperspectiveCheckBox.SetTooltip("Additional calculations for realistic sky to enable atmospheric effects for objects and other drawn effects.");
 	aerialperspectiveCheckBox.SetSize(XMFLOAT2(hei, hei));
 	aerialperspectiveCheckBox.SetPos(XMFLOAT2(x, y += step));
-	aerialperspectiveCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	aerialperspectiveCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.SetRealisticSkyAerialPerspective(args.bValue);
 		});
@@ -311,7 +311,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	realisticskyHighQualityCheckBox.SetTooltip("Skip LUT for more accurate sky and aerial perspective. This also enables shadowmaps to affect sky calculations. \nNote: For volumetric shadows to be visible, increase shadowmap boundary and/or enable cloud shadows.");
 	realisticskyHighQualityCheckBox.SetSize(XMFLOAT2(hei, hei));
 	realisticskyHighQualityCheckBox.SetPos(XMFLOAT2(x, y += step));
-	realisticskyHighQualityCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	realisticskyHighQualityCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.SetRealisticSkyHighQuality(args.bValue);
 		});
@@ -321,7 +321,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	realisticskyReceiveShadowCheckBox.SetTooltip("Realistic sky to recieve shadow from objects with shadow maps.");
 	realisticskyReceiveShadowCheckBox.SetSize(XMFLOAT2(hei, hei));
 	realisticskyReceiveShadowCheckBox.SetPos(XMFLOAT2(x, y += step));
-	realisticskyReceiveShadowCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	realisticskyReceiveShadowCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.SetRealisticSkyReceiveShadow(args.bValue);
 		});
@@ -331,7 +331,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	volumetricCloudsCheckBox.SetTooltip("Enable volumetric cloud rendering, which is separate from the simple cloud parameters.");
 	volumetricCloudsCheckBox.SetSize(XMFLOAT2(hei, hei));
 	volumetricCloudsCheckBox.SetPos(XMFLOAT2(x, y += step));
-	volumetricCloudsCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	volumetricCloudsCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.SetVolumetricClouds(args.bValue);
 		});
@@ -341,7 +341,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	volumetricCloudsReceiveShadowCheckBox.SetTooltip("Clouds to recieve shadow from objects with shadow maps.");
 	volumetricCloudsReceiveShadowCheckBox.SetSize(XMFLOAT2(hei, hei));
 	volumetricCloudsReceiveShadowCheckBox.SetPos(XMFLOAT2(x, y += step));
-	volumetricCloudsReceiveShadowCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	volumetricCloudsReceiveShadowCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.SetVolumetricCloudsReceiveShadow(args.bValue);
 		});
@@ -351,7 +351,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	volumetricCloudsCastShadowCheckBox.SetTooltip("Compute shadows for volumetric clouds that will be used for geometry and lighting.");
 	volumetricCloudsCastShadowCheckBox.SetSize(XMFLOAT2(hei, hei));
 	volumetricCloudsCastShadowCheckBox.SetPos(XMFLOAT2(x, y += step));
-	volumetricCloudsCastShadowCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	volumetricCloudsCastShadowCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.SetVolumetricCloudsCastShadow(args.bValue);
 		});
@@ -361,7 +361,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	cloudStartHeightSlider.SetTooltip("This tells how many meters above the surface the cloud system should appear");
 	cloudStartHeightSlider.SetSize(XMFLOAT2(wid, hei));
 	cloudStartHeightSlider.SetPos(XMFLOAT2(x, y += step));
-	cloudStartHeightSlider.OnSlide([&](wi::gui::EventArgs args) {
+	cloudStartHeightSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.cloudStartHeight = args.fValue;
 		});
@@ -371,7 +371,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	cloudThicknessSlider.SetTooltip("Specify the cloud system thickness, so from the start height plus additional thickness on top");
 	cloudThicknessSlider.SetSize(XMFLOAT2(wid, hei));
 	cloudThicknessSlider.SetPos(XMFLOAT2(x, y += step));
-	cloudThicknessSlider.OnSlide([&](wi::gui::EventArgs args) {
+	cloudThicknessSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.cloudThickness = args.fValue;
 		});
@@ -381,7 +381,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	skewAlongWindDirectionFirstSlider.SetTooltip("Adjust the skew on noise alone");
 	skewAlongWindDirectionFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	skewAlongWindDirectionFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	skewAlongWindDirectionFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	skewAlongWindDirectionFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.skewAlongWindDirection = args.fValue;
 		});
@@ -391,7 +391,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	totalNoiseScaleFirstSlider.SetTooltip("Total scale adjusts base noise, detail noise and curl noise");
 	totalNoiseScaleFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	totalNoiseScaleFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	totalNoiseScaleFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	totalNoiseScaleFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.totalNoiseScale = args.fValue;
 		});
@@ -400,7 +400,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	curlScaleFirstSlider.Create(0.0f, 1.0f, 0.3f, 1000.0f, "Curl scale 1: ");
 	curlScaleFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	curlScaleFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	curlScaleFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	curlScaleFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.curlScale = args.fValue;
 		});
@@ -410,7 +410,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	curlNoiseHeightFractionFirstSlider.SetTooltip("Higher values pulls the curl more towards bottom");
 	curlNoiseHeightFractionFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	curlNoiseHeightFractionFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	curlNoiseHeightFractionFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	curlNoiseHeightFractionFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.curlNoiseHeightFraction = args.fValue;
 		});
@@ -419,7 +419,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	curlNoiseModifierFirstSlider.Create(0.0f, 1000.0f, 500.0f, 1000.0f, "Curl modifier 1: ");
 	curlNoiseModifierFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	curlNoiseModifierFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	curlNoiseModifierFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	curlNoiseModifierFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.curlNoiseModifier = args.fValue;
 		});
@@ -428,7 +428,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	detailScaleFirstSlider.Create(0.0f, 5.0f, 4.0f, 1000.0f, "Detail scale 1: ");
 	detailScaleFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	detailScaleFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	detailScaleFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	detailScaleFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.detailScale = args.fValue;
 		});
@@ -438,7 +438,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	detailNoiseHeightFractionFirstSlider.SetTooltip("Higher values pulls the detail more towards bottom");
 	detailNoiseHeightFractionFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	detailNoiseHeightFractionFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	detailNoiseHeightFractionFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	detailNoiseHeightFractionFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.detailNoiseHeightFraction = args.fValue;
 		});
@@ -447,7 +447,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	detailNoiseModifierFirstSlider.Create(0.0f, 1.0f, 0.3f, 1000.0f, "Detail modifier 1: ");
 	detailNoiseModifierFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	detailNoiseModifierFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	detailNoiseModifierFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	detailNoiseModifierFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.detailNoiseModifier = args.fValue;
 		});
@@ -457,7 +457,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	skewAlongCoverageWindDirectionFirstSlider.SetTooltip("This pulls the entire clouds towards the wind direction along height");
 	skewAlongCoverageWindDirectionFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	skewAlongCoverageWindDirectionFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	skewAlongCoverageWindDirectionFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	skewAlongCoverageWindDirectionFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.skewAlongCoverageWindDirection = args.fValue;
 		});
@@ -467,7 +467,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	weatherScaleFirstSlider.SetTooltip("Scales the weather map that controls coverage, type and rain");
 	weatherScaleFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	weatherScaleFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	weatherScaleFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	weatherScaleFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.weatherScale = args.fValue;
 		});
@@ -477,7 +477,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	coverageAmountFirstSlider.SetTooltip("Adjust the coverage amount from the weather map");
 	coverageAmountFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	coverageAmountFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	coverageAmountFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	coverageAmountFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.coverageAmount = args.fValue;
 		});
@@ -487,7 +487,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	coverageMinimumFirstSlider.SetTooltip("Adjust the minimum amount from the weather map");
 	coverageMinimumFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	coverageMinimumFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	coverageMinimumFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	coverageMinimumFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.coverageMinimum = args.fValue;
 		});
@@ -497,7 +497,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	typeAmountFirstSlider.SetTooltip("Adjust the type amount from the weather map");
 	typeAmountFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	typeAmountFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	typeAmountFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	typeAmountFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.typeAmount = args.fValue;
 		});
@@ -507,7 +507,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	typeMinimumFirstSlider.SetTooltip("Adjust the minimum type from the weather map");
 	typeMinimumFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	typeMinimumFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	typeMinimumFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	typeMinimumFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.typeMinimum = args.fValue;
 		});
@@ -517,7 +517,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	rainAmountFirstSlider.SetTooltip("Adjust the rain amount from the weather map");
 	rainAmountFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	rainAmountFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	rainAmountFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	rainAmountFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.rainAmount = args.fValue;
 		});
@@ -527,7 +527,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	rainMinimumFirstSlider.SetTooltip("Adjust the minimum rain from the weather map");
 	rainMinimumFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	rainMinimumFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	rainMinimumFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	rainMinimumFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.rainMinimum = args.fValue;
 		});
@@ -596,7 +596,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	windSpeedFirstSlider.SetTooltip("Wind speed of the noise");
 	windSpeedFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	windSpeedFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	windSpeedFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	windSpeedFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.windSpeed = args.fValue;
 		});
@@ -606,7 +606,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	windAngleFirstSlider.SetTooltip("Wind angle in radians");
 	windAngleFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	windAngleFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	windAngleFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	windAngleFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.windAngle = args.fValue;
 		});
@@ -616,7 +616,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	windUpAmountFirstSlider.SetTooltip("How much wind up drag the noise recieves");
 	windUpAmountFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	windUpAmountFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	windUpAmountFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	windUpAmountFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.windUpAmount = args.fValue;
 		});
@@ -625,7 +625,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	coverageWindSpeedFirstSlider.Create(0.0f, 50.0f, 30.0f, 1000.0f, "Coverage wind speed 1: ");
 	coverageWindSpeedFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	coverageWindSpeedFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	coverageWindSpeedFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	coverageWindSpeedFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.coverageWindSpeed = args.fValue;
 		});
@@ -635,7 +635,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	coverageWindAngleFirstSlider.SetTooltip("Wind angle in radians");
 	coverageWindAngleFirstSlider.SetSize(XMFLOAT2(wid, hei));
 	coverageWindAngleFirstSlider.SetPos(XMFLOAT2(x, y += step));
-	coverageWindAngleFirstSlider.OnSlide([&](wi::gui::EventArgs args) {
+	coverageWindAngleFirstSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerFirst.coverageWindAngle = args.fValue;
 		});
@@ -645,7 +645,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	coverageAmountSecondSlider.SetTooltip("Adjust the coverage amount from the weather map");
 	coverageAmountSecondSlider.SetSize(XMFLOAT2(wid, hei));
 	coverageAmountSecondSlider.SetPos(XMFLOAT2(x, y += step));
-	coverageAmountSecondSlider.OnSlide([&](wi::gui::EventArgs args) {
+	coverageAmountSecondSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerSecond.coverageAmount = args.fValue;
 		});
@@ -655,7 +655,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	coverageMinimumSecondSlider.SetTooltip("Adjust the minimum amount from the weather map");
 	coverageMinimumSecondSlider.SetSize(XMFLOAT2(wid, hei));
 	coverageMinimumSecondSlider.SetPos(XMFLOAT2(x, y += step));
-	coverageMinimumSecondSlider.OnSlide([&](wi::gui::EventArgs args) {
+	coverageMinimumSecondSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.volumetricCloudParameters.layerSecond.coverageMinimum = args.fValue;
 		});
@@ -798,7 +798,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	ocean_enabledCheckBox.Create("Ocean simulation: ");
 	ocean_enabledCheckBox.SetSize(XMFLOAT2(hei, hei));
 	ocean_enabledCheckBox.SetPos(XMFLOAT2(x, y += step));
-	ocean_enabledCheckBox.OnClick([&](wi::gui::EventArgs args) {
+	ocean_enabledCheckBox.OnClick([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.SetOceanEnabled(args.bValue);
 		if (!weather.IsOceanEnabled())
@@ -814,7 +814,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	ocean_patchSizeSlider.SetPos(XMFLOAT2(x, y += step));
 	ocean_patchSizeSlider.SetValue(editor->GetCurrentScene().weather.oceanParameters.patch_length);
 	ocean_patchSizeSlider.SetTooltip("Adjust water tiling patch size");
-	ocean_patchSizeSlider.OnSlide([&](wi::gui::EventArgs args) {
+	ocean_patchSizeSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.oceanParameters.patch_length = args.fValue;
 		editor->GetCurrentScene().ocean = {};
@@ -826,7 +826,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	ocean_waveAmplitudeSlider.SetPos(XMFLOAT2(x, y += step));
 	ocean_waveAmplitudeSlider.SetValue(editor->GetCurrentScene().weather.oceanParameters.wave_amplitude);
 	ocean_waveAmplitudeSlider.SetTooltip("Adjust wave size");
-	ocean_waveAmplitudeSlider.OnSlide([&](wi::gui::EventArgs args) {
+	ocean_waveAmplitudeSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.oceanParameters.wave_amplitude = args.fValue;
 		editor->GetCurrentScene().ocean = {};
@@ -838,7 +838,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	ocean_choppyScaleSlider.SetPos(XMFLOAT2(x, y += step));
 	ocean_choppyScaleSlider.SetValue(editor->GetCurrentScene().weather.oceanParameters.choppy_scale);
 	ocean_choppyScaleSlider.SetTooltip("Adjust wave choppiness");
-	ocean_choppyScaleSlider.OnSlide([&](wi::gui::EventArgs args) {
+	ocean_choppyScaleSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.oceanParameters.choppy_scale = args.fValue;
 		});
@@ -849,7 +849,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	ocean_windDependencySlider.SetPos(XMFLOAT2(x, y += step));
 	ocean_windDependencySlider.SetValue(editor->GetCurrentScene().weather.oceanParameters.wind_dependency);
 	ocean_windDependencySlider.SetTooltip("Adjust wind contribution");
-	ocean_windDependencySlider.OnSlide([&](wi::gui::EventArgs args) {
+	ocean_windDependencySlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.oceanParameters.wind_dependency = args.fValue;
 		editor->GetCurrentScene().ocean = {};
@@ -861,7 +861,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	ocean_timeScaleSlider.SetPos(XMFLOAT2(x, y += step));
 	ocean_timeScaleSlider.SetValue(editor->GetCurrentScene().weather.oceanParameters.time_scale);
 	ocean_timeScaleSlider.SetTooltip("Adjust simulation speed");
-	ocean_timeScaleSlider.OnSlide([&](wi::gui::EventArgs args) {
+	ocean_timeScaleSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.oceanParameters.time_scale = args.fValue;
 		});
@@ -872,7 +872,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	ocean_heightSlider.SetPos(XMFLOAT2(x, y += step));
 	ocean_heightSlider.SetValue(0);
 	ocean_heightSlider.SetTooltip("Adjust water level");
-	ocean_heightSlider.OnSlide([&](wi::gui::EventArgs args) {
+	ocean_heightSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.oceanParameters.waterHeight = args.fValue;
 		});
@@ -883,7 +883,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	ocean_detailSlider.SetPos(XMFLOAT2(x, y += step));
 	ocean_detailSlider.SetValue(4);
 	ocean_detailSlider.SetTooltip("Adjust surface tessellation resolution. High values can decrease performance.");
-	ocean_detailSlider.OnSlide([&](wi::gui::EventArgs args) {
+	ocean_detailSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.oceanParameters.surfaceDetail = (uint32_t)args.iValue;
 		});
@@ -894,7 +894,7 @@ void WeatherWindow::Create(EditorComponent* _editor)
 	ocean_toleranceSlider.SetPos(XMFLOAT2(x, y += step));
 	ocean_toleranceSlider.SetValue(2);
 	ocean_toleranceSlider.SetTooltip("Big waves can introduce glitches on screen borders, this can fix that but surface detail will decrease.");
-	ocean_toleranceSlider.OnSlide([&](wi::gui::EventArgs args) {
+	ocean_toleranceSlider.OnSlide([this](wi::gui::EventArgs args) {
 		auto& weather = GetWeather();
 		weather.oceanParameters.surfaceDisplacementTolerance = args.fValue;
 		});

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -291,6 +291,10 @@ namespace wi::gui
 		Widget();
 		virtual ~Widget() = default;
 
+    // Delete copy/move to prevent invalidating `this`
+    // since it is often captured by event handlers.
+    Widget(const Widget &) = delete;
+
 		const std::string& GetName() const;
 		void SetName(const std::string& value);
 		std::string GetText() const;


### PR DESCRIPTION
First off, this deletes the copy/move constructor for `Widget` since they often capture `this` in their event handlers.

I also attempted to eliminate all reference captures and benign uses of `[&]` to prevent undefined behavior when some references point to objects on the stack or objects that live in containers where certain operations can invalidate their addresses. Please consider these changes. Thank you.

Oh, and I also added a `FIXME` note that needs special attention. I think that was the only non-benign case because the terrain component belongs to a `vector` and it isn't obvious if it would not be invalidated.