### PR TITLE
Add the texture slot name to the texture picker

### DIFF
--- a/Editor/MaterialWindow.cpp
+++ b/Editor/MaterialWindow.cpp
@@ -1254,6 +1254,7 @@ void MaterialWindow::ResizeLayout()
 		{
 			windowTitle += " (Entity: " + name->name + ")";
 		}
+		windowTitle += " [Texture slot: " + textureSlotComboBox.GetItemText(textureSlotComboBox.GetSelected()) + "]";
 		texturePickerWindow.moveDragger.SetText(windowTitle);
 
 		if (!texturePickerButtons.empty())


### PR DESCRIPTION
Sometimes a user may forget which texture slot they are selecting the texture for.