### PR TITLE
Fix editor layout parameters

### DIFF
--- a/Editor/ComponentsWindow.cpp
+++ b/Editor/ComponentsWindow.cpp
@@ -584,6 +584,10 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 	{
 		size.x = editor->main->config.GetSection("layout").GetFloat("components.width");
 	}
+	if (editor->main->config.GetSection("layout").Has("components.height"))
+	{
+		size.y = editor->main->config.GetSection("layout").GetFloat("components.height");
+	}
 	SetSize(size);
 }
 void ComponentsWindow::UpdateData(float dt)
@@ -601,6 +605,7 @@ void ComponentsWindow::ResizeLayout()
 	const float width = GetWidgetAreaSize().x;
 	const float height = GetWidgetAreaSize().y;
 	editor->main->config.GetSection("layout").Set("components.width", GetSize().x);
+	editor->main->config.GetSection("layout").Set("components.height", GetSize().y);
 	editor->main->config.GetSection("layout").Set("entities.height", entityTree.GetSize().y);
 
 	// Entities:

--- a/Editor/GeneralWindow.cpp
+++ b/Editor/GeneralWindow.cpp
@@ -26,7 +26,16 @@ void GeneralWindow::Create(EditorComponent* _editor)
 	wi::gui::Window::Create("General", wi::gui::Window::WindowControls::CLOSE | wi::gui::Window::WindowControls::RESIZE_RIGHT);
 	SetText("General Options " ICON_GENERALOPTIONS);
 
-	SetSize(XMFLOAT2(300, 740));
+	XMFLOAT2 size = XMFLOAT2(300, 740);
+	if (editor->main->config.GetSection("layout").Has("options.width"))
+	{
+		size.x = editor->main->config.GetSection("layout").GetFloat("options.width");
+	}
+	if (editor->main->config.GetSection("layout").Has("options.height"))
+	{
+		size.y = editor->main->config.GetSection("layout").GetFloat("options.height");
+	}
+	SetSize(size);
 
 	masterVolumeSlider.Create(0, 2, 1, 100, "Master Volume: ");
 	if (editor->main->config.GetSection("options").Has("volume"))
@@ -1464,6 +1473,9 @@ void GeneralWindow::ReloadThemes()
 void GeneralWindow::ResizeLayout()
 {
 	wi::gui::Window::ResizeLayout();
+
+	editor->main->config.GetSection("layout").Set("options.width", GetSize().x);
+	editor->main->config.GetSection("layout").Set("options.height", GetSize().y);
 
 	layout.add_right(versionCheckBox, fpsCheckBox, otherinfoCheckBox);
 


### PR DESCRIPTION
Editor layout parameters, such as width and height, are not being saved\loaded properly.