### PR TITLE
Fix spline fill asserts

### DIFF
--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -6295,15 +6295,12 @@ namespace wi::scene
 								mesh->indices.push_back(current);
 								mesh->indices.push_back(next);
 							}
-
-							assert(vertexCount == mesh->vertex_positions.size());
-							assert(indexCount == mesh->indices.size());
-							mesh->ComputeNormals(spline.fill_normals_mode);
 						}
-						else
+						assert(vertexCount == mesh->vertex_positions.size());
+						assert(indexCount == mesh->indices.size());
+						if (generateFill)
 						{
-							assert(vertexCount == mesh->vertex_positions.size());
-							assert(indexCount == mesh->indices.size());
+							mesh->ComputeNormals(spline.fill_normals_mode);
 						}
 						MeshComponent::MeshSubset& subset = mesh->subsets.front();
 						subset.indexCount = (uint32_t)mesh->indices.size();


### PR DESCRIPTION
Validate mesh vertex positions and indices for the spline fill before computing normals.