### PR TITLE
Implement terrain props reloading

### DIFF
--- a/Editor/Editor.h
+++ b/Editor/Editor.h
@@ -229,6 +229,8 @@ public:
 
 	void FocusCameraOnSelected();
 
+	void ReloadTerrainProps();
+
 	wi::Localization default_localization;
 	wi::Localization current_localization;
 	void SetDefaultLocalization();

--- a/Editor/TerrainWindow.cpp
+++ b/Editor/TerrainWindow.cpp
@@ -332,6 +332,7 @@ PropWindow::PropWindow(wi::terrain::Terrain* terrain, wi::terrain::Prop* prop, w
 			wi::scene::Scene::EntitySerializeFlags::RECURSIVE | wi::scene::Scene::EntitySerializeFlags::KEEP_INTERNAL_ENTITY_REFERENCES
 		);
 		archive.WriteData(prop->data);
+		prop->source_entity = ent;
 
 		generation_callback();
 	});
@@ -492,6 +493,14 @@ PropsWindow::PropsWindow(EditorComponent* editor)
 	});
 	AddWidget(&addButton);
 
+	reloadButton.Create("Reload props");
+	reloadButton.SetSize(XMFLOAT2(100, 20));
+	reloadButton.SetTooltip("Reload all props from their source entities to update with latest component changes");
+	reloadButton.OnClick([editor](wi::gui::EventArgs args) {
+		editor->ReloadTerrainProps();
+	});
+	AddWidget(&reloadButton);
+
 	SetSize(XMFLOAT2(420, 332));
 }
 
@@ -580,6 +589,7 @@ void PropsWindow::ResizeLayout()
 	layout.margin_left = 150;
 
 	layout.add_fullwidth(addButton);
+	layout.add_fullwidth(reloadButton);
 
 	for(auto& window : windows)
 	{

--- a/Editor/TerrainWindow.h
+++ b/Editor/TerrainWindow.h
@@ -75,6 +75,7 @@ struct PropWindow : public wi::gui::Window
 struct PropsWindow : public wi::gui::Window
 {
 	wi::gui::Button addButton;
+	wi::gui::Button reloadButton;
 
 	PropsWindow(EditorComponent* editor);
 

--- a/WickedEngine/wiScene.h
+++ b/WickedEngine/wiScene.h
@@ -56,7 +56,7 @@ namespace wi::scene
 		wi::ecs::ComponentManager<ScriptComponent>& scripts = componentLibrary.Register<ScriptComponent>("wi::scene::Scene::scripts");
 		wi::ecs::ComponentManager<ExpressionComponent>& expressions = componentLibrary.Register<ExpressionComponent>("wi::scene::Scene::expressions");
 		wi::ecs::ComponentManager<HumanoidComponent>& humanoids = componentLibrary.Register<HumanoidComponent>("wi::scene::Scene::humanoids", 3); // version = 3
-		wi::ecs::ComponentManager<wi::terrain::Terrain>& terrains = componentLibrary.Register<wi::terrain::Terrain>("wi::scene::Scene::terrains", 5); // version = 5
+		wi::ecs::ComponentManager<wi::terrain::Terrain>& terrains = componentLibrary.Register<wi::terrain::Terrain>("wi::scene::Scene::terrains", 6); // version = 6
 		wi::ecs::ComponentManager<wi::Sprite>& sprites = componentLibrary.Register<wi::Sprite>("wi::scene::Scene::sprites", 2); // version = 2
 		wi::ecs::ComponentManager<wi::SpriteFont>& fonts = componentLibrary.Register<wi::SpriteFont>("wi::scene::Scene::fonts");
 		wi::ecs::ComponentManager<wi::VoxelGrid>& voxel_grids = componentLibrary.Register<wi::VoxelGrid>("wi::scene::Scene::voxel_grids");
@@ -361,7 +361,7 @@ namespace wi::scene
 		//	seri		: serializer state for entity component system
 		//	entity		: if archive is in write mode, this is the entity to serialize. If archive is in read mode, it should be INVALID_ENTITY
 		//	flags		: specify options as EntitySerializeFlags bits to control internal behaviour
-		// 
+		//
 		//	Returns either the new entity that was read, or the original entity that was written
 		wi::ecs::Entity Entity_Serialize(
 			wi::Archive& archive,
@@ -383,10 +383,10 @@ namespace wi::scene
 			const std::string& name
 		);
 		wi::ecs::Entity Entity_CreateLight(
-			const std::string& name, 
-			const XMFLOAT3& position = XMFLOAT3(0, 0, 0), 
-			const XMFLOAT3& color = XMFLOAT3(1, 1, 1), 
-			float intensity = 1, 
+			const std::string& name,
+			const XMFLOAT3& position = XMFLOAT3(0, 0, 0),
+			const XMFLOAT3& color = XMFLOAT3(1, 1, 1),
+			float intensity = 1,
 			float range = 10,
 			LightComponent::LightType type = LightComponent::POINT,
 			float outerConeAngle = XM_PIDIV4,
@@ -681,5 +681,5 @@ namespace wi::scene
 
 template<>
 struct enable_bitmask_operators<wi::scene::Scene::EntitySerializeFlags> {
-	static const bool enable = true;
+	static constexpr bool enable = true;
 };

--- a/WickedEngine/wiTerrain.cpp
+++ b/WickedEngine/wiTerrain.cpp
@@ -2224,6 +2224,10 @@ namespace wi::terrain
 				archive >> prop.max_size;
 				archive >> prop.min_y_offset;
 				archive >> prop.max_y_offset;
+				if (terrain_version >= 6)
+				{
+					SerializeEntity(archive, prop.source_entity, seri);
+				}
 			}
 
 			archive >> count;
@@ -2379,6 +2383,7 @@ namespace wi::terrain
 				archive << prop.max_size;
 				archive << prop.min_y_offset;
 				archive << prop.max_y_offset;
+				SerializeEntity(archive, prop.source_entity, seri);
 			}
 
 			archive << chunks.size();

--- a/WickedEngine/wiTerrain.h
+++ b/WickedEngine/wiTerrain.h
@@ -246,6 +246,7 @@ namespace wi::terrain
 	struct Prop
 	{
 		wi::vector<uint8_t> data; // serialized component data storage
+		wi::ecs::Entity source_entity = wi::ecs::INVALID_ENTITY; // the original entity that this prop was serialized from
 		int min_count_per_chunk = 0; // a chunk will try to generate min this many props of this type
 		int max_count_per_chunk = 10; // a chunk will try to generate max this many props of this type
 		int region = 0; // region selection in range [0,3] (0: base/grass, 1: slopes, 2: low altitude (bottom level-0), 3: high altitude (0-top level))


### PR DESCRIPTION
When adding props to the terrain, store the source entity of each prop, and allow reloading of changes to its parameters and components on demand, either by clicking a button in the props section or by pressing Ctrl+R in the editor viewport.