### PR TITLE
fix: check for pipeline creation when reloading shaders

### DIFF
--- a/Samples/Example_ImGui/main_SDL2.cpp
+++ b/Samples/Example_ImGui/main_SDL2.cpp
@@ -33,7 +33,7 @@ int sdl_loop()
                             break;
                         case SDL_WINDOWEVENT_FOCUS_GAINED:
                             exampleImGui.is_window_active = true;
-                            if (wi::shadercompiler::GetRegisteredShaderCount() > 0)
+                            if (wi::shadercompiler::GetRegisteredShaderCount() > 0 && !wi::renderer::IsPipelineCreationActive())
                             {
                                 std::thread([] {
                                     wi::backlog::post("[Shader check] Started checking " + std::to_string(wi::shadercompiler::GetRegisteredShaderCount()) + " registered shaders for changes...");

--- a/Samples/Example_ImGui_Docking/main_SDL2.cpp
+++ b/Samples/Example_ImGui_Docking/main_SDL2.cpp
@@ -30,7 +30,7 @@ int sdl_loop()
                             break;
                         case SDL_WINDOWEVENT_FOCUS_GAINED:
                             exampleImGui.is_window_active = true;
-                            if (wi::shadercompiler::GetRegisteredShaderCount() > 0)
+                            if (wi::shadercompiler::GetRegisteredShaderCount() > 0 && !wi::renderer::IsPipelineCreationActive())
                             {
                                 std::thread([] {
                                     wi::backlog::post("[Shader check] Started checking " + std::to_string(wi::shadercompiler::GetRegisteredShaderCount()) + " registered shaders for changes...");

--- a/Samples/Tests/main_SDL2.cpp
+++ b/Samples/Tests/main_SDL2.cpp
@@ -32,7 +32,7 @@ int sdl_loop()
                             break;
                         case SDL_WINDOWEVENT_FOCUS_GAINED:
                             tests.is_window_active = true;
-                            if (wi::shadercompiler::GetRegisteredShaderCount() > 0)
+                            if (wi::shadercompiler::GetRegisteredShaderCount() > 0 && !wi::renderer::IsPipelineCreationActive())
                             {
                                 std::thread([] {
                                     wi::backlog::post("[Shader check] Started checking " + std::to_string(wi::shadercompiler::GetRegisteredShaderCount()) + " registered shaders for changes...");


### PR DESCRIPTION
This is done in the editor, but was omitted in the samples, causing them to crash.