### PR TITLE
Implement move to editor camera view for transforms

### DIFF
--- a/Editor/TransformWindow.h
+++ b/Editor/TransformWindow.h
@@ -11,6 +11,7 @@ public:
 	void SetEntity(wi::ecs::Entity entity);
 
 	wi::gui::Button clearButton;
+	wi::gui::Button moveToEditorCameraButton;
 
 	wi::gui::TextInputField txInput;
 	wi::gui::TextInputField tyInput;
@@ -19,12 +20,12 @@ public:
 	wi::gui::TextInputField rollInput;
 	wi::gui::TextInputField pitchInput;
 	wi::gui::TextInputField yawInput;
-					 
+
 	wi::gui::TextInputField rxInput;
 	wi::gui::TextInputField ryInput;
 	wi::gui::TextInputField rzInput;
 	wi::gui::TextInputField rwInput;
-					 
+
 	wi::gui::TextInputField sxInput;
 	wi::gui::TextInputField syInput;
 	wi::gui::TextInputField szInput;


### PR DESCRIPTION
Add a button to move transforms to the editor camera’s view. This is useful in some cases for quickly snapping entities to the desired position and rotation instead of using gizmos, as well as for perfectly aligning scene cameras with the desired view.