### PR TITLE
Add LOD to RenderBatch sorting

### DIFF
--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -235,6 +235,7 @@ struct alignas(16) RenderBatch
 
 	// opaque sorting
 	//	Priority is set to mesh index to have more instancing
+	//  LOD is included to group same-mesh objects for better batching
 	//	distance is second priority (front to back Z-buffering)
 	constexpr bool operator<(const RenderBatch& other) const
 	{
@@ -244,24 +245,28 @@ struct alignas(16) RenderBatch
 			{
 				// The order of members is important here, it means the sort priority (low to high)!
 				uint64_t distance : 16;
+				uint64_t lod : 8;
 				uint64_t meshIndex : 16;
-				uint64_t sort_bits : 32;
+				uint64_t sort_bits : 24;
 			} bits;
 			uint64_t value;
 		};
 		static_assert(sizeof(SortKey) == sizeof(uint64_t));
 		SortKey a = {};
 		a.bits.distance = distance;
+		a.bits.lod = lod_override;
 		a.bits.meshIndex = meshIndex;
 		a.bits.sort_bits = sort_bits;
 		SortKey b = {};
 		b.bits.distance = other.distance;
+		b.bits.lod = other.lod_override;
 		b.bits.meshIndex = other.meshIndex;
 		b.bits.sort_bits = other.sort_bits;
 		return a.value < b.value;
 	}
 	// transparent sorting
 	//	Priority is distance for correct alpha blending (back to front rendering)
+	//  LOD is included to group same-mesh objects for better batching
 	//	mesh index is second priority for instancing
 	constexpr bool operator>(const RenderBatch& other) const
 	{
@@ -270,8 +275,9 @@ struct alignas(16) RenderBatch
 			struct
 			{
 				// The order of members is important here, it means the sort priority (low to high)!
+				uint64_t lod : 8;
 				uint64_t meshIndex : 16;
-				uint64_t sort_bits : 32;
+				uint64_t sort_bits : 24;
 				uint64_t distance : 16;
 			} bits;
 			uint64_t value;
@@ -280,10 +286,12 @@ struct alignas(16) RenderBatch
 		SortKey a = {};
 		a.bits.distance = distance;
 		a.bits.sort_bits = sort_bits;
+		a.bits.lod = lod_override;
 		a.bits.meshIndex = meshIndex;
 		SortKey b = {};
 		b.bits.distance = other.distance;
 		b.bits.sort_bits = other.sort_bits;
+		b.bits.lod = other.lod_override;
 		b.bits.meshIndex = other.meshIndex;
 		return a.value > b.value;
 	}


### PR DESCRIPTION
If you open a new scene, add a terrain, and save it as a `.wiscene` file, then load that same scene from a script, the shadowmap rendering on the CPU will take 5x longer.

Digging deeper into this, you'll find that inside of each `wi::job` internal call to `RenderMeshes(..., FILTER_OPAQUE, ...)` there are between 600 and 800 flushes of the `RenderBatch` queue.

In `wiRenderer.cpp`, you'll see on line `3402` this comment:
```cpp
//	RenderQueue is sorted based on mesh index, so when a new mesh or stencil request is encountered, we need to flush the batch
```

And on line `7020` there's this call, which creates a batch for rendering shadowmaps with a distance of 0:
```cpp
RenderBatch batch;
batch.Create(object.mesh_index, uint32_t(i), 0, object.sort_bits, camera_mask, shadow_lod);
```

The result is that when the `.wiscene` is loaded, the meshes are in a random order. The editor seems to do an extra sorting step somewhere in order to populate the component outliner hierarchy, but a `.wiscene` with terrain and props that's loaded through `StartLoading` or similar seems to be unsorted, and with a distance of `0`, they stay in that same random order. This causes new meshes to be encountered at a very high rate and the queue to be flushed very often.

Adding the `lod` to the `RenderBatch` sort reduces the number of `RenderBatch` queue flushes to 40-45, and brings the CPU shadowmap rendering back down to ~1ms.