### PR TITLE
allocate application on heap instead of stack and delete it

### DIFF
--- a/Samples/Example_ImGui/main_SDL2.cpp
+++ b/Samples/Example_ImGui/main_SDL2.cpp
@@ -5,14 +5,14 @@
 #include "sdl2.h"
 #include "ImGui/imgui_impl_sdl.h"
 
-Example_ImGui exampleImGui;
+Example_ImGui* exampleImGui;
 
 int sdl_loop()
 {
     bool quit = false;
     while (!quit)
     {
-        exampleImGui.Run();
+        exampleImGui->Run();
         SDL_Event event;
         while(SDL_PollEvent(&event)){
             switch(event.type){
@@ -26,13 +26,13 @@ int sdl_loop()
                             break;
                         case SDL_WINDOWEVENT_RESIZED:
                             // Tells the engine to reload window configuration (size and dpi)
-                            exampleImGui.SetWindow(exampleImGui.window);
+                            exampleImGui->SetWindow(exampleImGui->window);
                             break;
                         case SDL_WINDOWEVENT_FOCUS_LOST: //TODO
-                            exampleImGui.is_window_active = false;
+                            exampleImGui->is_window_active = false;
                             break;
                         case SDL_WINDOWEVENT_FOCUS_GAINED:
-                            exampleImGui.is_window_active = true;
+                            exampleImGui->is_window_active = true;
                             if (wi::shadercompiler::GetRegisteredShaderCount() > 0)
                             {
                                 std::thread([] {
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
     // TODO: Place code here.
 
     wi::arguments::Parse(argc, argv);
-
+	exampleImGui = new Example_ImGui();
     sdl2::sdlsystem_ptr_t system = sdl2::make_sdlsystem(SDL_INIT_EVERYTHING | SDL_INIT_EVENTS);
     if (*system) {
 		wilog_error("Error creating SDL2 system");
@@ -85,10 +85,10 @@ int main(int argc, char *argv[])
 		wilog_error("Error creating window");
     }
 
-    exampleImGui.SetWindow(window.get());
+    exampleImGui->SetWindow(window.get());
 
     int ret = sdl_loop();
-
+    delete exampleImGui;
     SDL_Quit();
     return ret;
 }

--- a/Samples/Example_ImGui/main_Windows.cpp
+++ b/Samples/Example_ImGui/main_Windows.cpp
@@ -12,7 +12,7 @@
 HINSTANCE hInst;                                // current instance
 WCHAR szTitle[MAX_LOADSTRING];                  // The title bar text
 WCHAR szWindowClass[MAX_LOADSTRING];            // the main window class name
-Example_ImGui example_imgui;
+Example_ImGui* example_imgui;
 
 // Forward declarations of functions included in this code module:
 ATOM                MyRegisterClass(HINSTANCE hInstance);
@@ -28,6 +28,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     UNREFERENCED_PARAMETER(hPrevInstance);
     UNREFERENCED_PARAMETER(lpCmdLine);
 
+    example_imgui = new Example_ImGui();
     // TODO: Place code here.
 
     BOOL dpi_success = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
@@ -59,7 +60,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		}
 		else {
 
-			example_imgui.Run();
+			example_imgui->Run();
 
 		}
 	}
@@ -115,8 +116,8 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
       return FALSE;
    }
 
-   example_imgui.allow_hdr = false; // Imgui doesn't support HDR
-   example_imgui.SetWindow(hWnd);
+   example_imgui->allow_hdr = false; // Imgui doesn't support HDR
+   example_imgui->SetWindow(hWnd);
 
    ShowWindow(hWnd, nCmdShow);
    UpdateWindow(hWnd);
@@ -163,8 +164,8 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         break;
     case WM_SIZE:
     case WM_DPICHANGED:
-		if (example_imgui.is_window_active)
-			example_imgui.SetWindow(hWnd);
+		if (example_imgui->is_window_active)
+			example_imgui->SetWindow(hWnd);
         break;
 	case WM_CHAR:
 		switch (wParam)
@@ -186,10 +187,10 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		wi::input::rawinput::ParseMessage((void*)lParam);
 		break;
 	case WM_KILLFOCUS:
-		example_imgui.is_window_active = false;
+		example_imgui->is_window_active = false;
 		break;
 	case WM_SETFOCUS:
-		example_imgui.is_window_active = true;
+		example_imgui->is_window_active = true;
 		break;
     case WM_PAINT:
         {
@@ -205,6 +206,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     default:
         return DefWindowProc(hWnd, message, wParam, lParam);
     }
+	delete example_imgui;
     return 0;
 }
 

--- a/Samples/Example_ImGui_Docking/main_SDL2.cpp
+++ b/Samples/Example_ImGui_Docking/main_SDL2.cpp
@@ -2,14 +2,14 @@
 #include "sdl2.h"
 #include "ImGui/imgui_impl_sdl.h"
 
-Example_ImGui exampleImGui;
+Example_ImGui* exampleImGui;
 
 int sdl_loop()
 {
     bool quit = false;
     while (!quit)
     {
-        exampleImGui.Run();
+        exampleImGui->Run();
         SDL_Event event;
         while(SDL_PollEvent(&event)){
             switch(event.type){
@@ -23,13 +23,13 @@ int sdl_loop()
                             break;
                         case SDL_WINDOWEVENT_RESIZED:
                             // Tells the engine to reload window configuration (size and dpi)
-                            exampleImGui.SetWindow(exampleImGui.window);
+                            exampleImGui->SetWindow(exampleImGui->window);
                             break;
                         case SDL_WINDOWEVENT_FOCUS_LOST: //TODO
-                            exampleImGui.is_window_active = false;
+                            exampleImGui->is_window_active = false;
                             break;
                         case SDL_WINDOWEVENT_FOCUS_GAINED:
-                            exampleImGui.is_window_active = true;
+                            exampleImGui->is_window_active = true;
                             if (wi::shadercompiler::GetRegisteredShaderCount() > 0)
                             {
                                 std::thread([] {
@@ -66,6 +66,7 @@ int main(int argc, char *argv[])
 {
     // TODO: Place code here.
 
+	exampleImGui = new Example_ImGui();
     wi::arguments::Parse(argc, argv);
 
     sdl2::sdlsystem_ptr_t system = sdl2::make_sdlsystem(SDL_INIT_EVERYTHING | SDL_INIT_EVENTS);
@@ -82,10 +83,11 @@ int main(int argc, char *argv[])
 		wilog_error("Error creating window");
     }
 
-    exampleImGui.SetWindow(window.get());
+    exampleImGui->SetWindow(window.get());
 
     int ret = sdl_loop();
 
+	delete exampleImGui;
     SDL_Quit();
     return ret;
 }

--- a/Samples/Example_ImGui_Docking/main_Windows.cpp
+++ b/Samples/Example_ImGui_Docking/main_Windows.cpp
@@ -12,7 +12,7 @@
 HINSTANCE hInst;                                // current instance
 WCHAR szTitle[MAX_LOADSTRING];                  // The title bar text
 WCHAR szWindowClass[MAX_LOADSTRING];            // the main window class name
-Example_ImGui example_imgui;
+Example_ImGui* example_imgui;
 
 // Forward declarations of functions included in this code module:
 ATOM                MyRegisterClass(HINSTANCE hInstance);
@@ -28,6 +28,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     UNREFERENCED_PARAMETER(hPrevInstance);
     UNREFERENCED_PARAMETER(lpCmdLine);
 
+	example_imgui = new Example_ImGui();
     // TODO: Place code here.
 
     BOOL dpi_success = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
@@ -59,11 +60,11 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		}
 		else {
 
-			example_imgui.Run();
+			example_imgui->Run();
 
 		}
 	}
-
+	delete example_imgui;
     return (int) msg.wParam;
 }
 
@@ -117,14 +118,14 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
    HWND hWnd = CreateWindowW(szWindowClass, szTitle, WS_OVERLAPPEDWINDOW,
 	   rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, nullptr, nullptr, hInstance, nullptr);
 
-   
+
    if (!hWnd)
    {
       return FALSE;
    }
 
-   example_imgui.allow_hdr = false; // Imgui doesn't support HDR
-   example_imgui.SetWindow(hWnd);
+   example_imgui->allow_hdr = false; // Imgui doesn't support HDR
+   example_imgui->SetWindow(hWnd);
 
    ShowWindow(hWnd, nCmdShow);
    UpdateWindow(hWnd);
@@ -171,8 +172,8 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         break;
     case WM_SIZE:
     case WM_DPICHANGED:
-		if (example_imgui.is_window_active)
-			example_imgui.SetWindow(hWnd);
+		if (example_imgui->is_window_active)
+			example_imgui->SetWindow(hWnd);
         break;
 	case WM_CHAR:
 		switch (wParam)
@@ -194,10 +195,10 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		wi::input::rawinput::ParseMessage((void*)lParam);
 		break;
 	case WM_KILLFOCUS:
-		example_imgui.is_window_active = false;
+		example_imgui->is_window_active = false;
 		break;
 	case WM_SETFOCUS:
-		example_imgui.is_window_active = true;
+		example_imgui->is_window_active = true;
 		break;
     case WM_PAINT:
         {

--- a/Samples/Template_Linux/main.cpp
+++ b/Samples/Template_Linux/main.cpp
@@ -1,10 +1,11 @@
 #include "WickedEngine.h"
 #include <SDL2/SDL.h>
 
-wi::Application application;
+wi::Application* application;
 
 int main(int argc, char *argv[])
 {
+	application = new wi::Application();
 	// SDL window setup:
     sdl2::sdlsystem_ptr_t system = sdl2::make_sdlsystem(SDL_INIT_EVERYTHING | SDL_INIT_EVENTS);
     sdl2::window_ptr_t window = sdl2::make_window(
@@ -16,22 +17,22 @@ int main(int argc, char *argv[])
     SDL_Event event;
 
 	// set SDL window to engine:
-    application.SetWindow(window.get());
+    application->SetWindow(window.get());
 
 	// process command line string:
 	wi::arguments::Parse(argc, argv);
 
 	// just show some basic info:
-    application.infoDisplay.active = true;
-    application.infoDisplay.watermark = true;
-    application.infoDisplay.resolution = true;
-    application.infoDisplay.fpsinfo = true;
+    application->infoDisplay.active = true;
+    application->infoDisplay.watermark = true;
+    application->infoDisplay.resolution = true;
+    application->infoDisplay.fpsinfo = true;
 
 	bool quit = false;
 	while (!quit)
 	{
 		SDL_PumpEvents();
-		application.Run();
+		application->Run();
 
 		SDL_Event event;
 		while (SDL_PollEvent(&event))
@@ -48,7 +49,7 @@ int main(int argc, char *argv[])
 					quit = true;
 					break;
 				case SDL_WINDOWEVENT_RESIZED:
-					application.SetWindow(application.window);
+					application->SetWindow(application->window);
 					break;
 				default:
 					break;
@@ -61,6 +62,10 @@ int main(int argc, char *argv[])
 	}
 
 	wi::jobsystem::ShutDown(); // waits for jobs to finish before shutdown
+
+    // explicitly deleting prevents issues with Vulkan debug layers (debugdevice)
+    // which don't like vulkan calls happening during C++ application shutdown
+    delete application;
 
     SDL_Quit();
 


### PR DESCRIPTION
This prevents problems with Vulkan debug layers that don't like Vulkan calls to happen during C++ app shutdown.

Not pretty, but does the job