### PR TITLE
use const& and std::move where possible to avoid copying

### DIFF
--- a/WickedEngine/wiBacklog.cpp
+++ b/WickedEngine/wiBacklog.cpp
@@ -58,7 +58,7 @@ namespace wi::backlog
 			_forEachLogEntry_unsafe([&](auto&& entry) {retval += entry.text;});
 			return retval;
 		}
-		inline void _forEachLogEntry_unsafe(std::function<void(const LogEntry&)> cb)
+		inline void _forEachLogEntry_unsafe(const std::function<void(const LogEntry&)>& cb)
 		{
 			for (auto& entry : entries)
 			{
@@ -136,7 +136,7 @@ namespace wi::backlog
 					created = true;
 					inputField.Create("");
 					inputField.SetCancelInputEnabled(false);
-					inputField.OnInputAccepted([](wi::gui::EventArgs args) {
+					inputField.OnInputAccepted([](const wi::gui::EventArgs& args) {
 						historyPos = 0;
 						post(args.sValue);
 						LogEntry entry;
@@ -169,7 +169,7 @@ namespace wi::backlog
 					inputField.font.params.shadowColor = wi::Color::Transparent();
 
 					toggleButton.Create("V");
-					toggleButton.OnClick([](wi::gui::EventArgs args) {
+					toggleButton.OnClick([](const wi::gui::EventArgs& args) {
 						Toggle();
 						});
 					toggleButton.SetColor(theme_color_idle, wi::gui::IDLE);
@@ -352,7 +352,7 @@ namespace wi::backlog
 		return internal_state.getText();
 	}
 	// You generally don't want to use this. See notes in header
-	void _forEachLogEntry_unsafe(std::function<void(const LogEntry&)> cb)
+	void _forEachLogEntry_unsafe(const std::function<void(const LogEntry&)>& cb)
 	{
 		internal_state._forEachLogEntry_unsafe(cb);
 	}

--- a/WickedEngine/wiBacklog.h
+++ b/WickedEngine/wiBacklog.h
@@ -78,5 +78,5 @@ namespace wi::backlog
 	// It's also not considered part of the API and can change at any time.
 	//
 	// Use getText() instead, unless absolutely necessary.
-	void _forEachLogEntry_unsafe(std::function<void(const LogEntry&)> cb);
+	void _forEachLogEntry_unsafe(const std::function<void(const LogEntry&)>& cb);
 };

--- a/WickedEngine/wiEventHandler.cpp
+++ b/WickedEngine/wiEventHandler.cpp
@@ -4,6 +4,7 @@
 
 #include <list>
 #include <mutex>
+#include <utility>
 
 namespace wi::eventhandler
 {
@@ -40,7 +41,7 @@ namespace wi::eventhandler
 		handle.internal_state = eventinternal;
 		eventinternal->manager = manager;
 		eventinternal->id = id;
-		eventinternal->callback = callback;
+		eventinternal->callback = std::move(callback);
 
 		std::scoped_lock lck(manager->locker);
 		manager->subscribers[id].push_back(&eventinternal->callback);
@@ -48,7 +49,7 @@ namespace wi::eventhandler
 		return handle;
 	}
 
-	void Subscribe_Once(int id, std::function<void(uint64_t)> callback)
+	void Subscribe_Once(int id, const std::function<void(uint64_t)>& callback)
 	{
 		std::scoped_lock lck(manager->locker);
 		manager->subscribers_once[id].push_back(callback);

--- a/WickedEngine/wiEventHandler.h
+++ b/WickedEngine/wiEventHandler.h
@@ -17,7 +17,7 @@ namespace wi::eventhandler
 	};
 
 	Handle Subscribe(int id, std::function<void(uint64_t)> callback);
-	void Subscribe_Once(int id, std::function<void(uint64_t)> callback);
+	void Subscribe_Once(int id, const std::function<void(uint64_t)>& callback);
 	void FireEvent(int id, uint64_t userdata);
 
 

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -13,6 +13,7 @@
 
 #include <sstream>
 #include <iomanip> // setprecision
+#include <utility>
 
 using namespace wi::graphics;
 using namespace wi::primitive;
@@ -219,7 +220,7 @@ namespace wi::gui
 			widget->SetColor(color, id);
 		}
 	}
-	void GUI::SetImage(wi::Resource resource, int id)
+	void GUI::SetImage(const wi::Resource& resource, int id)
 	{
 		for (auto& widget : widgets)
 		{
@@ -828,11 +829,11 @@ namespace wi::gui
 	{
 		SetName(name);
 		SetText(name);
-		OnClick([](EventArgs args) {});
-		OnRightClick([](EventArgs args) {});
-		OnDragStart([](EventArgs args) {});
-		OnDrag([](EventArgs args) {});
-		OnDragEnd([](EventArgs args) {});
+		OnClick([](const EventArgs& args) {});
+		OnRightClick([](const EventArgs& args) {});
+		OnDragStart([](const EventArgs& args) {});
+		OnDrag([](const EventArgs& args) {});
+		OnDragEnd([](const EventArgs& args) {});
 		SetSize(XMFLOAT2(100, 20));
 
 		font.params.h_align = wi::font::WIFALIGN_CENTER;
@@ -1066,25 +1067,25 @@ namespace wi::gui
 		sprites[state].Draw(cmd);
 		font.Draw(cmd);
 	}
-	void Button::OnClick(std::function<void(EventArgs args)> func)
+	void Button::OnClick(std::function<void(const EventArgs& args)> func)
 	{
-		onClick = func;
+		onClick = std::move(func);
 	}
-	void Button::OnRightClick(std::function<void(EventArgs args)> func)
+	void Button::OnRightClick(std::function<void(const EventArgs& args)> func)
 	{
-		onRightClick = func;
+		onRightClick = std::move(func);
 	}
-	void Button::OnDragStart(std::function<void(EventArgs args)> func)
+	void Button::OnDragStart(std::function<void(const EventArgs& args)> func)
 	{
-		onDragStart = func;
+		onDragStart = std::move(func);
 	}
-	void Button::OnDrag(std::function<void(EventArgs args)> func)
+	void Button::OnDrag(std::function<void(const EventArgs& args)> func)
 	{
-		onDrag = func;
+		onDrag = std::move(func);
 	}
-	void Button::OnDragEnd(std::function<void(EventArgs args)> func)
+	void Button::OnDragEnd(std::function<void(const EventArgs& args)> func)
 	{
-		onDragEnd = func;
+		onDragEnd = std::move(func);
 	}
 	void Button::SetTheme(const Theme& theme, int id)
 	{
@@ -1594,7 +1595,7 @@ namespace wi::gui
 	{
 		SetName(name);
 		SetText(name);
-		OnInputAccepted([](EventArgs args) {});
+		OnInputAccepted([](const EventArgs& args) {});
 		SetSize(XMFLOAT2(100, 20));
 
 		font.params.v_align = wi::font::WIFALIGN_CENTER;
@@ -1940,13 +1941,13 @@ namespace wi::gui
 			font.Draw(cmd);
 		}
 	}
-	void TextInputField::OnInputAccepted(std::function<void(EventArgs args)> func)
+	void TextInputField::OnInputAccepted(std::function<void(const EventArgs& args)> func)
 	{
-		onInputAccepted = func;
+		onInputAccepted = std::move(func);
 	}
-	void TextInputField::OnInput(std::function<void(EventArgs args)> func)
+	void TextInputField::OnInput(std::function<void(const EventArgs& args)> func)
 	{
-		onInput = func;
+		onInput = std::move(func);
 	}
 	void TextInputField::AddInput(const wchar_t inputChar)
 	{
@@ -1985,7 +1986,7 @@ namespace wi::gui
 				{
 					// Copy:
 					caret_pos = caret_pos_prev;
-					std::wstring text = font_input.GetText();
+					const std::wstring& text = font_input.GetText();
 					int start = std::min(caret_begin, caret_pos);
 					int end = std::max(caret_begin, caret_pos);
 					std::wstring clipboard = std::wstring(text.c_str() + start, text.c_str() + end);
@@ -1996,7 +1997,7 @@ namespace wi::gui
 				{
 					// Cut:
 					caret_pos = caret_pos_prev;
-					std::wstring text = font_input.GetText();
+					const std::wstring& text = font_input.GetText();
 					int start = std::min(caret_begin, caret_pos);
 					int end = std::max(caret_begin, caret_pos);
 					std::wstring clipboard = std::wstring(text.c_str() + start, text.c_str() + end);
@@ -2098,7 +2099,7 @@ namespace wi::gui
 
 		SetName(name);
 		SetText(name);
-		OnSlide([](EventArgs args) {});
+		OnSlide([](const EventArgs& args) {});
 		SetSize(XMFLOAT2(200, 20));
 
 		valueInputField.Create(name + "_endInputField");
@@ -2106,26 +2107,20 @@ namespace wi::gui
 		valueInputField.SetShadowRadius(0);
 		valueInputField.SetTooltip("Enter number to modify value even outside slider limits. Other inputs:\n - reset : reset slider to initial state.\n - FLT_MAX : float max value\n - -FLT_MAX : negative float max value.");
 		valueInputField.SetValue(end);
-		valueInputField.OnInputAccepted([this, start, end, defaultValue](EventArgs args) {
+		valueInputField.OnInputAccepted([this, start, end, defaultValue](const EventArgs& args) {
 			if (args.sValue.compare("reset") == 0)
 			{
 				this->value = defaultValue;
 				this->start = start;
 				this->end = end;
-				args.fValue = this->value;
-				args.iValue = (int)this->value;
 			}
 			else if (args.sValue.compare("FLT_MAX") == 0)
 			{
 				this->value = FLT_MAX;
-				args.fValue = this->value;
-				args.iValue = (int)this->value;
 			}
 			else if (args.sValue.compare("-FLT_MAX") == 0)
 			{
 				this->value = -FLT_MAX;
-				args.fValue = this->value;
-				args.iValue = (int)this->value;
 			}
 			else
 			{
@@ -2343,9 +2338,9 @@ namespace wi::gui
 		Widget::RenderTooltip(canvas, cmd);
 		valueInputField.RenderTooltip(canvas, cmd);
 	}
-	void Slider::OnSlide(std::function<void(EventArgs args)> func)
+	void Slider::OnSlide(std::function<void(const EventArgs& args)> func)
 	{
-		onSlide = func;
+		onSlide = std::move(func);
 	}
 	void Slider::SetColor(wi::Color color, int id)
 	{
@@ -2390,7 +2385,7 @@ namespace wi::gui
 	{
 		SetName(name);
 		SetText(name);
-		OnClick([](EventArgs args) {});
+		OnClick([](const EventArgs& args) {});
 		SetSize(XMFLOAT2(20, 20));
 
 		font.params.h_align = wi::font::WIFALIGN_RIGHT;
@@ -2573,9 +2568,9 @@ namespace wi::gui
 		}
 
 	}
-	void CheckBox::OnClick(std::function<void(EventArgs args)> func)
+	void CheckBox::OnClick(std::function<void(const EventArgs& args)> func)
 	{
-		onClick = func;
+		onClick = std::move(func);
 	}
 	void CheckBox::SetCheck(bool value)
 	{
@@ -2608,7 +2603,7 @@ namespace wi::gui
 	{
 		SetName(name);
 		SetText(name);
-		OnSelect([](EventArgs args) {});
+		OnSelect([](const EventArgs& args) {});
 		SetSize(XMFLOAT2(100, 20));
 
 		font.params.h_align = wi::font::WIFALIGN_RIGHT;
@@ -3150,9 +3145,9 @@ namespace wi::gui
 			}
 		}
 	}
-	void ComboBox::OnSelect(std::function<void(EventArgs args)> func)
+	void ComboBox::OnSelect(std::function<void(const EventArgs& args)> func)
 	{
-		onSelect = func;
+		onSelect = std::move(func);
 	}
 	void ComboBox::AddItem(const std::string& name, uint64_t userdata)
 	{
@@ -3360,7 +3355,7 @@ namespace wi::gui
 				moveDragger.SetShadowRadius(0);
 				moveDragger.SetText(name);
 				moveDragger.font.params.h_align = wi::font::WIFALIGN_LEFT;
-				moveDragger.OnDrag([this](EventArgs args) {
+				moveDragger.OnDrag([this](const EventArgs& args) {
 					auto saved_parent = this->parent;
 					this->Detach();
 					this->Translate(XMFLOAT3(args.deltaPos.x, args.deltaPos.y, 0));
@@ -3377,11 +3372,11 @@ namespace wi::gui
 				closeButton.SetLocalizationEnabled(LocalizationEnabled::None);
 				closeButton.SetShadowRadius(0);
 				closeButton.SetText("x");
-				closeButton.OnClick([this](EventArgs args) {
+				closeButton.OnClick([this](const EventArgs& args) {
 					this->SetVisible(false);
 					if (onClose)
 					{
-						onClose(args);
+						onClose(std::move(args));
 					}
 					});
 				closeButton.SetTooltip("Close window");
@@ -3396,7 +3391,7 @@ namespace wi::gui
 				collapseButton.SetLocalizationEnabled(LocalizationEnabled::None);
 				collapseButton.SetShadowRadius(0);
 				collapseButton.SetText("-");
-				collapseButton.OnClick([this](EventArgs args) {
+				collapseButton.OnClick([this](const EventArgs& args) {
 					this->SetMinimized(!this->IsMinimized());
 					if (onCollapse)
 					{
@@ -4328,17 +4323,17 @@ namespace wi::gui
 		}
 		return size;
 	}
-	void Window::OnClose(std::function<void(EventArgs args)> func)
+	void Window::OnClose(std::function<void(const EventArgs& args)> func)
 	{
-		onClose = func;
+		onClose = std::move(func);
 	}
-	void Window::OnCollapse(std::function<void(EventArgs args)> func)
+	void Window::OnCollapse(std::function<void(const EventArgs& args)> func)
 	{
-		onCollapse = func;
+		onCollapse = std::move(func);
 	}
 	void Window::OnResize(std::function<void()> func)
 	{
-		onResize = func;
+		onResize = std::move(func);
 	}
 	void Window::SetColor(wi::Color color, int id)
 	{
@@ -4632,7 +4627,7 @@ namespace wi::gui
 		text_R.SetText("");
 		text_R.SetTooltip("Enter value for RED channel (0-255)");
 		text_R.SetDescription("R: ");
-		text_R.OnInputAccepted([this](EventArgs args) {
+		text_R.OnInputAccepted([this](const EventArgs& args) {
 			wi::Color color = GetPickColor();
 			color.setR((uint8_t)args.iValue);
 			SetPickColor(color);
@@ -4647,7 +4642,7 @@ namespace wi::gui
 		text_G.SetText("");
 		text_G.SetTooltip("Enter value for GREEN channel (0-255)");
 		text_G.SetDescription("G: ");
-		text_G.OnInputAccepted([this](EventArgs args) {
+		text_G.OnInputAccepted([this](const EventArgs& args) {
 			wi::Color color = GetPickColor();
 			color.setG((uint8_t)args.iValue);
 			SetPickColor(color);
@@ -4662,7 +4657,7 @@ namespace wi::gui
 		text_B.SetText("");
 		text_B.SetTooltip("Enter value for BLUE channel (0-255)");
 		text_B.SetDescription("B: ");
-		text_B.OnInputAccepted([this](EventArgs args) {
+		text_B.OnInputAccepted([this](const EventArgs& args) {
 			wi::Color color = GetPickColor();
 			color.setB((uint8_t)args.iValue);
 			SetPickColor(color);
@@ -4678,7 +4673,7 @@ namespace wi::gui
 		text_H.SetText("");
 		text_H.SetTooltip("Enter value for HUE channel (0-360)");
 		text_H.SetDescription("H: ");
-		text_H.OnInputAccepted([this](EventArgs args) {
+		text_H.OnInputAccepted([this](const EventArgs& args) {
 			hue = wi::math::Clamp(args.fValue, 0, 360.0f);
 			FireEvents();
 			});
@@ -4691,7 +4686,7 @@ namespace wi::gui
 		text_S.SetText("");
 		text_S.SetTooltip("Enter value for SATURATION channel (0-100)");
 		text_S.SetDescription("S: ");
-		text_S.OnInputAccepted([this](EventArgs args) {
+		text_S.OnInputAccepted([this](const EventArgs& args) {
 			saturation = wi::math::Clamp(args.fValue / 100.0f, 0, 1);
 			FireEvents();
 			});
@@ -4704,7 +4699,7 @@ namespace wi::gui
 		text_V.SetText("");
 		text_V.SetTooltip("Enter value for LUMINANCE channel (0-100)");
 		text_V.SetDescription("V: ");
-		text_V.OnInputAccepted([this](EventArgs args) {
+		text_V.OnInputAccepted([this](const EventArgs& args) {
 			luminance = wi::math::Clamp(args.fValue / 100.0f, 0, 1);
 			FireEvents();
 			});
@@ -4718,7 +4713,7 @@ namespace wi::gui
 		text_hex.SetTooltip("Enter RGBA hex value");
 		text_hex.SetDescription("#");
 		text_hex.font_description.params.scaling = 1.2f;
-		text_hex.OnInputAccepted([this](EventArgs args) {
+		text_hex.OnInputAccepted([this](const EventArgs& args) {
 			wi::Color color(args.sValue.c_str());
 			SetPickColor(color);
 			FireEvents();
@@ -4731,7 +4726,7 @@ namespace wi::gui
 		alphaSlider.SetSize(XMFLOAT2(150, 18));
 		alphaSlider.SetText("A: ");
 		alphaSlider.SetTooltip("Value for ALPHA - TRANSPARENCY channel (0-255)");
-		alphaSlider.OnSlide([this](EventArgs args) {
+		alphaSlider.OnSlide([this](const EventArgs& args) {
 			FireEvents();
 			});
 		AddWidget(&alphaSlider);
@@ -5327,9 +5322,9 @@ namespace wi::gui
 		args.color = GetPickColor();
 		onColorChanged(args);
 	}
-	void ColorPicker::OnColorChanged(std::function<void(EventArgs args)> func)
+	void ColorPicker::OnColorChanged(std::function<void(const EventArgs& args)> func)
 	{
-		onColorChanged = func;
+		onColorChanged = std::move(func);
 	}
 
 
@@ -5340,7 +5335,7 @@ namespace wi::gui
 	{
 		SetName(name);
 		SetText(name);
-		OnSelect([](EventArgs args) {});
+		OnSelect([](const EventArgs& args) {});
 
 		SetColor(wi::Color(100, 100, 100, 100), wi::gui::IDLE);
 		for (int i = FOCUS + 1; i < WIDGETSTATE_COUNT; ++i)
@@ -5850,17 +5845,17 @@ namespace wi::gui
 			wi::font::Draw(item.name, fp, cmd);
 		}
 	}
-	void TreeList::OnSelect(std::function<void(EventArgs args)> func)
+	void TreeList::OnSelect(std::function<void(const EventArgs& args)> func)
 	{
-		onSelect = func;
+		onSelect = std::move(func);
 	}
-	void TreeList::OnDelete(std::function<void(EventArgs args)> func)
+	void TreeList::OnDelete(std::function<void(const EventArgs& args)> func)
 	{
-		onDelete = func;
+		onDelete = std::move(func);
 	}
-	void TreeList::OnDoubleClick(std::function<void(EventArgs args)> func)
+	void TreeList::OnDoubleClick(std::function<void(const EventArgs& args)> func)
 	{
-		onDoubleClick = func;
+		onDoubleClick = std::move(func);
 	}
 	void TreeList::AddItem(const Item& item)
 	{

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -252,7 +252,7 @@ namespace wi::gui
 		bool IsVisible() const { return visible; }
 
 		void SetColor(wi::Color color, int id = -1);
-		void SetImage(wi::Resource resource, int id = -1);
+		void SetImage(const wi::Resource& resource, int id = -1);
 		void SetShadowColor(wi::Color color);
 		void SetTheme(const Theme& theme, int id = -1);
 
@@ -385,11 +385,11 @@ namespace wi::gui
 	class Button : public Widget
 	{
 	protected:
-		std::function<void(EventArgs args)> onClick;
-		std::function<void(EventArgs args)> onRightClick;
-		std::function<void(EventArgs args)> onDragStart;
-		std::function<void(EventArgs args)> onDrag;
-		std::function<void(EventArgs args)> onDragEnd;
+		std::function<void(const EventArgs& args)> onClick;
+		std::function<void(const EventArgs& args)> onRightClick;
+		std::function<void(const EventArgs& args)> onDragStart;
+		std::function<void(const EventArgs& args)> onDrag;
+		std::function<void(const EventArgs& args)> onDragEnd;
 		XMFLOAT2 dragStart = XMFLOAT2(0, 0);
 		XMFLOAT2 prevPos = XMFLOAT2(0, 0);
 		bool disableClicking = false;
@@ -401,11 +401,11 @@ namespace wi::gui
 		void SetTheme(const Theme& theme, int id = -1) override;
 		const char* GetWidgetTypeName() const override { return "Button"; }
 
-		void OnClick(std::function<void(EventArgs args)> func);
-		void OnRightClick(std::function<void(EventArgs args)> func);
-		void OnDragStart(std::function<void(EventArgs args)> func);
-		void OnDrag(std::function<void(EventArgs args)> func);
-		void OnDragEnd(std::function<void(EventArgs args)> func);
+		void OnClick(std::function<void(const EventArgs& args)> func);
+		void OnRightClick(std::function<void(const EventArgs& args)> func);
+		void OnDragStart(std::function<void(const EventArgs& args)> func);
+		void OnDrag(std::function<void(const EventArgs& args)> func);
+		void OnDragEnd(std::function<void(const EventArgs& args)> func);
 
 		wi::SpriteFont font_description;
 		void SetDescription(const std::string& desc) { font_description.SetText(desc); }
@@ -515,8 +515,8 @@ namespace wi::gui
 	class TextInputField : public Widget
 	{
 	protected:
-		std::function<void(EventArgs args)> onInputAccepted;
-		std::function<void(EventArgs args)> onInput;
+		std::function<void(const EventArgs& args)> onInputAccepted;
+		std::function<void(const EventArgs& args)> onInput;
 		static wi::SpriteFont font_input;
 		bool cancel_input_enabled = true;
 		int float_precision = -1;
@@ -553,9 +553,9 @@ namespace wi::gui
 		const char* GetWidgetTypeName() const override { return "TextInputField"; }
 
 		// Called when input was accepted with ENTER key:
-		void OnInputAccepted(std::function<void(EventArgs args)> func);
+		void OnInputAccepted(std::function<void(const EventArgs& args)> func);
 		// Called when input was updated with new character:
-		void OnInput(std::function<void(EventArgs args)> func);
+		void OnInput(std::function<void(const EventArgs& args)> func);
 
 		wi::SpriteFont font_description;
 		void SetDescription(const std::string& desc) { font_description.SetText(desc); }
@@ -569,7 +569,7 @@ namespace wi::gui
 	class Slider : public Widget
 	{
 	protected:
-		std::function<void(EventArgs args)> onSlide;
+		std::function<void(const EventArgs& args)> onSlide;
 		float start = 0, end = 1;
 		float step = 1000;
 		float value = 0;
@@ -595,7 +595,7 @@ namespace wi::gui
 		const char* GetWidgetTypeName() const override { return "Slider"; }
 		WIDGETSTATE GetState() const override { return std::max(state, valueInputField.GetState()); };
 
-		void OnSlide(std::function<void(EventArgs args)> func);
+		void OnSlide(std::function<void(const EventArgs& args)> func);
 
 		TextInputField valueInputField;
 	};
@@ -604,7 +604,7 @@ namespace wi::gui
 	class CheckBox :public Widget
 	{
 	protected:
-		std::function<void(EventArgs args)> onClick;
+		std::function<void(const EventArgs& args)> onClick;
 		bool checked = false;
 		std::wstring check_text;
 		std::wstring uncheck_text;
@@ -618,7 +618,7 @@ namespace wi::gui
 		void Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const override;
 		const char* GetWidgetTypeName() const override { return "CheckBox"; }
 
-		void OnClick(std::function<void(EventArgs args)> func);
+		void OnClick(std::function<void(const EventArgs& args)> func);
 
 		static void SetCheckTextGlobal(const std::string& text);
 		void SetCheckText(const std::string& text);
@@ -629,7 +629,7 @@ namespace wi::gui
 	class ComboBox :public Widget
 	{
 	protected:
-		std::function<void(EventArgs args)> onSelect;
+		std::function<void(const EventArgs& args)> onSelect;
 		int selected = -1;
 		int maxVisibleItemCount = 8;
 		int firstItemVisible = 0;
@@ -696,7 +696,7 @@ namespace wi::gui
 		void SetTheme(const Theme& theme, int id = -1) override;
 		const char* GetWidgetTypeName() const override { return "ComboBox"; }
 
-		void OnSelect(std::function<void(EventArgs args)> func);
+		void OnSelect(std::function<void(const EventArgs& args)> func);
 
 		wi::SpriteFont selected_font;
 
@@ -719,8 +719,8 @@ namespace wi::gui
 		bool right_aligned_image = false;
 		Widget scrollable_area;
 		float control_size = 20;
-		std::function<void(EventArgs args)> onClose;
-		std::function<void(EventArgs args)> onCollapse;
+		std::function<void(const EventArgs& args)> onClose;
+		std::function<void(const EventArgs& args)> onCollapse;
 		std::function<void()> onResize;
 
 		float resizehitboxwidth = 6;
@@ -940,8 +940,8 @@ namespace wi::gui
 		XMFLOAT2 GetSize() const override; // For the window, the returned size can be modified by collapsed state
 		XMFLOAT2 GetWidgetAreaSize() const;
 
-		void OnClose(std::function<void(EventArgs args)> func);
-		void OnCollapse(std::function<void(EventArgs args)> func);
+		void OnClose(std::function<void(const EventArgs& args)> func);
+		void OnCollapse(std::function<void(const EventArgs& args)> func);
 		void OnResize(std::function<void()> func);
 
 		Button closeButton;
@@ -965,7 +965,7 @@ namespace wi::gui
 	class ColorPicker : public Window
 	{
 	protected:
-		std::function<void(EventArgs args)> onColorChanged;
+		std::function<void(const EventArgs& args)> onColorChanged;
 		enum COLORPICKERSTATE
 		{
 			CPS_IDLE,
@@ -990,7 +990,7 @@ namespace wi::gui
 		wi::Color GetPickColor() const;
 		void SetPickColor(wi::Color value);
 
-		void OnColorChanged(std::function<void(EventArgs args)> func);
+		void OnColorChanged(std::function<void(const EventArgs& args)> func);
 
 		TextInputField text_R;
 		TextInputField text_G;
@@ -1015,9 +1015,9 @@ namespace wi::gui
 			bool selected = false;
 		};
 	protected:
-		std::function<void(EventArgs args)> onSelect;
-		std::function<void(EventArgs args)> onDelete;
-		std::function<void(EventArgs args)> onDoubleClick;
+		std::function<void(const EventArgs& args)> onSelect;
+		std::function<void(const EventArgs& args)> onDelete;
+		std::function<void(const EventArgs& args)> onDoubleClick;
 		int item_highlight = -1;
 		int opener_highlight = -1;
 
@@ -1063,9 +1063,9 @@ namespace wi::gui
 		void SetTheme(const Theme& theme, int id = -1) override;
 		const char* GetWidgetTypeName() const override { return "TreeList"; }
 
-		void OnSelect(std::function<void(EventArgs args)> func);
-		void OnDelete(std::function<void(EventArgs args)> func);
-		void OnDoubleClick(std::function<void(EventArgs args)> func);
+		void OnSelect(std::function<void(const EventArgs& args)> func);
+		void OnDelete(std::function<void(const EventArgs& args)> func);
+		void OnDoubleClick(std::function<void(const EventArgs& args)> func);
 
 		ScrollBar scrollbar;
 	};

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -1111,7 +1111,7 @@ namespace vulkan_internal
 		SwapChain_Vulkan* internal_state,
 		VkPhysicalDevice physicalDevice,
 		VkDevice device,
-		wi::allocator::shared_ptr<GraphicsDevice_Vulkan::AllocationHandler> allocationhandler
+		const wi::allocator::shared_ptr<GraphicsDevice_Vulkan::AllocationHandler>& allocationhandler
 	)
 	{
 		// In vulkan, the swapchain recreate can happen whenever it gets outdated, it's not in application's control

--- a/WickedEngine/wiHelper.cpp
+++ b/WickedEngine/wiHelper.cpp
@@ -1396,7 +1396,7 @@ namespace wi::helper
 #endif // _WIN32
 	}
 
-	void FileDialog(const FileDialogParams& params, std::function<void(std::string fileName)> onSuccess, std::function<void()> onFailure)
+	void FileDialog(const FileDialogParams& params, const std::function<void(std::string fileName)>& onSuccess, const std::function<void()>& onFailure)
 	{
 #ifdef PLATFORM_WINDOWS_DESKTOP
 		std::thread([=] {
@@ -1568,7 +1568,7 @@ namespace wi::helper
 #endif // __SCE__
 	}
 
-	void GetFileNamesInDirectory(const std::string& directory, std::function<void(std::string fileName)> onSuccess, const std::string& filter_extension)
+	void GetFileNamesInDirectory(const std::string& directory, const std::function<void(std::string fileName)>& onSuccess, const std::string& filter_extension)
 	{
 		std::filesystem::path directory_path = ToNativeString(directory);
 		if (!std::filesystem::exists(directory_path))
@@ -1586,7 +1586,7 @@ namespace wi::helper
 		}
 	}
 
-	void GetFolderNamesInDirectory(const std::string& directory, std::function<void(std::string folderName)> onSuccess)
+	void GetFolderNamesInDirectory(const std::string& directory, const std::function<void(std::string folderName)>& onSuccess)
 	{
 		std::filesystem::path directory_path = ToNativeString(directory);
 		if (!std::filesystem::exists(directory_path))

--- a/WickedEngine/wiHelper.h
+++ b/WickedEngine/wiHelper.h
@@ -154,13 +154,13 @@ namespace wi::helper
 		wi::vector<std::string> extensions;
 		bool multiselect = true; // only for TYPE::OPEN
 	};
-	void FileDialog(const FileDialogParams& params, std::function<void(std::string fileName)> onSuccess, std::function<void()> onFailure = nullptr);
+	void FileDialog(const FileDialogParams& params, const std::function<void(std::string fileName)>& onSuccess, const std::function<void()>& onFailure = nullptr);
 
 	std::string FolderDialog(const std::string& description = "Select folder");
 
-	void GetFileNamesInDirectory(const std::string& directory, std::function<void(std::string fileName)> onSuccess, const std::string& filter_extension = "");
+	void GetFileNamesInDirectory(const std::string& directory, const std::function<void(std::string fileName)>& onSuccess, const std::string& filter_extension = "");
 
-	void GetFolderNamesInDirectory(const std::string& directory, std::function<void(std::string folderName)> onSuccess);
+	void GetFolderNamesInDirectory(const std::string& directory, const std::function<void(std::string folderName)>& onSuccess);
 
 	// Converts a file into a C++ header file that contains the file contents as byte array.
 	//	dataName : the byte array's name

--- a/WickedEngine/wiInput.cpp
+++ b/WickedEngine/wiInput.cpp
@@ -135,7 +135,7 @@ namespace wi::input
 		initialized.store(true);
 	}
 
-	void Update(wi::platform::window_type _window, wi::Canvas _canvas)
+	void Update(wi::platform::window_type _window, const wi::Canvas& _canvas)
 	{
 		window = _window;
 		canvas = _canvas;

--- a/WickedEngine/wiInput.h
+++ b/WickedEngine/wiInput.h
@@ -184,7 +184,7 @@ namespace wi::input
 	void Initialize();
 
 	// call once per frame
-	void Update(wi::platform::window_type window, wi::Canvas canvas);
+	void Update(wi::platform::window_type window, const wi::Canvas& canvas);
 
 	// Some things need to be cleared for next frame, like touches and delta states
 	//	These things can occasionally be updated outside engine's loop, depending on operating system messages

--- a/WickedEngine/wiLoadingScreen.cpp
+++ b/WickedEngine/wiLoadingScreen.cpp
@@ -28,7 +28,7 @@ namespace wi
 		return (int)std::round(percent * 100);
 	}
 
-	void LoadingScreen::addLoadingFunction(std::function<void(wi::jobsystem::JobArgs)> loadingFunction)
+	void LoadingScreen::addLoadingFunction(const std::function<void(wi::jobsystem::JobArgs)>& loadingFunction)
 	{
 		if (loadingFunction != nullptr)
 		{
@@ -46,7 +46,7 @@ namespace wi
 			});
 	}
 
-	void LoadingScreen::onFinished(std::function<void()> finishFunction)
+	void LoadingScreen::onFinished(const std::function<void()>& finishFunction)
 	{
 		if (finishFunction != nullptr)
 			finish = finishFunction;

--- a/WickedEngine/wiLoadingScreen.h
+++ b/WickedEngine/wiLoadingScreen.h
@@ -31,11 +31,11 @@ namespace wi
 		} background_mode = BackgroundMode::Fill;
 
 		//Add a loading task which should be executed
-		void addLoadingFunction(std::function<void(wi::jobsystem::JobArgs)> loadingFunction);
+		void addLoadingFunction(const std::function<void(wi::jobsystem::JobArgs)>& loadingFunction);
 		//Helper for loading a whole renderable component
 		void addLoadingComponent(RenderPath* component, Application* main, float fadeSeconds = 0, wi::Color fadeColor = wi::Color(0, 0, 0, 255), wi::FadeManager::FadeType fadetype = wi::FadeManager::FadeType::FadeToColor);
 		//Set a function that should be called when the loading finishes
-		void onFinished(std::function<void()> finishFunction);
+		void onFinished(const std::function<void()>& finishFunction);
 		//See if the loading is currently running
 		bool isActive() const;
 		// See if there are any loading tasks that are still not finished

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -9986,7 +9986,7 @@ void VXGI_Voxelize(
 void VXGI_Resolve(
 	const VXGIResources& res,
 	const Scene& scene,
-	Texture texture_lineardepth,
+	const Texture& texture_lineardepth,
 	CommandList cmd
 )
 {

--- a/WickedEngine/wiRenderer.h
+++ b/WickedEngine/wiRenderer.h
@@ -502,7 +502,7 @@ namespace wi::renderer
 	void VXGI_Resolve(
 		const VXGIResources& res,
 		const wi::scene::Scene& scene,
-		wi::graphics::Texture texture_lineardepth,
+		const wi::graphics::Texture& texture_lineardepth,
 		wi::graphics::CommandList cmd
 	);
 


### PR DESCRIPTION
Most of the changes were proposed by clang-tidy which normally doesn't propose incorrect changes. I've done a few tests and everything seems to work, but double-checking doesn't hurt.