### PR TITLE
Ensure pointer is visible when right mouse button is not held

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -1834,6 +1834,12 @@ void EditorComponent::Update(float dt)
 		componentsWnd.RefreshEntityTree();
 	}
 
+	// Ensure pointer is visible when right mouse button is not held:
+	if (!wi::input::Down(wi::input::MOUSE_BUTTON_RIGHT))
+	{
+		wi::input::HidePointer(false);
+	}
+
 	// Camera control:
 	if (!drive_mode && !wi::backlog::isActive() && !GetGUI().HasFocus())
 	{


### PR DESCRIPTION
Fix cursor visibility in cases such as when a combobox is active and the user presses the right mouse button to move the camera in the viewport, causing the cursor to disappear and remain hidden.