### PR TITLE
linux: work around DirectXShaderCompiler bug

### DIFF
--- a/WickedEngine/wiShaderCompiler.cpp
+++ b/WickedEngine/wiShaderCompiler.cpp
@@ -489,6 +489,21 @@ namespace wi::shadercompiler
 			args_raw.push_back(x.c_str());
 		}
 
+#ifndef _WIN32
+		// work around https://github.com/microsoft/DirectXShaderCompiler/issues/7869
+		static std::mutex locale_mut;
+		static char* prev_locale;
+		// we need to use a mutex anyway, so no point in using atomic_int
+		static int scope = 0;
+
+		{
+			std::scoped_lock lock(locale_mut);
+			if (scope++ == 0) {
+				prev_locale = strdup(setlocale(LC_ALL, nullptr));
+				setlocale(LC_ALL, "en_US.UTF-8");
+			}
+		}
+#endif
 		ComPtr<IDxcResult> pResults;
 		hr = dxcCompiler->Compile(
 			&Source,						// Source buffer.
@@ -497,6 +512,15 @@ namespace wi::shadercompiler
 			&includehandler,		// User-provided interface to handle #include directives (optional).
 			IID_PPV_ARGS(&pResults)	// Compiler output status, buffer, and errors.
 		);
+#ifndef _WIN32
+		{
+			std::scoped_lock lock(locale_mut);
+			if (--scope == 0) {
+				setlocale(LC_ALL, prev_locale);
+				free(prev_locale);
+			}
+		}
+#endif
 		assert(SUCCEEDED(hr));
 
 		ComPtr<IDxcBlobUtf8> pErrors = nullptr;


### PR DESCRIPTION
microsoft/DirectXShaderCompiler#7869 prevents us from using address sanitizer if LC_ALL isn't set to en_US.UTF-8. So work around that by temporarily setting it before calling the compile method which calls the problematic MultiByteToWideChar method.