### PR TITLE
Implement right-click open in new scene for content window

### DIFF
--- a/Editor/ContentBrowserWindow.cpp
+++ b/Editor/ContentBrowserWindow.cpp
@@ -404,6 +404,13 @@ void ContentBrowserWindow::AddItem(const std::string& filename, const std::strin
 			});
 		this->SetVisible(false);
 		});
+	button.OnRightClick([this, filename](wi::gui::EventArgs args) {
+		wi::eventhandler::Subscribe_Once(wi::eventhandler::EVENT_THREAD_SAFE_POINT, [=](uint64_t userdata) {
+			editor->NewScene();
+			editor->Open(filename);
+			});
+		this->SetVisible(false);
+		});
 	button.font_description.params.h_align = wi::font::WIFALIGN_CENTER;
 	button.font_description.params.v_align = wi::font::WIFALIGN_TOP;
 	button.font.params.size = 42;
@@ -438,4 +445,5 @@ void ContentBrowserWindow::AddItem(const std::string& filename, const std::strin
 			}
 		}
 	}
+	button.SetTooltip(button.GetTooltip() + "\n\nLeft-click: Merge into current scene\nRight-click: Open in new scene tab");
 }

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -829,6 +829,7 @@ namespace wi::gui
 		SetName(name);
 		SetText(name);
 		OnClick([](EventArgs args) {});
+		OnRightClick([](EventArgs args) {});
 		OnDragStart([](EventArgs args) {});
 		OnDrag([](EventArgs args) {});
 		OnDragEnd([](EventArgs args) {});
@@ -881,7 +882,8 @@ namespace wi::gui
 				Deactivate();
 			}
 
-			bool clicked = false;
+			bool leftButtonClicked = false;
+			bool rightButtonClicked = false;
 			// hover the button
 			if (pointerHitbox.intersects(hitBox))
 			{
@@ -896,7 +898,16 @@ namespace wi::gui
 				if (state == FOCUS)
 				{
 					// activate
-					clicked = true;
+					leftButtonClicked = true;
+				}
+			}
+
+			if (wi::input::Press(wi::input::MOUSE_BUTTON_RIGHT))
+			{
+				if (state == FOCUS)
+				{
+					// right-click
+					rightButtonClicked = true;
 				}
 			}
 
@@ -918,13 +929,21 @@ namespace wi::gui
 				}
 			}
 
-			if (clicked)
+			if (leftButtonClicked)
 			{
 				EventArgs args;
 				args.clickPos = pointerHitbox.pos;
 				dragStart = args.clickPos;
 				args.startPos = dragStart;
 				onDragStart(args);
+				Activate();
+			}
+
+			if (rightButtonClicked)
+			{
+				EventArgs args;
+				args.clickPos = pointerHitbox.pos;
+				onRightClick(args);
 				Activate();
 			}
 
@@ -1050,6 +1069,10 @@ namespace wi::gui
 	void Button::OnClick(std::function<void(EventArgs args)> func)
 	{
 		onClick = func;
+	}
+	void Button::OnRightClick(std::function<void(EventArgs args)> func)
+	{
+		onRightClick = func;
 	}
 	void Button::OnDragStart(std::function<void(EventArgs args)> func)
 	{

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -386,6 +386,7 @@ namespace wi::gui
 	{
 	protected:
 		std::function<void(EventArgs args)> onClick;
+		std::function<void(EventArgs args)> onRightClick;
 		std::function<void(EventArgs args)> onDragStart;
 		std::function<void(EventArgs args)> onDrag;
 		std::function<void(EventArgs args)> onDragEnd;
@@ -401,6 +402,7 @@ namespace wi::gui
 		const char* GetWidgetTypeName() const override { return "Button"; }
 
 		void OnClick(std::function<void(EventArgs args)> func);
+		void OnRightClick(std::function<void(EventArgs args)> func);
 		void OnDragStart(std::function<void(EventArgs args)> func);
 		void OnDrag(std::function<void(EventArgs args)> func);
 		void OnDragEnd(std::function<void(EventArgs args)> func);


### PR DESCRIPTION
Enable right-clicking in the content window to create a new scene and open files in a new tab, and add a tooltip to clarify the click behavior.