### PR TITLE
Fix editor's input system flaw

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -2435,7 +2435,7 @@ void EditorComponent::Update(float dt)
 	main->infoDisplay.colorgrading_helper = false;
 
 	// Control operations...
-	if (!GetGUI().IsTyping() && (wi::input::Down(wi::input::KEYBOARD_BUTTON_LCONTROL) || wi::input::Down(wi::input::KEYBOARD_BUTTON_RCONTROL)))
+	if (!GetGUI().IsTyping() && !GetGUI().HasFocus() && (wi::input::Down(wi::input::KEYBOARD_BUTTON_LCONTROL) || wi::input::Down(wi::input::KEYBOARD_BUTTON_RCONTROL)))
 	{
 		bool isCtrlDown = wi::input::Down(wi::input::KEYBOARD_BUTTON_LCONTROL) || wi::input::Down(wi::input::KEYBOARD_BUTTON_RCONTROL);
 		bool isShiftDown = wi::input::Down(wi::input::KEYBOARD_BUTTON_LSHIFT) || wi::input::Down(wi::input::KEYBOARD_BUTTON_RSHIFT);


### PR DESCRIPTION
Fix input system flaw where keyboard shortcuts (e.g., Ctrl+A) pressed while cursor was over GUI panels would execute delayed when cursor moved back to viewport. 