### PR TITLE
handle self-assign

### DIFF
--- a/WickedEngine/wiAllocator.h
+++ b/WickedEngine/wiAllocator.h
@@ -546,6 +546,7 @@ namespace wi::allocator
 			}
 			Allocation& operator=(const Allocation& other)
 			{
+				if (&other == this) return *this;
 				Reset();
 				allocator = other.allocator;
 				internal_state = other.internal_state;

--- a/WickedEngine/wiFunction.h
+++ b/WickedEngine/wiFunction.h
@@ -86,6 +86,7 @@ namespace wi
 
 		function& operator=(const function& other)
 		{
+			if (&other == this) return *this;
 			destroy();
 			if (other.ptr)
 			{


### PR DESCRIPTION
found by clang-tidy. A self-assign would destroy `Allocation` and `function`. The only other instance is in wiVector, where a self-assignment would just result in unnecessary work, and since a self-assign is unlikely to happen, I decided to ignore it there.

I don't think a self-assign is actually happening anywhere in the code base, but if this happens, it would cause hard to track down bugs, I think the check is worth it.

NB: c++20 has the `unlikely` attribute, which would be a nice to have in cases like this.