### PR TITLE
wrap utility_common.cpp in extern "C"

### DIFF
--- a/WickedEngine/Utility/utility_common.cpp
+++ b/WickedEngine/Utility/utility_common.cpp
@@ -3,6 +3,9 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif // _CRT_SECURE_NO_WARNINGS
 
+// prevent linking problems when using ASAN
+extern "C" {
+
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
@@ -22,3 +25,5 @@
 #include "mikktspace.c"
 
 #include "zstd/zstd.c"
+
+}


### PR DESCRIPTION
This seems to solve a linking problem when using address sanitizer