### PR TITLE
Implement persistence for the editor window's size

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -372,6 +372,43 @@ bool Editor::KeepRunning() {
 	return !exit_requested || renderComponent.save_in_progress;
 }
 
+void Editor::SaveWindowSize()
+{
+	if (window != nullptr)
+	{
+#ifdef _WIN32
+		WINDOWPLACEMENT placement = {};
+		placement.length = sizeof(WINDOWPLACEMENT);
+		if (GetWindowPlacement(window, &placement) && placement.showCmd != SW_SHOWMAXIMIZED)
+		{
+			RECT rect;
+			GetWindowRect(window, &rect);
+			int width = rect.right - rect.left;
+			int height = rect.bottom - rect.top;
+			if (width > 0 && height > 0)
+			{
+				config.Set("width", width);
+				config.Set("height", height);
+				config.Commit();
+			}
+		}
+#elif defined(SDL2)
+		if (!(SDL_GetWindowFlags(window) & SDL_WINDOW_MAXIMIZED))
+		{
+			int width = 0;
+			int height = 0;
+			SDL_GetWindowSize(window, &width, &height);
+			if (width > 0 && height > 0)
+			{
+				config.Set("width", width);
+				config.Set("height", height);
+				config.Commit();
+			}
+		}
+#endif
+	}
+}
+
 void Editor::Exit()
 {
 	// Check all scenes for unsaved changes
@@ -382,6 +419,10 @@ void Editor::Exit()
 			return;
 		}
 	}
+
+	// Save window size to config
+	SaveWindowSize();
+
 	// main loop will need to quit for us
 	exit_requested = true;
 }

--- a/Editor/Editor.h
+++ b/Editor/Editor.h
@@ -266,6 +266,8 @@ public:
 
 	bool KeepRunning();
 
+	void SaveWindowSize();
+
 	void Exit() override;
 
 	~Editor() override

--- a/Editor/main_SDL2.cpp
+++ b/Editor/main_SDL2.cpp
@@ -46,6 +46,7 @@ int sdl_loop()
                         case SDL_WINDOWEVENT_RESIZED:
                             // Tells the engine to reload window configuration (size and dpi)
                             editor.SetWindow(editor.window);
+                            editor.SaveWindowSize();
                             break;
                         case SDL_WINDOWEVENT_FOCUS_LOST:
                             editor.is_window_active = false;

--- a/Editor/main_Windows.cpp
+++ b/Editor/main_Windows.cpp
@@ -23,7 +23,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		case WM_SIZE:
 		case WM_DPICHANGED:
 			if (editor.is_window_active && LOWORD(lParam) > 0 && HIWORD(lParam) > 0)
+			{
 				editor.SetWindow(hWnd);
+				editor.SaveWindowSize();
+			}
 			break;
 		case WM_CHAR:
 			switch (wParam)


### PR DESCRIPTION
We have functionality for loading the editor window's width and height, but not for saving them.