### PR TITLE
Fix terrain generation restores deleted materials as dummy entities

### DIFF
--- a/WickedEngine/wiTerrain.cpp
+++ b/WickedEngine/wiTerrain.cpp
@@ -495,6 +495,22 @@ namespace wi::terrain
 
 		// Restore surface source materials:
 		{
+			// Clean up invalid material entities that no longer exist in the scene
+			for (size_t i = 0; i < materialEntities.size(); )
+			{
+				if (materialEntities[i] != INVALID_ENTITY && !scene->materials.Contains(materialEntities[i]))
+				{
+					materialEntities.erase(materialEntities.begin() + i);
+					if (i < materials.size())
+					{
+						materials.erase(materials.begin() + i);
+					}
+					continue;
+				}
+				++i;
+			}
+
+			// Restore valid materials
 			for (size_t i = 0; i < materialEntities.size(); ++i)
 			{
 				if (materialEntities[i] == INVALID_ENTITY)


### PR DESCRIPTION
The terrain logic might end up in a state containing material entities that were deleted from a scene after terrain generation but were restored as dummy entities.