### PR TITLE
Fix debug environment probe spheres drifting away

### DIFF
--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -8220,6 +8220,9 @@ void DrawDebugWorld(
 	if (debugEnvProbes)
 	{
 		device->EventBegin("Debug EnvProbes", cmd);
+
+		BindCameraCB(camera, camera, camera, cmd);
+
 		// Envmap spheres:
 
 		device->BindPipelineState(&PSO_debug[DEBUGRENDERING_ENVPROBE], cmd);


### PR DESCRIPTION
Fix environment-probe spheres drifting away when the debug visualizer is enabled by binding the camera constant buffer before drawing the environment probes.