### PR TITLE
Improve camera speed mouse scroll

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -1954,9 +1954,24 @@ void EditorComponent::Update(float dt)
 			if (!paintToolWnd.IsVisible() && std::abs(currentMouse.z) > 0.1f)
 			{
 				float current = cameraWnd.movespeedSlider.GetValue();
-				float increment = current > 10 ? 2.0f : 1.0f;
-				float add = currentMouse.z < 0 ? -increment : increment;
-				cameraWnd.movespeedSlider.SetValue(std::max(0.1f, std::ceil(current + add)));
+				bool scrollingDown = currentMouse.z < 0;
+				float newValue;
+
+				if (current < 1.0f || (current == 1.0f && scrollingDown))
+				{
+					// Below 1.0 threshold: use 0.1 increments
+					float add = scrollingDown ? -0.1f : 0.1f;
+					newValue = std::max(0.1f, current + add);
+				}
+				else
+				{
+					// Above 1.0 threshold
+					float increment = current > 10 ? 2.0f : 1.0f;
+					float add = scrollingDown ? -increment : increment;
+					newValue = std::max(0.1f, std::ceil(current + add));
+				}
+
+				cameraWnd.movespeedSlider.SetValue(newValue);
 				char txt[256];
 				snprintf(txt, arraysize(txt), "Camera speed: %.1f", cameraWnd.movespeedSlider.GetValue());
 				save_text_message = txt;


### PR DESCRIPTION
Improve the camera scroll speed by using finer 0.1 increments below the 1.0 threshold, making navigation through very small spaces easier. Alice in Wonderland would appreciate the change!