### PR TITLE
Improve the depth indicator for the hierarchy component

### DIFF
--- a/Editor/HierarchyWindow.cpp
+++ b/Editor/HierarchyWindow.cpp
@@ -120,7 +120,7 @@ void HierarchyWindow::SetEntity(Entity entity)
 			std::string depth_indicator;
 			if (depth > 3)
 			{
-				depth_indicator = ">" + std::to_string(depth);
+				depth_indicator = "> " + std::to_string(depth) + " >";
 			}
 			else
 			{


### PR DESCRIPTION
I realized that my original approach for depth indication might get out of hand in complex hierarchies like character rigs. So, instead of displaying `>>>` infinitely, limit it to three levels and use numbers thereafter e.g., `> 4 >` for better readability.