### PR TITLE
ensure jobsystem::ShutDown is called at exit

### DIFF
--- a/WickedEngine/wiJobSystem.cpp
+++ b/WickedEngine/wiJobSystem.cpp
@@ -430,6 +430,8 @@ namespace wi::jobsystem
 		}
 
 		wilog("wi::jobsystem Initialized with %d cores in %.2f ms\n\tHigh priority threads: %d\n\tLow priority threads: %d\n\tStreaming threads: %d", internal_state.numCores, timer.elapsed(), GetThreadCount(Priority::High), GetThreadCount(Priority::Low), GetThreadCount(Priority::Streaming));
+
+		std::atexit(ShutDown);
 	}
 
 	void ShutDown()


### PR DESCRIPTION
This prevents difficult to debug memory corruption if a developer forgot to call it explicitly (would never happen to me, of course *ahem*)