### PR TITLE
Fix root node GLTF export

### DIFF
--- a/Editor/ModelImporter_GLTF.cpp
+++ b/Editor/ModelImporter_GLTF.cpp
@@ -4442,7 +4442,10 @@ void ExportModel_GLTF(const std::string& filename, Scene& scene)
 		auto nameComponent = wiscene.names.GetComponent(meshEntity);
 
 		tinygltf::Mesh mesh_builder;
-		mesh_builder.name = nameComponent->name;
+		if (nameComponent != nullptr)
+		{
+			mesh_builder.name = nameComponent->name;
+		}
 
 		tinygltf::Buffer buffer_builder;
 		int buffer_index = (int)state.gltfModel.buffers.size();
@@ -5037,7 +5040,6 @@ void ExportModel_GLTF(const std::string& filename, Scene& scene)
 		
 		state.nodeMap[transformEntity] = node_index;
 		state.gltfModel.nodes.push_back(node_builder);
-		scene_builder.nodes.push_back(node_index);
 	}
 
 	// Write Armature
@@ -5237,6 +5239,7 @@ void ExportModel_GLTF(const std::string& filename, Scene& scene)
 	}
 
 	// Compose hierarchy
+	wi::unordered_set<int> child_node_indices;
 	for(size_t h_id = 0; h_id < wiscene.hierarchy.GetCount(); ++h_id)
 	{
 		auto& hierarchyComponent = wiscene.hierarchy[h_id];
@@ -5246,6 +5249,17 @@ void ExportModel_GLTF(const std::string& filename, Scene& scene)
 			int node_index = (int)wiscene.transforms.GetIndex(hierarchyEntity);
 			size_t parent_node_index = wiscene.transforms.GetIndex(hierarchyComponent.parentID);
 			state.gltfModel.nodes[parent_node_index].children.push_back(node_index);
+			child_node_indices.insert(node_index);
+		}
+	}
+
+	// Scene root must only contain top-level nodes
+	for (size_t t_id = 0; t_id < wiscene.transforms.GetCount(); ++t_id)
+	{
+		int node_index = (int)t_id;
+		if (child_node_indices.find(node_index) == child_node_indices.end())
+		{
+			scene_builder.nodes.push_back(node_index);
 		}
 	}
 


### PR DESCRIPTION
When exporting scenes to GLTF\GLB format, all transforms were being added to the scene's root node list, regardless of whether they were children in the hierarchy. This caused Blender's importer to instantiate and link the same objects multiple times, resulting in "Object already in collection" errors. The fix ensures that only top-level nodes (those without parents) are added to the scene roots, while child nodes are only referenced through their parent's children list. This maintains proper hierarchy semantics and allows Blender to correctly import the exported models.