### PR TITLE
Fix texture resolution and mip levels display

### DIFF
--- a/Editor/MaterialWindow.cpp
+++ b/Editor/MaterialWindow.cpp
@@ -5,9 +5,19 @@ using namespace wi::graphics;
 using namespace wi::ecs;
 using namespace wi::scene;
 
-void AddTexturePropertiesString(const wi::graphics::TextureDesc& desc, std::string& str)
+void AddTexturePropertiesString(const wi::graphics::TextureDesc& desc, std::string& str, uint32_t full_mip_count = 0)
 {
-	str += "\nResolution: " + std::to_string(desc.width) + " * " + std::to_string(desc.height);
+	uint32_t full_width = desc.width;
+	uint32_t full_height = desc.height;
+	uint32_t display_mip_levels = desc.mip_levels;
+	if (full_mip_count > desc.mip_levels)
+	{
+		const uint32_t mip_offset = full_mip_count - desc.mip_levels;
+		full_width <<= mip_offset;
+		full_height <<= mip_offset;
+		display_mip_levels = full_mip_count;
+	}
+	str += "\nResolution: " + std::to_string(full_width) + " * " + std::to_string(full_height);
 	if (desc.array_size > 1)
 	{
 		str += " * " + std::to_string(desc.array_size);
@@ -20,7 +30,7 @@ void AddTexturePropertiesString(const wi::graphics::TextureDesc& desc, std::stri
 	{
 		str += " (cubemap)";
 	}
-	str += "\nMip levels: " + std::to_string(desc.mip_levels);
+	str += "\nMip levels: " + std::to_string(display_mip_levels);
 	str += "\nFormat: ";
 	str += GetFormatString(desc.format);
 	str += "\nSwizzle: ";
@@ -1016,7 +1026,7 @@ void MaterialWindow::Create(EditorComponent* _editor)
 			if (material->textures[args.iValue].resource.IsValid())
 			{
 				const Texture& texture = material->textures[args.iValue].resource.GetTexture();
-				AddTexturePropertiesString(texture.GetDesc(), tooltiptext);
+				AddTexturePropertiesString(texture.GetDesc(), tooltiptext, material->textures[args.iValue].resource.GetTextureFullMipCount());
 			}
 		}
 
@@ -1359,7 +1369,7 @@ void MaterialWindow::RecreateTexturePickerButtons()
 		button.Create("");
 		button.SetImage(textureResource);
 		std::string tooltipText = wi::helper::GetFileNameFromPath(textureName) + "\nFull path: " + textureName;
-		AddTexturePropertiesString(textureResource.GetTexture().GetDesc(), tooltipText);
+		AddTexturePropertiesString(textureResource.GetTexture().GetDesc(), tooltipText, textureResource.GetTextureFullMipCount());
 		button.SetTooltip(tooltipText);
 		texturePickerWindow.AddWidget(&button);
 		button.SetVisible(false);

--- a/WickedEngine/wiHelper.cpp
+++ b/WickedEngine/wiHelper.cpp
@@ -409,7 +409,7 @@ namespace wi::helper
 				dds_format = dds::DXGI_FORMAT_B8G8R8A8_UNORM;
 				break;
 			case wi::graphics::Format::B8G8R8A8_UNORM_SRGB:
-				dds_format = dds::DXGI_FORMAT_R16G16_SINT;
+				dds_format = dds::DXGI_FORMAT_B8G8R8A8_UNORM_SRGB;
 				break;
 			case wi::graphics::Format::R16G16_FLOAT:
 				dds_format = dds::DXGI_FORMAT_R16G16_FLOAT;

--- a/WickedEngine/wiResourceManager.cpp
+++ b/WickedEngine/wiResourceManager.cpp
@@ -105,6 +105,13 @@ namespace wi
 		const ResourceInternal* resourceinternal = (ResourceInternal*)internal_state.get();
 		return resourceinternal->video;
 	}
+	uint32_t Resource::GetTextureFullMipCount() const
+	{
+		const ResourceInternal* resourceinternal = (ResourceInternal*)internal_state.get();
+		if (resourceinternal->streaming_texture.mip_count > 0)
+			return resourceinternal->streaming_texture.mip_count;
+		return resourceinternal->texture.GetDesc().mip_levels;
+	}
 	int Resource::GetTextureSRGBSubresource() const
 	{
 		const ResourceInternal* resourceinternal = (ResourceInternal*)internal_state.get();
@@ -132,7 +139,7 @@ namespace wi
 			internal_state = wi::allocator::make_shared<ResourceInternal>();
 		}
 		ResourceInternal* resourceinternal = (ResourceInternal*)internal_state.get();
-		resourceinternal->filedata = data;
+		resourceinternal->filedata = std::move(data);
 	}
 	void Resource::SetTexture(const wi::graphics::Texture& texture, int srgb_subresource)
 	{

--- a/WickedEngine/wiResourceManager.h
+++ b/WickedEngine/wiResourceManager.h
@@ -24,6 +24,7 @@ namespace wi
 
 		const wi::vector<uint8_t>& GetFileData() const;
 		const wi::graphics::Texture& GetTexture() const;
+		uint32_t GetTextureFullMipCount() const;
 		const wi::audio::Sound& GetSound() const;
 		const std::string& GetScript() const;
 		size_t GetScriptHash() const;


### PR DESCRIPTION
The material window shows the current streaming resolution of textures, not the actual full resolution.