### PR TITLE
Fix zero bone opacity doesn’t disable bone picking

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -5692,7 +5692,13 @@ void EditorComponent::PostSaveText(const std::string& message, const std::string
 
 void EditorComponent::CheckBonePickingEnabled()
 {
-	Scene& scene = GetCurrentScene();
+	const Scene& scene = GetCurrentScene();
+
+	if (generalWnd.bonePickerOpacitySlider.GetValue() <= 0.0f)
+	{
+		bone_picking = false;
+		return;
+	}
 
 	if (generalWnd.skeletonsVisibleCheckBox.GetCheck())
 	{


### PR DESCRIPTION
Disable bone picking when the bone picker opacity is set to zero to avoid looping through all humanoid bones, which can be extremely expensive, reducing editor performance.