### PR TITLE
Fix pinning of editor component windows

### DIFF
--- a/Editor/AnimationWindow.cpp
+++ b/Editor/AnimationWindow.cpp
@@ -1071,7 +1071,7 @@ void AnimationWindow::SetEntity(Entity entity)
 		wi::scene::Scene& scene = editor->GetCurrentScene();
 
 		AnimationComponent* animation = scene.animations.GetComponent(entity);
-		if (animation != nullptr || IsCollapsed())
+		if (animation != nullptr || (IsCollapsed() && entity == INVALID_ENTITY))
 		{
 			this->entity = entity;
 			RefreshKeyframesList();

--- a/Editor/ArmatureWindow.cpp
+++ b/Editor/ArmatureWindow.cpp
@@ -219,7 +219,7 @@ void ArmatureWindow::SetEntity(Entity entity)
 
 	const ArmatureComponent* armature = scene.armatures.GetComponent(entity);
 
-	if (armature != nullptr || IsCollapsed())
+	if (armature != nullptr || (IsCollapsed() && entity == INVALID_ENTITY))
 	{
 		this->entity = entity;
 		RefreshBoneList();

--- a/Editor/HumanoidWindow.cpp
+++ b/Editor/HumanoidWindow.cpp
@@ -319,7 +319,7 @@ void HumanoidWindow::SetEntity(Entity entity)
 		ragdollCheckBox.SetCheck(humanoid->IsRagdollPhysicsEnabled()); // this is always force updated
 	}
 
-	if (humanoid != nullptr || IsCollapsed())
+	if (humanoid != nullptr || (IsCollapsed() && entity == INVALID_ENTITY))
 	{
 		if (this->entity != entity)
 		{


### PR DESCRIPTION
Fix bug where collapsing `HumanoidWindow`, `ArmatureWindow`, and `AnimationWindow` on child entities without the component would release the component window making it impossible to use.