### PR TITLE
Clean up the shaders folder when cleaning the editor project

### DIFF
--- a/Editor/Editor_Windows.vcxproj
+++ b/Editor/Editor_Windows.vcxproj
@@ -281,4 +281,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <Target Name="BeforeClean">
+    <RemoveDir Directories="$(ProjectDir)shaders" />
+  </Target>
 </Project>


### PR DESCRIPTION
Recently, I ran into a tricky issue with compiled shaders that took a while to diagnose. I tried cleaning up the project by running “Rebuild Solution” and “Clean Solution”, but eventually realized that I had to manually delete the shaders folder to force a recompile and resolve the problem.