### PR TITLE
make bind_ptrs constant

### DIFF
--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -7619,8 +7619,8 @@ using namespace vulkan_internal;
 			out_bind.memory_binds.reserve(in_command.num_resource_regions);
 			out_bind.image_memory_binds.reserve(in_command.num_resource_regions);
 
-			const VkSparseMemoryBind* memory_bind_ptr = out_bind.memory_binds.data();
-			const VkSparseImageMemoryBind* image_memory_bind_ptr = out_bind.image_memory_binds.data();
+			const VkSparseMemoryBind* const memory_bind_ptr = out_bind.memory_binds.data();
+			const VkSparseImageMemoryBind* const image_memory_bind_ptr = out_bind.image_memory_binds.data();
 
 			if (in_command.sparse_resource->IsBuffer())
 			{
@@ -7631,7 +7631,6 @@ using namespace vulkan_internal;
 				info.buffer = internal_sparse->resource;
 				info.pBinds = memory_bind_ptr;
 				info.bindCount = in_command.num_resource_regions;
-				memory_bind_ptr += in_command.num_resource_regions;
 
 				for (uint32_t j = 0; j < in_command.num_resource_regions; ++j)
 				{
@@ -7705,7 +7704,6 @@ using namespace vulkan_internal;
 					if (is_miptail)
 					{
 						opaque_info.bindCount++;
-						memory_bind_ptr++;
 
 						const TileRangeFlags& in_flags = in_command.range_flags[j];
 						uint32_t in_offset = in_command.range_start_offsets[j];
@@ -7727,7 +7725,6 @@ using namespace vulkan_internal;
 					else
 					{
 						info.bindCount++;
-						image_memory_bind_ptr++;
 
 						const TileRangeFlags& in_flags = in_command.range_flags[j];
 						uint32_t in_offset = in_command.range_start_offsets[j];


### PR DESCRIPTION
this one was found while playing with clang-tidy. The ptr values are incremented, but never used afterwards; it doesn't look like a bug but just some leftover from a previous iteration of the code.

Feel free to close if there's something I'm missing.