### PR TITLE
Implement update interval for render to texture

### DIFF
--- a/Editor/CameraComponentWindow.cpp
+++ b/Editor/CameraComponentWindow.cpp
@@ -259,6 +259,13 @@ void CameraComponentWindow::Create(EditorComponent* _editor)
 	}));
 	AddWidget(&samplecountSlider);
 
+	updateIntervalSlider.Create(0.0f, 2.0f, 0.0f, 200, "Update Interval: ");
+	updateIntervalSlider.SetTooltip("Control how often the camera renders in seconds. 0 - every frame, 1.0 - once per second, etc.");
+	updateIntervalSlider.OnSlide(forEachSelectedCameraComponent([](auto camera, auto args) {
+		camera->render_to_texture.update_interval = args.fValue;
+	}));
+	AddWidget(&updateIntervalSlider);
+
 	crtCheckbox.Create("CRT: ");
 	crtCheckbox.SetTooltip("Toggle CRT TV mode for this camera (when render to texture is enabled)");
 	crtCheckbox.OnClick(forEachSelectedCameraComponent([](auto camera, auto args) {
@@ -299,6 +306,7 @@ void CameraComponentWindow::SetEntity(Entity entity)
 		resolutionXSlider.SetValue((int)camera->render_to_texture.resolution.x);
 		resolutionYSlider.SetValue((int)camera->render_to_texture.resolution.y);
 		samplecountSlider.SetValue((int)camera->render_to_texture.sample_count);
+		updateIntervalSlider.SetValue(camera->render_to_texture.update_interval);
 		crtCheckbox.SetCheck(camera->IsCRT());
 
 		preview.entity = entity;
@@ -336,11 +344,13 @@ void CameraComponentWindow::ResizeLayout()
 		resolutionXSlider.SetVisible(true);
 		resolutionYSlider.SetVisible(true);
 		samplecountSlider.SetVisible(true);
+		updateIntervalSlider.SetVisible(true);
 		crtCheckbox.SetVisible(true);
 
 		layout.add(resolutionXSlider);
 		layout.add(resolutionYSlider);
 		layout.add(samplecountSlider);
+		layout.add(updateIntervalSlider);
 		layout.add_right(crtCheckbox);
 	}
 	else
@@ -348,6 +358,7 @@ void CameraComponentWindow::ResizeLayout()
 		resolutionXSlider.SetVisible(false);
 		resolutionYSlider.SetVisible(false);
 		samplecountSlider.SetVisible(false);
+		updateIntervalSlider.SetVisible(false);
 		crtCheckbox.SetVisible(false);
 	}
 

--- a/Editor/CameraComponentWindow.h
+++ b/Editor/CameraComponentWindow.h
@@ -35,6 +35,7 @@ public:
 	wi::gui::Slider resolutionXSlider;
 	wi::gui::Slider resolutionYSlider;
 	wi::gui::Slider samplecountSlider;
+	wi::gui::Slider updateIntervalSlider;
 	wi::gui::CheckBox crtCheckbox;
 
 	CameraPreview preview;

--- a/WickedEngine/wiRenderPath3D.cpp
+++ b/WickedEngine/wiRenderPath3D.cpp
@@ -2566,6 +2566,15 @@ namespace wi
 				continue;
 			}
 
+			camera.render_to_texture.time_accumulator += scene->dt;
+			bool should_render = (camera.render_to_texture.update_interval <= 0.0f) || 
+				(camera.render_to_texture.time_accumulator >= camera.render_to_texture.update_interval);
+			if (!should_render)
+			{
+				continue;
+			}
+			camera.render_to_texture.time_accumulator = 0.0f;
+
 			GraphicsDevice* device = GetDevice();
 			CommandList cmd = device->BeginCommandList();
 
@@ -2651,6 +2660,8 @@ namespace wi
 			}
 			camera.width = (float)camera.render_to_texture.resolution.x;
 			camera.height = (float)camera.render_to_texture.resolution.y;
+			camera.UpdateCamera();
+
 			if (camera.render_to_texture.depthstencil_resolved.IsValid())
 			{
 				camera.texture_depth_index = device->GetDescriptorIndex(&camera.render_to_texture.depthstencil_resolved, SubresourceType::SRV);
@@ -2752,7 +2763,8 @@ namespace wi
 
 					if (camera.IsCRT() && getSceneUpdateEnabled())
 					{
-						wi::renderer::Postprocess_CRT(camera.render_to_texture.rendertarget_render, camera.render_to_texture.rendertarget_display, cmd, 0.2f, frameCB.time * 100, false);
+						wi::renderer::Postprocess_CRT(camera.render_to_texture.rendertarget_render, camera.render_to_texture.rendertarget_display, cmd, 0, 0, false);
+						// Swap so rendertarget_render now contains the CRT-processed result for mipchain and display
 						std::swap(camera.render_to_texture.rendertarget_render, camera.render_to_texture.rendertarget_display);
 					}
 

--- a/WickedEngine/wiScene.h
+++ b/WickedEngine/wiScene.h
@@ -39,7 +39,7 @@ namespace wi::scene
 		wi::ecs::ComponentManager<SoftBodyPhysicsComponent>& softbodies = componentLibrary.Register<SoftBodyPhysicsComponent>("wi::scene::Scene::softbodies", 3); // version = 3
 		wi::ecs::ComponentManager<ArmatureComponent>& armatures = componentLibrary.Register<ArmatureComponent>("wi::scene::Scene::armatures");
 		wi::ecs::ComponentManager<LightComponent>& lights = componentLibrary.Register<LightComponent>("wi::scene::Scene::lights", 5); // version = 5
-		wi::ecs::ComponentManager<CameraComponent>& cameras = componentLibrary.Register<CameraComponent>("wi::scene::Scene::cameras", 2); // version = 2
+		wi::ecs::ComponentManager<CameraComponent>& cameras = componentLibrary.Register<CameraComponent>("wi::scene::Scene::cameras", 3); // version = 3
 		wi::ecs::ComponentManager<EnvironmentProbeComponent>& probes = componentLibrary.Register<EnvironmentProbeComponent>("wi::scene::Scene::probes", 2); // version = 2
 		wi::ecs::ComponentManager<ForceFieldComponent>& forces = componentLibrary.Register<ForceFieldComponent>("wi::scene::Scene::forces", 1); // version = 1
 		wi::ecs::ComponentManager<DecalComponent>& decals = componentLibrary.Register<DecalComponent>("wi::scene::Scene::decals", 1); // version = 1

--- a/WickedEngine/wiScene_Components.h
+++ b/WickedEngine/wiScene_Components.h
@@ -1474,6 +1474,7 @@ namespace wi::scene
 		{
 			XMUINT2 resolution = XMUINT2(0, 0);
 			uint32_t sample_count = 1;
+			float update_interval = 0.0f;
 			wi::graphics::Texture rendertarget_MSAA;
 			wi::graphics::Texture rendertarget_render;
 			wi::graphics::Texture rendertarget_display;
@@ -1482,6 +1483,7 @@ namespace wi::scene
 			XMUINT2 tileCount = {};
 			wi::graphics::GPUBuffer entityTiles;
 			wi::allocator::shared_ptr<void> visibility;
+			float time_accumulator = 0.0f;
 		} render_to_texture;
 
 		void CreateOrtho(float newWidth, float newHeight, float newNear, float newFar, float newVerticalSize = 1);

--- a/WickedEngine/wiScene_Serializers.cpp
+++ b/WickedEngine/wiScene_Serializers.cpp
@@ -1338,6 +1338,11 @@ namespace wi::scene
 				archive >> render_to_texture.sample_count;
 			}
 
+			if (seri.GetVersion() >= 3)
+			{
+				archive >> render_to_texture.update_interval;
+			}
+
 			SetDirty();
 		}
 		else
@@ -1365,6 +1370,11 @@ namespace wi::scene
 			{
 				archive << render_to_texture.resolution;
 				archive << render_to_texture.sample_count;
+			}
+
+			if (seri.GetVersion() >= 3)
+			{
+				archive << render_to_texture.update_interval;
 			}
 		}
 	}


### PR DESCRIPTION
Implement an update interval to the camera component’s render to texture feature to control how often it refreshes.

Additionally, fix the CRT effect flickering on the rendered texture.