### PR TITLE
Implement the application exit method

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -362,6 +362,21 @@ void Editor::Initialize()
 		}
 	}
 }
+
+void Editor::Exit()
+{
+	// Check all scenes for unsaved changes
+	for (int i = 0; i < (int)renderComponent.scenes.size(); ++i)
+	{
+		if (!renderComponent.CheckUnsavedChanges(i))
+		{
+			return;
+		}
+	}
+
+	Application::Exit();
+}
+
 void Editor::HotReload()
 {
 	if (IsScriptReplacement())
@@ -1295,15 +1310,7 @@ void EditorComponent::Load()
 	exitButton.SetColor(wi::Color(160, 50, 50, 180), wi::gui::WIDGETSTATE::IDLE);
 	exitButton.SetColor(wi::Color(200, 50, 50, 255), wi::gui::WIDGETSTATE::FOCUS);
 	exitButton.OnClick([this](wi::gui::EventArgs args) {
-		// Check all scenes for unsaved changes
-		for (int i = 0; i < (int)scenes.size(); ++i)
-		{
-			if (!CheckUnsavedChanges(i))
-			{
-				return;
-			}
-		}
-		wi::platform::Exit();
+		main->Exit();
 		});
 	topmenuWnd.AddWidget(&exitButton);
 

--- a/Editor/Editor.h
+++ b/Editor/Editor.h
@@ -256,6 +256,8 @@ public:
 
 	void HotReload();
 
+	void Exit() override;
+
 	~Editor() override
 	{
 		config.Commit();

--- a/Editor/main_Windows.cpp
+++ b/Editor/main_Windows.cpp
@@ -84,6 +84,9 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 			SetForegroundWindow(hWnd);
 		}
 		break;
+		case WM_CLOSE:
+			editor.Exit();
+			break;
 		case WM_DESTROY:
 			PostQuitMessage(0);
 			break;

--- a/WickedEngine/wiApplication.cpp
+++ b/WickedEngine/wiApplication.cpp
@@ -41,7 +41,6 @@ using namespace wi::graphics;
 
 namespace wi
 {
-
 	void Application::Initialize()
 	{
 		if (initialized)
@@ -707,6 +706,11 @@ namespace wi
 		wi::profiler::EndRange(range); // Compose
 	}
 
+	void Application::Exit()
+	{
+		wi::platform::Exit();
+	}
+
 	void Application::SetWindow(wi::platform::window_type window)
 	{
 		this->window = window;
@@ -880,7 +884,6 @@ namespace wi
 	{
 		return wi::helper::FileExists(rewriteable_startup_script_text);
 	}
-
 }
 
 

--- a/WickedEngine/wiApplication.h
+++ b/WickedEngine/wiApplication.h
@@ -76,17 +76,19 @@ namespace wi
 
 		// This is where the critical initializations happen (before any rendering or anything else)
 		virtual void Initialize();
-		// This is where application-wide updates get executed once per frame. 
+		// This is where application-wide updates get executed once per frame.
 		//  RenderPath::Update is also called from here for the active component
 		virtual void Update(float dt);
-		// This is where application-wide updates get executed in a fixed timestep based manner. 
+		// This is where application-wide updates get executed in a fixed timestep based manner.
 		//  RenderPath::FixedUpdate is also called from here for the active component
 		virtual void FixedUpdate();
-		// This is where application-wide rendering happens to offscreen buffers. 
+		// This is where application-wide rendering happens to offscreen buffers.
 		//  RenderPath::Render is also called from here for the active component
 		virtual void Render();
 		// This is where the application will render to the screen (backbuffer). It must render to the provided command list.
 		virtual void Compose(wi::graphics::CommandList cmd);
+		// This is where the application about to exit.
+		virtual void Exit();
 
 		// You need to call this before calling Run() or Initialize() if you want to render
 		void SetWindow(wi::platform::window_type);

--- a/WickedEngine/wiApplication_BindLua.cpp
+++ b/WickedEngine/wiApplication_BindLua.cpp
@@ -515,8 +515,13 @@ namespace wi::lua
 
 	int Application_BindLua::Exit(lua_State* L)
 	{
-		wi::platform::Exit();
-		return 0;
+		if (component)
+		{
+			component->Exit();
+			return 0;
+		}
+
+		return 1;
 	}
 	int Application_BindLua::IsFaded(lua_State* L)
 	{


### PR DESCRIPTION
Implement a single unified point for exiting the application, triggered when the application window is closed or the exit button is pressed, while also allowing optional resource cleanup or performing additional checks by overriding the method, for example, checking for unsaved changes in the editor.