### PR TITLE
fix exit button on Windows, and in edge cases on Linux

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -363,8 +363,8 @@ void Editor::Initialize()
 	}
 }
 
-bool Editor::CanExit() {
-	return !renderComponent.save_in_progress;
+bool Editor::KeepRunning() {
+	return !exit_requested || renderComponent.save_in_progress;
 }
 
 void Editor::Exit()
@@ -377,8 +377,8 @@ void Editor::Exit()
 			return;
 		}
 	}
-
-	Application::Exit();
+	// main loop will need to quit for us
+	exit_requested = true;
 }
 
 void Editor::HotReload()
@@ -6181,8 +6181,7 @@ bool EditorComponent::CheckUnsavedChanges(int scene_index)
 		{
 			// Need to prompt for save location
 			SaveAs();
-			// After SaveAs, check if the scene was actually saved
-			return !editorscene.has_unsaved_changes;
+			return true;
 		}
 		else
 		{

--- a/Editor/Editor.h
+++ b/Editor/Editor.h
@@ -253,12 +253,13 @@ class Editor : public wi::Application
 public:
 	EditorComponent renderComponent;
 	wi::config::File config;
+	bool exit_requested = false;
 
 	void Initialize() override;
 
 	void HotReload();
 
-	bool CanExit();
+	bool KeepRunning();
 
 	void Exit() override;
 

--- a/Editor/main_SDL2.cpp
+++ b/Editor/main_SDL2.cpp
@@ -31,8 +31,7 @@ public:
 
 int sdl_loop()
 {
-    bool quit = false;
-    while (!quit || !editor.CanExit())
+    while (editor.KeepRunning())
     {
         editor.Run();
         SDL_Event event;
@@ -41,7 +40,6 @@ int sdl_loop()
             switch(event.type){
                 case SDL_QUIT:
                     editor.Exit();
-                    quit = true;
                     break;
                 case SDL_WINDOWEVENT:
                     switch (event.window.event) {

--- a/Editor/main_Windows.cpp
+++ b/Editor/main_Windows.cpp
@@ -8,8 +8,6 @@
 
 Editor editor;
 
-bool quit = false;
-
 int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
                      _In_opt_ HINSTANCE hPrevInstance,
                      _In_ LPWSTR    lpCmdLine,
@@ -88,7 +86,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		break;
 		case WM_CLOSE:
 			editor.Exit();
-			quit = true;
 			break;
 		case WM_DESTROY:
 			PostQuitMessage(0);
@@ -228,7 +225,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 
 	MSG msg = { 0 };
 
-	while (!quit || !editor.CanExit())
+	while (editor.KeepRunning())
 	{
 		if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
 			TranslateMessage(&msg);


### PR DESCRIPTION
After #1258, the exit button (not close) didn't work at all in Windows and on Linux it didn't actually cause the application to close if an untitled file had been saved.

Rewrite the logic to work both for close as well as exit.