### PR TITLE
Delete Widget copy/move constructors to prevent invalidating this

### DIFF
--- a/Editor/ContentBrowserWindow.h
+++ b/Editor/ContentBrowserWindow.h
@@ -22,7 +22,7 @@ public:
 	};
 	SELECTION current_selection = SELECTION_COUNT;
 	wi::gui::Button folderButtons[SELECTION_COUNT];
-	wi::vector<wi::gui::Button> itemButtons;
+  std::deque<wi::gui::Button> itemButtons;
 
 	wi::gui::Button openFolderButton;
 

--- a/Editor/HairParticleWindow.h
+++ b/Editor/HairParticleWindow.h
@@ -35,9 +35,9 @@ public:
 	wi::gui::Slider uniformitySlider;
 
 	wi::gui::Button addSpriteButton;
-	wi::vector<wi::gui::Button> sprites;
-	wi::vector<wi::gui::Button> spriteRemoveButtons;
-	wi::vector<wi::gui::Slider> spriteSizeSliders;
+  std::deque<wi::gui::Button> sprites;
+	std::deque<wi::gui::Button> spriteRemoveButtons;
+	std::deque<wi::gui::Slider> spriteSizeSliders;
 
 	SpriteRectWindow spriterectwnd;
 

--- a/Editor/LightWindow.cpp
+++ b/Editor/LightWindow.cpp
@@ -359,8 +359,6 @@ void LightWindow::RefreshCascades()
 	if (light == nullptr || light->type != LightComponent::DIRECTIONAL)
 		return;
 
-	cascades.reserve(light->cascade_distances.size());
-
 	int counter = 0;
 	for (auto& x : light->cascade_distances)
 	{

--- a/Editor/LightWindow.h
+++ b/Editor/LightWindow.h
@@ -40,7 +40,7 @@ public:
 		wi::gui::Slider distanceSlider;
 		wi::gui::Button removeButton;
 	};
-	wi::vector<CascadeConfig> cascades;
+  std::deque<CascadeConfig> cascades;
 	wi::gui::Button addCascadeButton;
 	void RefreshCascades();
 

--- a/Editor/MaterialPickerWindow.h
+++ b/Editor/MaterialPickerWindow.h
@@ -8,7 +8,7 @@ public:
 
 	EditorComponent* editor = nullptr;
 
-	wi::vector<wi::gui::Button> buttons;
+  std::deque<wi::gui::Button> buttons;
 
 	wi::gui::Slider zoomSlider;
 

--- a/Editor/MetadataWindow.cpp
+++ b/Editor/MetadataWindow.cpp
@@ -140,14 +140,6 @@ void MetadataWindow::RefreshEntries()
 	if (metadata == nullptr)
 		return;
 
-	entries.reserve(
-		metadata->bool_values.size() +
-		metadata->int_values.size() +
-		metadata->float_values.size() +
-		metadata->string_values.size()
-	);
-
-
 	auto forEachSelectedWithRefresh = [this] (auto name, auto func) {
 		return [this, func, name] (auto args) {
 			wi::scene::Scene& scene = editor->GetCurrentScene();

--- a/Editor/MetadataWindow.h
+++ b/Editor/MetadataWindow.h
@@ -21,7 +21,7 @@ public:
 		wi::gui::CheckBox check;
 		bool is_bool = false;
 	};
-	wi::vector<Entry> entries;
+  std::deque<Entry> entries;
 
 	void RefreshEntries();
 

--- a/Editor/PaintToolWindow.h
+++ b/Editor/PaintToolWindow.h
@@ -92,7 +92,7 @@ public:
 		Z
 	};
 
-	wi::vector<wi::gui::Button> terrain_material_buttons;
+  std::deque<wi::gui::Button> terrain_material_buttons;
 	size_t terrain_material_layer = 0;
 
 	float texture_paint_radius = 50;

--- a/Editor/SplineWindow.cpp
+++ b/Editor/SplineWindow.cpp
@@ -179,8 +179,6 @@ void SplineWindow::RefreshEntries()
 	if (spline == nullptr)
 		return;
 
-	entries.reserve(spline->spline_node_entities.size());
-
 	for (size_t i = 0; i < spline->spline_node_entities.size(); ++i)
 	{
 		Entity entity = spline->spline_node_entities[i];

--- a/Editor/SplineWindow.h
+++ b/Editor/SplineWindow.h
@@ -27,7 +27,7 @@ public:
 		wi::gui::Button removeButton;
 		wi::gui::Button entityButton;
 	};
-	wi::vector<Entry> entries;
+  std::deque<Entry> entries;
 
 	void RefreshEntries();
 

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -291,6 +291,9 @@ namespace wi::gui
 		Widget();
 		virtual ~Widget() = default;
 
+    // Delete copy/move to keep internal references stable.
+    Widget(const Widget &) = delete;
+
 		const std::string& GetName() const;
 		void SetName(const std::string& value);
 		std::string GetText() const;


### PR DESCRIPTION
This deletes the copy/move constructors for `Widget`. The changes here are only to fix what this change would break. ie use of `vector` and calls to `reserve`. As was discussed, this is a breaking change that could affect downstream users of any kind of object whose class derives from `Widget`. However, it does create a safer, less error prone interface that could possibly fix difficult to reproduce crashes caused by the use of invalid references in the event handlers.