### PR TITLE
Fix texture streaming is not being disabled

### DIFF
--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -4193,16 +4193,30 @@ namespace wi::scene
 
 			if (textureStreamingFeedbackMapped != nullptr)
 			{
-				const uint32_t request_packed = textureStreamingFeedbackMapped[args.jobIndex];
-				if (request_packed != 0)
+				if (material.IsTextureStreamingDisabled())
 				{
-					const uint32_t request_uvset0 = request_packed & 0xFFFF;
-					const uint32_t request_uvset1 = (request_packed >> 16u) & 0xFFFF;
+					// Request maximum resolution to keep textures fully loaded
 					for (auto& slot : material.textures)
 					{
 						if (slot.resource.IsValid())
 						{
-							slot.resource.StreamingRequestResolution(slot.uvset == 0 ? request_uvset0 : request_uvset1);
+							slot.resource.StreamingRequestResolution(65536);
+						}
+					}
+				}
+				else
+				{
+					const uint32_t request_packed = textureStreamingFeedbackMapped[args.jobIndex];
+					if (request_packed != 0)
+					{
+						const uint32_t request_uvset0 = request_packed & 0xFFFF;
+						const uint32_t request_uvset1 = (request_packed >> 16u) & 0xFFFF;
+						for (auto& slot : material.textures)
+						{
+							if (slot.resource.IsValid())
+							{
+								slot.resource.StreamingRequestResolution(slot.uvset == 0 ? request_uvset0 : request_uvset1);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Fix the _Disable Texture Streaming_ option on materials has no effect. Such materials should always request the maximum resolution.