### PR TITLE
Implement distance-based culling for the physics bodies debug visualization

### DIFF
--- a/Editor/GeneralWindow.cpp
+++ b/Editor/GeneralWindow.cpp
@@ -59,6 +59,21 @@ void GeneralWindow::Create(EditorComponent* _editor)
 	physicsDebugCheckBox.SetCheck(wi::physics::IsDebugDrawEnabled());
 	AddWidget(&physicsDebugCheckBox);
 
+	physicsDebugMaxDistanceSlider.Create(0.0f, 2000.0f, 500.0f, 100, "Physics draw distance: ");
+	physicsDebugMaxDistanceSlider.SetTooltip("Maximum distance to draw physics debug shapes");
+	physicsDebugMaxDistanceSlider.SetSize(XMFLOAT2(100, 18));
+	if (editor->main->config.GetSection("options").Has("physics_max_draw_distance"))
+	{
+		wi::physics::SetDebugDrawMaxDistance(editor->main->config.GetSection("options").GetFloat("physics_max_draw_distance"));
+		physicsDebugMaxDistanceSlider.SetValue(wi::physics::GetDebugDrawMaxDistance());
+	}
+	physicsDebugMaxDistanceSlider.OnSlide([=](wi::gui::EventArgs args) {
+		wi::physics::SetDebugDrawMaxDistance(args.fValue);
+		editor->main->config.GetSection("options").Set("physics_max_draw_distance", args.fValue);
+		editor->main->config.Commit();
+	});
+	AddWidget(&physicsDebugMaxDistanceSlider);
+
 	nameDebugCheckBox.Create("Name visualizer: ");
 	nameDebugCheckBox.SetTooltip("Visualize the entity names in the scene");
 	AddWidget(&nameDebugCheckBox);
@@ -1499,6 +1514,7 @@ void GeneralWindow::ResizeLayout()
 
 	layout.add(wireFrameComboBox);
 	layout.add_right(physicsDebugCheckBox);
+	layout.add(physicsDebugMaxDistanceSlider);
 	layout.add_right(nameDebugCheckBox);
 	layout.add_right(gridHelperCheckBox);
 	layout.add_right(aabbDebugCheckBox);

--- a/Editor/GeneralWindow.h
+++ b/Editor/GeneralWindow.h
@@ -19,6 +19,7 @@ public:
 	wi::gui::ComboBox languageCombo;
 
 	wi::gui::CheckBox physicsDebugCheckBox;
+	wi::gui::Slider physicsDebugMaxDistanceSlider;
 	wi::gui::CheckBox nameDebugCheckBox;
 	wi::gui::CheckBox gridHelperCheckBox;
 	wi::gui::CheckBox aabbDebugCheckBox;

--- a/WickedEngine/wiPhysics.h
+++ b/WickedEngine/wiPhysics.h
@@ -34,6 +34,10 @@ namespace wi::physics
 	void SetConstraintDebugSize(float value);
 	float GetConstraintDebugSize();
 
+	// Set maximum distance for debug drawing physics shapes
+	void SetDebugDrawMaxDistance(float value);
+	float GetDebugDrawMaxDistance();
+
 	// Set the accuracy of the simulation
 	//	This value corresponds to maximum simulation step count
 	//	Higher values will be slower but more accurate


### PR DESCRIPTION
Visualizing complex scenes that use large numbers of physics bodies can significantly impact runtime performance and may cause the engine to crash. Use distance-based culling to mitigate this issue.