### PR TITLE
Implement input coordinates for the mesh center

### DIFF
--- a/Editor/MeshWindow.h
+++ b/Editor/MeshWindow.h
@@ -10,6 +10,7 @@ public:
 	wi::ecs::Entity entity;
 	int subset = -1;
 	void SetEntity(wi::ecs::Entity entity, int subset);
+	void UpdateRecenterInputs(XMFLOAT3 center);
 
 	wi::gui::Label meshInfoLabel;
 	wi::gui::Button subsetRemoveButton;
@@ -30,6 +31,9 @@ public:
 	wi::gui::Button computeNormalsHardButton;
 	wi::gui::Button recenterButton;
 	wi::gui::Button recenterToBottomButton;
+	wi::gui::TextInputField recenterToXInput;
+	wi::gui::TextInputField recenterToYInput;
+	wi::gui::TextInputField recenterToZInput;
 	wi::gui::Button mergeButton;
 	wi::gui::Button optimizeButton;
 	wi::gui::Button exportHeaderButton;

--- a/WickedEngine/wiScene_Components.cpp
+++ b/WickedEngine/wiScene_Components.cpp
@@ -806,7 +806,7 @@ namespace wi::scene
 				}
 			}
 		}
-		
+
 #ifdef __APPLE__
 		if (position_format == Vertex_POS32::FORMAT)
 		{
@@ -1951,7 +1951,7 @@ namespace wi::scene
 	}
 	void MeshComponent::Recenter()
 	{
-		XMFLOAT3 center = aabb.getCenter();
+		const XMFLOAT3 center = aabb.getCenter();
 
 		for (auto& pos : vertex_positions)
 		{
@@ -1972,6 +1972,19 @@ namespace wi::scene
 			pos.x -= center.x;
 			pos.y -= center.y;
 			pos.z -= center.z;
+		}
+
+		CreateRenderData();
+	}
+	void MeshComponent::RecenterTo(float x, float y, float z)
+	{
+		const XMFLOAT3 center = aabb.getCenter();
+
+		for (auto& pos : vertex_positions)
+		{
+			pos.x -= center.x - x;
+			pos.y -= center.y - y;
+			pos.z -= center.z - z;
 		}
 
 		CreateRenderData();

--- a/WickedEngine/wiScene_Components.h
+++ b/WickedEngine/wiScene_Components.h
@@ -871,6 +871,7 @@ namespace wi::scene
 		void FlipNormals();
 		void Recenter();
 		void RecenterToBottom();
+		void RecenterTo(float x, float y, float z);
 		wi::primitive::Sphere GetBoundingSphere() const;
 
 		uint32_t GetBoneInfluenceDiv4() const


### PR DESCRIPTION
In some cases, it's useful to set exact coordinates for a mesh's center point, such as for a sword handle or a gun grip. Changing any value in the input fields will automatically recenter the mesh. Pressing the _Recenter_ or _Recenter to Bottom_ buttons will update the coordinate fields to match the new position.

<img width="407" height="100" alt="image" src="https://github.com/user-attachments/assets/3d165e73-286f-4191-a030-3562744d7977" />
