### PR TITLE
Implement sorting for the content browser

### DIFF
--- a/Editor/ContentBrowserWindow.h
+++ b/Editor/ContentBrowserWindow.h
@@ -11,7 +11,7 @@ public:
 	std::string content_folder;
 	enum SELECTION
 	{
-		SELECTION_RECENT,
+		SELECTION_ALL,
 		SELECTION_MODELS,
 		SELECTION_SCRIPTS,
 
@@ -20,17 +20,39 @@ public:
 
 		SELECTION_COUNT
 	};
+	enum SORTING
+	{
+		SORTING_RECENT,
+		SORTING_NAME,
+		SORTING_PATH,
+		SORTING_SIZE,
+
+		SORTING_COUNT
+	};
 	SELECTION current_selection = SELECTION_COUNT;
+	SORTING current_sorting = SORTING_RECENT;
 	wi::gui::Button folderButtons[SELECTION_COUNT];
 	std::deque<wi::gui::Button> itemButtons;
 
 	wi::gui::Button openFolderButton;
+	wi::gui::ComboBox sortingComboBox;
+
+	struct ItemInfo
+	{
+		std::string fileName;
+		std::string icon;
+		size_t recent_index = 0;
+		size_t file_size = 0;
+	};
+	std::vector<ItemInfo> added_items;
 
 	void RefreshContent();
 
 	void SetSelection(SELECTION selection);
 	void AddItems(const std::string& folder, const std::string& extension, const std::string& icon);
-	void AddItem(const std::string& filename, const std::string& icon);
+	void AddItem(const std::string& fileName, const std::string& icon);
+	void SortAndCreateItemButtons();
+	void CreateItemButton(const std::string& fileName, const std::string& icon);
 
 	void Update(const wi::Canvas& canvas, float dt) override;
 	void Render(const wi::Canvas& canvas, wi::graphics::CommandList cmd) const override;


### PR DESCRIPTION
Implement sorting for the content browser items:
- By recent: Most recently used items first
- By name: Alphabetically by file name
- By path: Alphabetically by full path
- By size: Largest files first

<img width="396" height="184" alt="image" src="https://github.com/user-attachments/assets/1a665549-87e3-4f41-b929-518296404652" />
