### PR TITLE
Fixing DPI Scaling on KDE Wayland Linux when display scale isn't 100%

### DIFF
--- a/WickedEngine/wiPlatform.h
+++ b/WickedEngine/wiPlatform.h
@@ -88,7 +88,14 @@ namespace wi::platform
 		int window_width, window_height;
 		SDL_GetWindowSize(window, &window_width, &window_height);
 		SDL_Vulkan_GetDrawableSize(window, &dest->width, &dest->height);
-		dest->dpi = ((float)dest->width / (float)window_width) * 96.f;
+
+		float dpi;
+		int window_index = SDL_GetWindowDisplayIndex(window);
+		if (SDL_GetDisplayDPI(window_index, &dpi, nullptr, nullptr) != 0)
+		{
+			dpi = 96.f;
+		}
+		dest->dpi = ((float)dest->width / (float)window_width) * dpi;
 #endif // PLATFORM_LINUX
 	}
 }


### PR DESCRIPTION
Hi, this is a small fix for DPI scaling on linux.

I've downloaded the engine today, and quickly needed to track down the DPI settings, because the text was unreadably small on my monitor. I did my best to follow conding standards, but if there is something wrong, I'll do my best to fix it. 

One thing that comes to mind is whether the DPI should be set to the default 96 on SDL error, or whether there should be an exception thrown in that case, I opted for just defaulting to the previous value for the sake of not throwing random exceptions around if things break, since that seems to be the standard.

**Environment**
OS: Linux Fedora 43
DE: KDE Wayland (I'm assuming the same issue will be present on other desktop environments)
Compiler: Clang 21.1.5
Monitors: Kamvas 16 gen 3 (150% scale) & Framework13 2880x1920 screen (200% scale)

**How to repro the issue**
1. Increase the scaling of a monitor in KDE settings (I'm assuming the exact same repro applies for GNOME)
2. Start the editor
3. Notice the editor UI doesn't respect the DPI scale

**Tested edge cases**
Changing the scale and confirming that the DPI was getting updated accordingly.
Changing the scale while the editor was running.
Dragging the application window between 2 monitors with different DPI.