### PR TITLE
Fix overlapped style condition check for full-screen mode

### DIFF
--- a/WickedEngine/wiApplication.cpp
+++ b/WickedEngine/wiApplication.cpp
@@ -910,7 +910,7 @@ namespace wi
 			}
 		}
 		else if (!fullscreen && isFullScreen) {
-			if (has_overlapped_style) {
+			if (!has_overlapped_style) {
 				SetWindowLong(window, GWL_STYLE,
 					dwStyle | WS_OVERLAPPEDWINDOW);
 			}


### PR DESCRIPTION
#1490 introduced a bug where the editor won’t restore the titlebar on Windows when exiting full-screen mode due to an inverted condition check.