### PR TITLE
Implement placing in front of the camera option

### DIFF
--- a/Editor/Editor.h
+++ b/Editor/Editor.h
@@ -231,6 +231,8 @@ public:
 
 	void ReloadTerrainProps();
 
+	XMFLOAT3 GetPositionInFrontOfCamera() const;
+
 	wi::Localization default_localization;
 	wi::Localization current_localization;
 	void SetDefaultLocalization();

--- a/Editor/GeneralWindow.cpp
+++ b/Editor/GeneralWindow.cpp
@@ -396,6 +396,18 @@ void GeneralWindow::Create(EditorComponent* _editor)
 	});
 	AddWidget(&localizationButton);
 
+	placeInFrontOfCameraCheckBox.Create("Place entities in front of camera: ");
+	placeInFrontOfCameraCheckBox.SetTooltip("When enabled, newly created entities and imported models will be positioned in front of the editor camera instead of at the origin.");
+	if (editor->main->config.GetSection("options").Has("place_entities_in_front_of_camera"))
+	{
+		placeInFrontOfCameraCheckBox.SetCheck(editor->main->config.GetSection("options").GetBool("place_entities_in_front_of_camera"));
+	}
+	placeInFrontOfCameraCheckBox.OnClick([this](wi::gui::EventArgs args) {
+		editor->main->config.GetSection("options").Set("place_entities_in_front_of_camera", args.bValue);
+		editor->main->config.Commit();
+	});
+	AddWidget(&placeInFrontOfCameraCheckBox);
+
 	wireFrameComboBox.Create("Render wireframe: ");
 	wireFrameComboBox.SetTooltip("Choose wireframe rendering mode:\nDisabled: Normal rendering\nWireframe Only: Replace geometry with wireframe\nWireframe Overlay: Show wireframe on top of geometry");
 	wireFrameComboBox.AddItem("Disabled", wi::renderer::WIREFRAME_DISABLED);
@@ -1511,6 +1523,8 @@ void GeneralWindow::ResizeLayout()
 	layout.add(languageCombo);
 
 	layout.add_fullwidth(localizationButton);
+
+	layout.add_right(placeInFrontOfCameraCheckBox);
 
 	layout.add(wireFrameComboBox);
 	layout.add_right(physicsDebugCheckBox);

--- a/Editor/GeneralWindow.h
+++ b/Editor/GeneralWindow.h
@@ -27,6 +27,7 @@ public:
 	wi::gui::CheckBox debugEmittersCheckBox;
 	wi::gui::CheckBox debugForceFieldsCheckBox;
 	wi::gui::CheckBox debugRaytraceBVHCheckBox;
+	wi::gui::CheckBox placeInFrontOfCameraCheckBox;
 	wi::gui::ComboBox wireFrameComboBox;
 	wi::gui::CheckBox envProbesCheckBox;
 	wi::gui::CheckBox cameraVisCheckBox;


### PR DESCRIPTION
Newly imported models and some entities are always placed at the origin. Implement an option to place newly added entities in front of the camera instead, except for directional lights and cameras.