### PR TITLE
Fix entity tree selection focus

### DIFF
--- a/Editor/ComponentsWindow.cpp
+++ b/Editor/ComponentsWindow.cpp
@@ -1418,6 +1418,12 @@ void ComponentsWindow::RefreshEntityTree()
 
 	entitytree_added_items.clear();
 	entitytree_opened_items.clear();
+
+	if (entitytree_pending_focus != INVALID_ENTITY)
+	{
+		entityTree.FocusOnItemByUserdata(entitytree_pending_focus);
+		entitytree_pending_focus = INVALID_ENTITY;
+	}
 }
 
 // Returns a priority value for an entity based on its component type.

--- a/Editor/ComponentsWindow.h
+++ b/Editor/ComponentsWindow.h
@@ -128,6 +128,7 @@ public:
 	wi::unordered_set<wi::ecs::Entity> entitytree_temp_items;
 	wi::unordered_set<wi::ecs::Entity> entitytree_added_items;
 	wi::unordered_set<wi::ecs::Entity> entitytree_opened_items;
+	wi::ecs::Entity entitytree_pending_focus = wi::ecs::INVALID_ENTITY;
 	void PushToEntityTree(wi::ecs::Entity entity, int level);
 	void RefreshEntityTree();
 	bool CheckEntityFilter(wi::ecs::Entity entity) const;

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -4970,7 +4970,7 @@ void EditorComponent::AddSelected(const PickResult& picked, bool allow_refocus)
 		translator.selected.push_back(picked);
 		if (allow_refocus)
 		{
-			componentsWnd.entityTree.FocusOnItemByUserdata(picked.entity);
+			componentsWnd.entitytree_pending_focus = picked.entity;
 		}
 	}
 }


### PR DESCRIPTION
Defer the selection focus operation until after the entity tree rebuild is complete. In heavy scenes, when selecting an entity in the viewport, the entity tree may not scroll to reveal the selected entity because it refreshes immediately and rebuilds the tree.