### PR TITLE
Implement throttling for the camera preview

### DIFF
--- a/Editor/CameraComponentWindow.cpp
+++ b/Editor/CameraComponentWindow.cpp
@@ -17,13 +17,19 @@ void CameraPreview::RenderPreview()
 			scale = scale_local;
 			if (!camera->render_to_texture.rendertarget_render.IsValid())
 			{
-				renderpath.setSceneUpdateEnabled(false); // we just view our scene with this that's updated by the main rernderpath
-				renderpath.setOcclusionCullingEnabled(false); // occlusion culling only works for one camera
-				renderpath.PreUpdate();
-				renderpath.Update(0);
-				renderpath.PostUpdate();
-				renderpath.PreRender();
-				renderpath.Render();
+				// Throttle preview rendering to reduce performance impact
+				preview_timer += renderpath.scene->dt;
+				if (preview_timer >= preview_update_frequency)
+				{
+					preview_timer = 0.0f;
+					renderpath.setSceneUpdateEnabled(false); // we just view our scene with this that's updated by the main rernderpath
+					renderpath.setOcclusionCullingEnabled(false); // occlusion culling only works for one camera
+					renderpath.PreUpdate();
+					renderpath.Update(0);
+					renderpath.PostUpdate();
+					renderpath.PreRender();
+					renderpath.Render();
+				}
 			}
 		}
 		else

--- a/Editor/CameraComponentWindow.h
+++ b/Editor/CameraComponentWindow.h
@@ -7,6 +7,8 @@ public:
 	wi::RenderPath3D renderpath;
 	wi::ecs::Entity entity = wi::ecs::INVALID_ENTITY;
 	EditorComponent* editor = nullptr;
+	float preview_timer = 0.0f;
+	float preview_update_frequency = 0.1f; // Update preview every 0.1 seconds (10 FPS)
 
 	void RenderPreview();
 


### PR DESCRIPTION
In heavy scenes with many entities and high graphics settings, selecting a camera in the editor can reduce performance by half, causing the editor to stutter. One solution is to throttle the preview of the selected camera. By default, the throttle is set to 10 FPS.