### PR TITLE
Ensure GPU has finished rendering before creating thumbnail

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -5573,6 +5573,10 @@ void EditorComponent::SaveAs()
 Texture EditorComponent::CreateThumbnail(Texture texture, uint32_t target_width, uint32_t target_height, bool mipmaps) const
 {
 	GraphicsDevice* device = GetDevice();
+	// Ensure GPU has finished rendering before creating thumbnail
+	device->SubmitCommandLists();
+	device->WaitForGPU();
+
 	CommandList cmd = device->BeginCommandList();
 	Texture thumbnail = texture;
 


### PR DESCRIPTION
Sometimes geometry in thumbnails may be rendered only partially due to the async nature of rendering. Wait for the GPU to finish rendering before creating the thumbnail.