### PR TITLE
gh actions: force lld linker on clang, re-enable IPO on nightly/master

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Compile with embedded shaders
       run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -DWICKED_EMBED_SHADERS=YES -DWICKED_ENABLE_IPO=NO
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DWICKED_EMBED_SHADERS=YES -DWICKED_ENABLE_IPO=YES
         make -C build -j$(nproc)
 
     - name: Move files

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -193,9 +193,11 @@ jobs:
         include:
         - cc: gcc
           cxx: g++
+          linker_type: DEFAULT
           package_bins: true
         - cc: clang
           cxx: clang++
+          linker_type: LLD
           package_bins: false
 
     steps:
@@ -216,7 +218,7 @@ jobs:
 
     - name: Compile with embedded shaders
       run: |
-        CC=${{ matrix.cc }} CXX=${{ matrix.cxx }} cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DWICKED_ENABLE_IPO=NO -DWICKED_EMBED_SHADERS=YES
+        CC=${{ matrix.cc }} CXX=${{ matrix.cxx }} cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_LINKER_TYPE=${{ matrix.linker_type }} -DWICKED_ENABLE_IPO=NO -DWICKED_EMBED_SHADERS=YES
         make -C build -j$(nproc)
 
     - name: Save Ccache database

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,9 +95,11 @@ jobs:
         include:
         - cc: gcc
           cxx: g++
+          linker_type: DEFAULT
           package_bins: true
         - cc: clang
           cxx: clang++
+          linker_type: LLD
           package_bins: false
 
     steps:
@@ -118,7 +120,7 @@ jobs:
 
     - name: Compile with embedded shaders
       run: |
-        CC=${{ matrix.cc }} CXX=${{ matrix.cxx }} cmake -B build -DWICKED_ENABLE_IPO=NO -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DWICKED_EMBED_SHADERS=YES
+        CC=${{ matrix.cc }} CXX=${{ matrix.cxx }} cmake -B build -DWICKED_ENABLE_IPO=YES -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_LINKER_TYPE=${{ matrix.linker_type }} -DWICKED_EMBED_SHADERS=YES
         make -C build -j$(nproc)
 
     - name: Save Ccache database


### PR DESCRIPTION
for some reason, github actions seem to try to link clang code with the GNU linker instead of LLD, which doesn't work when LTO/IPO is enabled. Explicitly specifying LLD on Clang builds seems to solve this.

Hence, set the linker explicitly and re-enable IPO as it produces slightly better code.

IPO stays disabled for PR because it increases compilation time and we want fast compilation feedback for those