### PR TITLE
Fix editor's camera movement deadzone

### DIFF
--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -2024,8 +2024,10 @@ void EditorComponent::Update(float dt)
 
 			move = XMVectorLerp(move, moveNew, std::min(1.0f, cameraWnd.accelerationSlider.GetValue() * clampedDT / 0.0166f)); // smooth the movement a bit
 			float moveLength = XMVectorGetX(XMVector3Length(move));
+			float moveNewLength = XMVectorGetX(XMVector3Length(moveNew));
 
-			if (moveLength < 0.0001f)
+			// Only zero out movement when there is no input
+			if (moveLength < 0.0001f && moveNewLength < 0.0001f)
 			{
 				move = XMVectorSet(0, 0, 0, 0);
 			}


### PR DESCRIPTION
Fix camera movement issue where low speeds (e.g., `0.1`) caused the camera to stop entirely. The deadzone threshold was zeroing out movement during active input due to lerp smoothing. Now deadzone only applies when no input is provided, allowing small movements to accumulate properly.