### PR TITLE
rename utility_common.cpp to utility_common.c

### DIFF
--- a/WickedEngine/Utility/CMakeLists.txt
+++ b/WickedEngine/Utility/CMakeLists.txt
@@ -33,7 +33,7 @@ install(FILES ${HEADER_FILES}
 # so they are not source files that should be
 # compiled on their own; hence we mark them as header files
 file(GLOB_RECURSE DIRECTLY_INCLUDED_FILES CONFIGURE_DEPENDS
-	# included by utility_common.cpp
+	# included by utility_common.c
 	mikktspace.c
 	zstd.c
 

--- a/WickedEngine/Utility/utility_common.c
+++ b/WickedEngine/Utility/utility_common.c
@@ -3,6 +3,10 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif // _CRT_SECURE_NO_WARNINGS
 
+// needs to be first because it defines _GNU_SOURCE which
+// then changes which symbols stdlib exports
+#include "zstd/zstd.c"
+
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
@@ -21,4 +25,3 @@
 
 #include "mikktspace.c"
 
-#include "zstd/zstd.c"

--- a/WickedEngine/WickedEngine_SOURCE.vcxitems
+++ b/WickedEngine/WickedEngine_SOURCE.vcxitems
@@ -646,7 +646,7 @@
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)Utility\utility_common.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Utility\utility_common.c" />
     <ClCompile Include="$(MSBuildThisFileDirectory)wiArchive.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)wiAudio.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)wiAudio_BindLua.cpp" />

--- a/WickedEngine/WickedEngine_SOURCE.vcxitems.filters
+++ b/WickedEngine/WickedEngine_SOURCE.vcxitems.filters
@@ -1604,7 +1604,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)wiGPUSortLib.cpp">
       <Filter>ENGINE\Graphics</Filter>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)Utility\utility_common.cpp">
+    <ClCompile Include="$(MSBuildThisFileDirectory)Utility\utility_common.c">
       <Filter>UTILITY</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)wiGPUBVH.cpp">


### PR DESCRIPTION
compiling it as C++ source will result in missing linker symbols when using address sanitizer.

an alternative would be to keep it a .cpp file, but add `extern "C" {` at the beginning.