### PR TITLE
Fix stale pointers crash in terrain virtual textures

### DIFF
--- a/WickedEngine/wiTerrain.cpp
+++ b/WickedEngine/wiTerrain.cpp
@@ -462,6 +462,7 @@ namespace wi::terrain
 			}
 		}
 		chunks.clear();
+		virtual_textures_in_use.clear();
 
 		if (chunkGroupEntity != INVALID_ENTITY)
 		{
@@ -640,6 +641,7 @@ namespace wi::terrain
 				}
 			}
 			chunks.clear();
+			virtual_textures_in_use.clear();
 			return;
 		}
 
@@ -868,6 +870,10 @@ namespace wi::terrain
 		if (virtual_texture_any)
 		{
 			UpdateVirtualTexturesCPU();
+		}
+		else
+		{
+			virtual_textures_in_use.clear();
 		}
 
 		const uint64_t required_chunk_buffer_size = sizeof(ShaderTerrainChunk) * (chunk_buffer_range * 2 + 1) * (chunk_buffer_range * 2 + 1);


### PR DESCRIPTION
There are scenarios where the terrain might end up with invalid entries in `virtual_textures_in_use`, for example, when changing materials to `BUTTON_NONE` in the editor and then restarting terrain generation.