### PR TITLE
Editor: Linux file dialogs: remember last-used dir

### DIFF
--- a/WickedEngine/wiHelper.cpp
+++ b/WickedEngine/wiHelper.cpp
@@ -1545,11 +1545,15 @@ namespace wi::helper
 				{
 					options = options | pfd::opt::multiselect;
 				}
-				std::vector<std::string> selection = pfd::open_file("Open file", "", extensions, options).result();
+				static std::string recent_dir_path = "";
+				std::vector<std::string> selection = pfd::open_file("Open file", recent_dir_path, extensions, options).result();
 				if (!selection.empty())
 				{
 					for (auto& x : selection)
 					{
+#ifdef PLATFORM_LINUX
+						recent_dir_path = GetDirectoryFromPath(x);
+#endif
 						onSuccess(x);
 					}
 				} else {
@@ -1559,9 +1563,13 @@ namespace wi::helper
 			}
 			case FileDialogParams::SAVE:
 			{
-				std::string destination = pfd::save_file("Save file", "", extensions).result();
+				static std::string recent_dir_path = "";
+				std::string destination = pfd::save_file("Save file", recent_dir_path, extensions).result();
 				if (!destination.empty())
 				{
+#ifdef PLATFORM_LINUX
+					recent_dir_path = GetDirectoryFromPath(destination);
+#endif
 					onSuccess(destination);
 				} else {
 					if (onFailure) onFailure();


### PR DESCRIPTION
Thanks for giving consideration to this minor Editor-on-Linux proposal:

- Behavior stays like it was previously for users who never change dirs in Open/Save dialogs.
- But for those who previously had to keep selecting other folders than `$PWD` every single time in an open/save-file dialog, now the last-used directory (in this session; ie. no persistence) is being defaulted to instead.
- Open and Save dialog each keep their own last-used dir path. If in a user's workflow both stay the same anyway, then no problem. But some workflows keep importing assets from one dir and saving `.wiscene`s to another, and for those, that separation can be beneficial.
