### PR TITLE
remove undefined behaviour

### DIFF
--- a/WickedEngine/wiFont.cpp
+++ b/WickedEngine/wiFont.cpp
@@ -417,7 +417,7 @@ namespace wi::font
 						&bitmap.yoff
 					);
 					bitmap.data.resize(bitmap.width * bitmap.height);
-					std::memcpy(bitmap.data.data(), data, bitmap.data.size());
+					if (data) std::memcpy(bitmap.data.data(), data, bitmap.data.size());
 					stbtt_FreeSDF(data, nullptr);
 				}
 				else
@@ -433,7 +433,7 @@ namespace wi::font
 						&bitmap.yoff
 					);
 					bitmap.data.resize(bitmap.width * bitmap.height);
-					std::memcpy(bitmap.data.data(), data, bitmap.data.size());
+					if (data) std::memcpy(bitmap.data.data(), data, bitmap.data.size());
 					stbtt_FreeBitmap(data, nullptr);
 				}
 


### PR DESCRIPTION
technically memcpy with nullptr src or dst is not safe, even if size is zero. *shrug*