### PR TITLE
add explicit ShutDown function to Application

### DIFF
--- a/Editor/main_SDL2.cpp
+++ b/Editor/main_SDL2.cpp
@@ -271,6 +271,7 @@ int main(int argc, char *argv[])
     int ret = sdl_loop();
 
 	wi::jobsystem::ShutDown();
+	editor.ShutDown();
 
     return ret;
 }

--- a/Editor/main_Windows.cpp
+++ b/Editor/main_Windows.cpp
@@ -255,6 +255,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 	}
 
 	wi::jobsystem::ShutDown();
+	editor.ShutDown();
 
     return (int)msg.wParam;
 }

--- a/Samples/Template_Linux/main.cpp
+++ b/Samples/Template_Linux/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
 	}
 
 	wi::jobsystem::ShutDown(); // waits for jobs to finish before shutdown
-
+	application.ShutDown();
     SDL_Quit();
 
     return 0;

--- a/Samples/Template_Windows/main.cpp
+++ b/Samples/Template_Windows/main.cpp
@@ -95,6 +95,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 	}
 
 	wi::jobsystem::ShutDown(); // waits for jobs to finish before shutdown
+	application.ShutDown();
 
 	return (int)msg.wParam;
 }

--- a/WickedEngine/wiApplication.cpp
+++ b/WickedEngine/wiApplication.cpp
@@ -717,7 +717,13 @@ namespace wi
 
 	void Application::Exit()
 	{
+		ShutDown();
 		wi::platform::Exit();
+	}
+
+	void Application::ShutDown()
+	{
+		graphicsDevice.reset(nullptr);
 	}
 
 	void Application::SetWindow(wi::platform::window_type window)

--- a/WickedEngine/wiApplication.h
+++ b/WickedEngine/wiApplication.h
@@ -49,8 +49,7 @@ namespace wi
 		bool isFullScreen = false;
 
 	public:
-		virtual ~Application() = default;
-
+		virtual ~Application() { ShutDown(); }
 		bool is_window_active = true;
 		bool allow_hdr = true;
 		wi::graphics::SwapChain swapChain;
@@ -93,6 +92,8 @@ namespace wi
 		virtual void Compose(wi::graphics::CommandList cmd);
 		// This is where the application about to exit.
 		virtual void Exit();
+		// Shut down the application cleanly (Exit and the destructor already call this, but it can be useful to call it explicitly when using Vulkan debug layers that don't like Vulkan calls in atexit() functions)
+		virtual void ShutDown();
 
 		// You need to call this before calling Run() or Initialize() if you want to render
 		void SetWindow(wi::platform::window_type window);


### PR DESCRIPTION
This can be helpful when using debugdevice on modern Vulkan SDK debug layers, as they don't like vulkan calls happening in atexit handlers (which is where ~GraphicsDevice is called)

Closes #1503