### PR TITLE
Fix right arrow text deselection

### DIFF
--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -1734,10 +1734,13 @@ namespace wi::gui
 					}
 					caret_timer.record();
 				}
-				else if (wi::input::Press(wi::input::KEYBOARD_BUTTON_RIGHT) && caret_pos < font_input.GetText().size())
+				else if (wi::input::Press(wi::input::KEYBOARD_BUTTON_RIGHT))
 				{
 					// caret repositioning right:
-					caret_pos++;
+					if (caret_pos < font_input.GetText().size())
+					{
+						caret_pos++;
+					}
 					if (!wi::input::Down(wi::input::BUTTON::KEYBOARD_BUTTON_LSHIFT) && !wi::input::Down(wi::input::BUTTON::KEYBOARD_BUTTON_RSHIFT))
 					{
 						caret_begin = caret_pos;


### PR DESCRIPTION
When all text is selected in an input field, such as when pressing <kbd>F2</kbd> to rename an entity, the right arrow <kbd>→</kbd> doesn't deselect the text.