### PR TITLE
Implement multiple values per config key

### DIFF
--- a/WickedEngine/wiConfig.cpp
+++ b/WickedEngine/wiConfig.cpp
@@ -105,6 +105,88 @@ namespace wi::config
 		return it->second;
 	}
 
+	std::vector<std::string> Section::GetTextArray(const char* name) const
+	{
+		std::vector<std::string> result;
+		const auto it = values.find(name);
+		if (it == values.end())
+		{
+			return result;
+		}
+		const std::string& str = it->second;
+		if (str.empty())
+		{
+			return result;
+		}
+		size_t start = 0;
+		size_t end = str.find(',');
+		while (end != std::string::npos)
+		{
+			std::string token = str.substr(start, end - start);
+			// Trim leading/trailing whitespace
+			size_t first = token.find_first_not_of(" \t");
+			size_t last = token.find_last_not_of(" \t");
+			if (first != std::string::npos)
+				result.push_back(token.substr(first, last - first + 1));
+			else
+				result.push_back("");
+			start = end + 1;
+			end = str.find(',', start);
+		}
+		// Last token
+		std::string token = str.substr(start);
+		size_t first = token.find_first_not_of(" \t");
+		size_t last = token.find_last_not_of(" \t");
+		if (first != std::string::npos)
+			result.push_back(token.substr(first, last - first + 1));
+		else
+			result.push_back("");
+		return result;
+	}
+	std::vector<int> Section::GetIntArray(const char* name) const
+	{
+		std::vector<int> result;
+		std::vector<std::string> strings = GetTextArray(name);
+		result.reserve(strings.size());
+		for (const auto& s : strings)
+		{
+			if (!s.empty())
+				result.push_back(std::stoi(s));
+			else
+				result.push_back(0);
+		}
+		return result;
+	}
+	std::vector<float> Section::GetFloatArray(const char* name) const
+	{
+		std::vector<float> result;
+		std::vector<std::string> strings = GetTextArray(name);
+		result.reserve(strings.size());
+		for (const auto& s : strings)
+		{
+			if (!s.empty())
+				result.push_back(std::stof(s));
+			else
+				result.push_back(0.0f);
+		}
+		return result;
+	}
+	size_t Section::GetCount(const char* name) const
+	{
+		const auto it = values.find(name);
+		if (it == values.end() || it->second.empty())
+		{
+			return 0;
+		}
+		size_t count = 1;
+		for (char c : it->second)
+		{
+			if (c == ',')
+				count++;
+		}
+		return count;
+	}
+
 	void Section::Set(const char* name, bool value)
 	{
 		values[name] = value ? "true" : "false";
@@ -128,6 +210,39 @@ namespace wi::config
 	void Section::Set(const char* name, const std::string& value)
 	{
 		values[name] = value;
+	}
+	void Section::Set(const char* name, const std::vector<std::string>& arr)
+	{
+		std::string result;
+		for (size_t i = 0; i < arr.size(); ++i)
+		{
+			if (i > 0)
+				result += ", ";
+			result += arr[i];
+		}
+		values[name] = result;
+	}
+	void Section::Set(const char* name, const std::vector<int>& arr)
+	{
+		std::string result;
+		for (size_t i = 0; i < arr.size(); ++i)
+		{
+			if (i > 0)
+				result += ", ";
+			result += std::to_string(arr[i]);
+		}
+		values[name] = result;
+	}
+	void Section::Set(const char* name, const std::vector<float>& arr)
+	{
+		std::string result;
+		for (size_t i = 0; i < arr.size(); ++i)
+		{
+			if (i > 0)
+				result += ", ";
+			result += std::to_string(arr[i]);
+		}
+		values[name] = result;
 	}
 
 	bool File::Open(const char* filename)

--- a/WickedEngine/wiConfig.h
+++ b/WickedEngine/wiConfig.h
@@ -25,6 +25,14 @@ namespace wi::config
 		float GetFloat(const char* name) const;
 		std::string GetText(const char* name) const;
 
+		// Get multiple values for the key (comma-separated in the file):
+		std::vector<std::string> GetTextArray(const char* name) const;
+		std::vector<int> GetIntArray(const char* name) const;
+		std::vector<float> GetFloatArray(const char* name) const;
+
+		// Get the number of values for the key:
+		size_t GetCount(const char* name) const;
+
 		// Set the associated value for the key:
 		void Set(const char* name, bool value);
 		void Set(const char* name, int value);
@@ -32,6 +40,11 @@ namespace wi::config
 		void Set(const char* name, float value);
 		void Set(const char* name, const char* value);
 		void Set(const char* name, const std::string& value);
+
+		// Set multiple values for the key:
+		void Set(const char* name, const std::vector<std::string>& values);
+		void Set(const char* name, const std::vector<int>& values);
+		void Set(const char* name, const std::vector<float>& values);
 
 		std::unordered_map<std::string, std::string>::iterator begin() { return values.begin(); }
 		std::unordered_map<std::string, std::string>::const_iterator begin() const { return values.begin(); }


### PR DESCRIPTION
Implement comma-separated values per config key. This is useful for games that require multiple keybindings for a single action.