### PR TITLE
cmake: fix MSVC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,13 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 if (WIN32)
     set(PLATFORM "Windows")
     add_compile_definitions(WIN32=1)
+    if (MSVC)
+        add_compile_options(
+            /W3
+            /MP
+        )
+	endif()
+
     # add_compile_definitions(_WIN32=1) this is a given from the compiler
 elseif(UNIX)
     set(PLATFORM "SDL2")

--- a/WickedEngine/CMakeLists.txt
+++ b/WickedEngine/CMakeLists.txt
@@ -30,6 +30,12 @@ endif()
 if (WIN32)
     # TODO: Choose whether to use SDL2 on windows as well
     set(TARGET_NAME WickedEngine_Windows)
+
+    if (MSVC)
+        add_compile_options(
+            /bigobj
+        )
+    endif()
 else ()
     set(TARGET_NAME WickedEngine_Linux)
     find_package(SDL2 REQUIRED)
@@ -184,14 +190,6 @@ if (WIN32)
     target_compile_definitions(${TARGET_NAME} PUBLIC
         UNICODE _UNICODE
     )
-
-    if (MSVC)
-        add_compile_options(
-            /W3
-            /MP
-            /bigobj
-        )
-    endif()
 
     set(LIBDXCOMPILER "dxcompiler.dll")
 else ()


### PR DESCRIPTION
add_compile_options add to the directory COMPILE_OPTIONS property; it seems that setting target specific COMPILE_OPTIONS will only use the current directory COMPILE_OPTIONS at the time the target_compile_options is encountered, but ignore later ones.

Long story short: move the compile options further up, and the /W3 and /MP ones to the toplevel so they also apply to the Editor and Samples.