### PR TITLE
Fix texture streaming resolution overflow

### DIFF
--- a/WickedEngine/shaders/surfaceHF.hlsli
+++ b/WickedEngine/shaders/surfaceHF.hlsli
@@ -448,8 +448,8 @@ struct Surface
 
 			const float lod_uvset0 = compute_texture_lod(65536, 65536, lod_constant0, ray_direction, surf_normal, cone_width);
 			const float lod_uvset1 = compute_texture_lod(65536, 65536, lod_constant1, ray_direction, surf_normal, cone_width);
-			const uint resolution0 = 65536u >> uint(max(0, lod_uvset0));
-			const uint resolution1 = 65536u >> uint(max(0, lod_uvset1));
+			const uint resolution0 = 65536u >> clamp(uint(lod_uvset0), 1u, 16u);
+			const uint resolution1 = 65536u >> clamp(uint(lod_uvset1), 1u, 16u);
 			write_mipmap_feedback(geometry.materialIndex, resolution0, resolution1);
 #endif // SURFACE_LOAD_MIPCONE
 


### PR DESCRIPTION
When the camera is very close to a surface, the calculated LOD value can be `0` or negative, resulting in a resolution request of 65536 (= 2^16). The value 65536 requires 17 bits to represent (0x10000), which doesn’t fit in 16 bits. When the CPU reads this back with `request_packed & 0xFFFF`, the result is `0`, meaning no streaming request is made for that texture:
```cpp
const uint32_t request_packed = textureStreamingFeedbackMapped[args.jobIndex];
if (request_packed != 0)
{
	const uint32_t request_uvset0 = request_packed & 0xFFFF;
	const uint32_t request_uvset1 = (request_packed >> 16u) & 0xFFFF;
```

This causes the texture to fall back to its lowest loaded mip level.