### PR TITLE
Expose normals computation for spline fill

### DIFF
--- a/Editor/SplineWindow.h
+++ b/Editor/SplineWindow.h
@@ -22,6 +22,7 @@ public:
 	wi::gui::Slider terrainTexSlider;
 	wi::gui::Slider terrainPushdownSlider;
 	wi::gui::Button recenterButton;
+	wi::gui::ComboBox fillNormalsComboBox;
 	wi::gui::Button addButton;
 
 	struct Entry

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -5987,6 +5987,7 @@ namespace wi::scene
 			dirty |= spline.prev_filled != spline.IsFilled();
 			dirty |= spline.prev_width != spline.width;
 			dirty |= spline.prev_rotation != spline.rotation;
+			dirty |= spline.prev_fill_normals_mode != spline.fill_normals_mode;
 
 			bool dirty_terrain = spline.prev_terrain_modifier_amount != spline.terrain_modifier_amount;
 			dirty_terrain |= spline.prev_terrain_pushdown != spline.terrain_pushdown;
@@ -5998,6 +5999,7 @@ namespace wi::scene
 
 			spline.prev_width = spline.width;
 			spline.prev_rotation = spline.rotation;
+			spline.prev_fill_normals_mode = spline.fill_normals_mode;
 			spline.prev_looped = spline.IsLooped();
 			spline.prev_filled = spline.IsFilled();
 
@@ -6294,7 +6296,7 @@ namespace wi::scene
 								mesh->indices.push_back(next);
 							}
 
-							mesh->ComputeNormals(MeshComponent::COMPUTE_NORMALS_SMOOTH_FAST);
+							mesh->ComputeNormals(spline.fill_normals_mode);
 						}
 						MeshComponent::MeshSubset& subset = mesh->subsets.front();
 						subset.indexCount = (uint32_t)mesh->indices.size();

--- a/WickedEngine/wiScene.h
+++ b/WickedEngine/wiScene.h
@@ -63,7 +63,7 @@ namespace wi::scene
 		wi::ecs::ComponentManager<MetadataComponent>& metadatas = componentLibrary.Register<MetadataComponent>("wi::scene::Scene::metadatas");
 		wi::ecs::ComponentManager<CharacterComponent>& characters = componentLibrary.Register<CharacterComponent>("wi::scene::Scene::characters");
 		wi::ecs::ComponentManager<PhysicsConstraintComponent>& constraints = componentLibrary.Register<PhysicsConstraintComponent>("wi::scene::Scene::constraints", 6); // version = 6
-		wi::ecs::ComponentManager<SplineComponent>& splines = componentLibrary.Register<SplineComponent>("wi::scene::Scene::splines", 3); // version = 3
+		wi::ecs::ComponentManager<SplineComponent>& splines = componentLibrary.Register<SplineComponent>("wi::scene::Scene::splines", 4); // version = 4
 
 		// Non-serialized attributes:
 		float dt = 0;

--- a/WickedEngine/wiScene_Components.h
+++ b/WickedEngine/wiScene_Components.h
@@ -2639,6 +2639,7 @@ namespace wi::scene
 		float terrain_modifier_amount = 0; // increase above 0 to affect terrain generation (greater values increase the strength of the terrain trying to match the spline plane)
 		float terrain_pushdown = 0; // push down the terrain below the spline plane (or above if negative value)
 		float terrain_texture_falloff = 0.8f; // texture blend falloff for terrain modifier spline
+		MeshComponent::COMPUTE_NORMALS fill_normals_mode = MeshComponent::COMPUTE_NORMALS_SMOOTH; // normals computation method for filled spline
 
 		wi::vector<wi::ecs::Entity> spline_node_entities;
 
@@ -2648,6 +2649,7 @@ namespace wi::scene
 		float precomputed_total_distance = 0;
 		float prev_width = 1;
 		float prev_rotation = 0;
+		MeshComponent::COMPUTE_NORMALS prev_fill_normals_mode = MeshComponent::COMPUTE_NORMALS_SMOOTH;
 		int prev_mesh_generation_subdivision = 0;
 		int prev_mesh_generation_vertical_subdivision = 0;
 		int prev_mesh_generation_nodes = 0;

--- a/WickedEngine/wiScene_Serializers.cpp
+++ b/WickedEngine/wiScene_Serializers.cpp
@@ -2596,6 +2596,10 @@ namespace wi::scene
 				archive >> terrain_pushdown;
 				archive >> terrain_texture_falloff;
 			}
+			if (seri.GetVersion() >= 4)
+			{
+				archive >> (uint32_t&)fill_normals_mode;
+			}
 		}
 		else
 		{
@@ -2619,6 +2623,10 @@ namespace wi::scene
 			{
 				archive << terrain_pushdown;
 				archive << terrain_texture_falloff;
+			}
+			if (seri.GetVersion() >= 4)
+			{
+				archive << (uint32_t)fill_normals_mode;
 			}
 		}
 	}


### PR DESCRIPTION
In some cases, it's desirable to choose between smooth and hard normals for a spline fill. Additionally, we no longer use the fast smooth method, as it does not produce proper shading in either case.