### PR TITLE
Fix editor window captures input while inactive

### DIFF
--- a/Editor/main_Windows.cpp
+++ b/Editor/main_Windows.cpp
@@ -40,7 +40,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 			}
 			break;
 		case WM_INPUT:
-			wi::input::rawinput::ParseMessage((void*)lParam);
+			if (editor.is_window_active)
+			{
+				wi::input::rawinput::ParseMessage((void*)lParam);
+			}
 			break;
 		case WM_POINTERUPDATE:
 		{


### PR DESCRIPTION
There are cases where the editor window captures input while inactive, causing problems without being noticed.