### PR TITLE
Fix light shafts MSAA resolve bind flags

### DIFF
--- a/WickedEngine/wiRenderPath3D.cpp
+++ b/WickedEngine/wiRenderPath3D.cpp
@@ -3226,6 +3226,7 @@ namespace wi
 
 			if (getMSAASampleCount() > 1)
 			{
+				desc.bind_flags = BindFlag::RENDER_TARGET | BindFlag::SHADER_RESOURCE;
 				desc.width = internalResolution.x;
 				desc.height = internalResolution.y;
 				desc.sample_count = 1;


### PR DESCRIPTION
Explicitly set bind flags for `rtSun_resolved` when using MSAA.