### PR TITLE
Implement the Uchimura tonemapping

### DIFF
--- a/Editor/GraphicsWindow.cpp
+++ b/Editor/GraphicsWindow.cpp
@@ -759,6 +759,7 @@ void GraphicsWindow::Create(EditorComponent* _editor)
 	tonemapCombo.SetScriptTip("RenderPath3D::SetTonemap(Tonemap value)");
 	tonemapCombo.AddItem("Reinhard", (uint64_t)wi::renderer::Tonemap::Reinhard);
 	tonemapCombo.AddItem("ACES", (uint64_t)wi::renderer::Tonemap::ACES);
+	tonemapCombo.AddItem("Uchimura", (uint64_t)wi::renderer::Tonemap::Uchimura);
 	tonemapCombo.OnSelect([=](wi::gui::EventArgs args) {
 		editor->renderPath->setTonemap((wi::renderer::Tonemap)args.iValue);
 		editor->main->config.GetSection("graphics").Set("tonemap", args.iValue);

--- a/WickedEngine/shaders/ShaderInterop_Postprocess.h
+++ b/WickedEngine/shaders/ShaderInterop_Postprocess.h
@@ -130,6 +130,7 @@ enum TONEMAP_FLAGS
 	TONEMAP_FLAG_DITHER = 1 << 0,
 	TONEMAP_FLAG_ACES = 1 << 1,
 	TONEMAP_FLAG_SRGB = 1 << 2,
+	TONEMAP_FLAG_UCHIMURA = 1 << 3,
 };
 struct PushConstantsTonemap
 {

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -17084,6 +17084,10 @@ void Postprocess_Tonemap(
 	{
 		tonemap_push.flags_hdrcalibration |= TONEMAP_FLAG_ACES;
 	}
+	if (tonemap == Tonemap::Uchimura)
+	{
+		tonemap_push.flags_hdrcalibration |= TONEMAP_FLAG_UCHIMURA;
+	}
 	if (display_colorspace == ColorSpace::SRGB)
 	{
 		tonemap_push.flags_hdrcalibration |= TONEMAP_FLAG_SRGB;

--- a/WickedEngine/wiRenderer.h
+++ b/WickedEngine/wiRenderer.h
@@ -888,7 +888,8 @@ namespace wi::renderer
 	enum class Tonemap
 	{
 		Reinhard,
-		ACES
+		ACES,
+		Uchimura
 	};
 	void Postprocess_Tonemap(
 		const wi::graphics::Texture& input,


### PR DESCRIPTION
Uchimura tonemapping from Gran Turismo 7. Unlike ACES, which is more "cinematic", this tonemapper aims for a more "photographic" look and is highly adjustable (by default, tuned toward the Gran Turismo 7 style).

Reference: [Driving Toward Reality: Physically Based Tone Mapping and Perceptual Fidelity in Gran Turismo 7](https://s3.amazonaws.com/gran-turismo.com/pdi_publications/s2025_PBS_Physically_Based_Tone_Mapping_GT7.pdf)