### PR TITLE
Editor: add drag-and-drop entity reordering in hierarchy tree (#1084)

### DIFF
--- a/Editor/ComponentsWindow.cpp
+++ b/Editor/ComponentsWindow.cpp
@@ -122,6 +122,100 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 	entityTree.OnDoubleClick([this](wi::gui::EventArgs args) {
 		editor->FocusCameraOnSelected();
 		});
+	entityTree.OnReorder([this](wi::gui::EventArgs args) {
+		int source_idx = args.iValue;
+		int target_idx = (int)args.userdata;
+		if (source_idx < 0 || source_idx >= entityTree.GetItemCount())
+			return;
+		if (target_idx < 0 || target_idx > entityTree.GetItemCount())
+			return;
+
+		const Scene& scene = editor->GetCurrentScene();
+		Entity source_entity = (Entity)entityTree.GetItem(source_idx).userdata;
+
+		// Determine parent entity of the source (INVALID_ENTITY = top-level)
+		Entity parent_entity = INVALID_ENTITY;
+		const HierarchyComponent* hier = scene.hierarchy.GetComponent(source_entity);
+		if (hier != nullptr && hier->parentID != INVALID_ENTITY && entitytree_temp_items.count(hier->parentID) != 0)
+		{
+			parent_entity = hier->parentID;
+		}
+
+		// Collect all current siblings of source_entity
+		wi::vector<Entity> siblings;
+		if (parent_entity == INVALID_ENTITY)
+		{
+			for (auto& e : entitytree_temp_items)
+			{
+				const HierarchyComponent* h = scene.hierarchy.GetComponent(e);
+				if (h == nullptr || h->parentID == INVALID_ENTITY || entitytree_temp_items.count(h->parentID) == 0)
+					siblings.push_back(e);
+			}
+		}
+		else
+		{
+			for (size_t i = 0; i < scene.hierarchy.GetCount(); ++i)
+			{
+				if (scene.hierarchy[i].parentID == parent_entity)
+					siblings.push_back(scene.hierarchy.GetEntity(i));
+			}
+		}
+
+		// Build (or refresh) the ordered list for this parent, preserving existing custom order
+		wi::vector<Entity>& order = entity_user_order[parent_entity];
+		wi::vector<Entity> new_order;
+		new_order.reserve(siblings.size());
+		for (Entity e : order)
+		{
+			for (Entity s : siblings)
+			{
+				if (s == e) { new_order.push_back(e); break; }
+			}
+		}
+		for (Entity s : siblings)
+		{
+			bool found = false;
+			for (Entity e : new_order) { if (e == s) { found = true; break; } }
+			if (!found) new_order.push_back(s);
+		}
+		order = new_order;
+
+		// Find which sibling is just above the drop point (same parent)
+		Entity entity_above = INVALID_ENTITY;
+		for (int i = target_idx - 1; i >= 0; --i)
+		{
+			Entity e = (Entity)entityTree.GetItem(i).userdata;
+			const HierarchyComponent* h = scene.hierarchy.GetComponent(e);
+			Entity p = (h != nullptr && h->parentID != INVALID_ENTITY && entitytree_temp_items.count(h->parentID) != 0)
+				? h->parentID : INVALID_ENTITY;
+			if (p == parent_entity)
+			{
+				entity_above = e;
+				break;
+			}
+		}
+
+		// Move source_entity in the order list
+		auto it_src = std::find(order.begin(), order.end(), source_entity);
+		if (it_src == order.end()) return;
+		order.erase(it_src);
+
+		if (entity_above == INVALID_ENTITY)
+		{
+			// Insert at beginning of sibling list
+			order.insert(order.begin(), source_entity);
+		}
+		else
+		{
+			auto it_above = std::find(order.begin(), order.end(), entity_above);
+			if (it_above != order.end())
+				order.insert(it_above + 1, source_entity);
+			else
+				order.push_back(source_entity);
+		}
+
+		RefreshEntityTree();
+		});
 	AddWidget(&entityTree);
 
 	if (editor->main->config.GetSection("layout").Has("entities.height"))
@@ -1365,13 +1459,49 @@ void ComponentsWindow::PushToEntityTree(wi::ecs::Entity entity, int level)
 
 	// Get sorting mode from config and sort children
 	const int sortingMode = editor->main->config.GetSection("options").GetInt("entity_tree_sorting");
-	SortEntitiesByMode(children, scene, sortingMode);
+	if (sortingMode == 0)
+	{
+		ApplyUserOrder(children, entity);
+	}
+	else
+	{
+		SortEntitiesByMode(children, scene, sortingMode);
+	}
 
 	// Add sorted children
 	for (Entity child : children)
 	{
 		PushToEntityTree(child, level + 1);
 	}
+}
+void ComponentsWindow::ApplyUserOrder(wi::vector<wi::ecs::Entity>& entities, wi::ecs::Entity parent_entity) const
+{
+	auto it = entity_user_order.find(parent_entity);
+	if (it == entity_user_order.end() || it->second.empty())
+		return;
+
+	const wi::vector<Entity>& order = it->second;
+	wi::vector<Entity> result;
+	result.reserve(entities.size());
+
+	// First, add entities that appear in the custom order (in that order)
+	for (Entity e : order)
+	{
+		for (Entity s : entities)
+		{
+			if (s == e) { result.push_back(e); break; }
+		}
+	}
+
+	// Then append any new entities not yet in the custom order
+	for (Entity s : entities)
+	{
+		bool found = false;
+		for (Entity e : result) { if (e == s) { found = true; break; } }
+		if (!found) result.push_back(s);
+	}
+
+	entities = result;
 }
 void ComponentsWindow::RefreshEntityTree()
 {
@@ -1408,7 +1538,14 @@ void ComponentsWindow::RefreshEntityTree()
 
 	// Get sorting mode from config and sort top-level entities
 	const int sortingMode = editor->main->config.GetSection("options").GetInt("entity_tree_sorting");
-	SortEntitiesByMode(topLevelEntities, scene, sortingMode);
+	if (sortingMode == 0)
+	{
+		ApplyUserOrder(topLevelEntities, INVALID_ENTITY);
+	}
+	else
+	{
+		SortEntitiesByMode(topLevelEntities, scene, sortingMode);
+	}
 
 	// Add sorted top-level entities
 	for (const auto& x : topLevelEntities)

--- a/Editor/ComponentsWindow.cpp
+++ b/Editor/ComponentsWindow.cpp
@@ -123,8 +123,14 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 		editor->FocusCameraOnSelected();
 		});
 	entityTree.OnReorder([this](wi::gui::EventArgs args) {
+		// Only apply custom ordering when sortingMode==0 and no text filter is active
+		if (editor->main->config.GetSection("options").GetInt("entity_tree_sorting") != 0)
+			return;
+		if (!filterInput.GetCurrentInputValue().empty())
+			return;
+
 		int source_idx = args.iValue;
-		int target_idx = (int)args.userdata;
+		int target_idx = args.iValue2;
 		if (source_idx < 0 || source_idx >= entityTree.GetItemCount())
 			return;
 		if (target_idx < 0 || target_idx > entityTree.GetItemCount())
@@ -161,24 +167,40 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 			}
 		}
 
-		// Build (or refresh) the ordered list for this parent, preserving existing custom order
-		wi::vector<Entity>& order = entity_user_order[parent_entity];
-		wi::vector<Entity> new_order;
-		new_order.reserve(siblings.size());
-		for (Entity e : order)
-		{
-			for (Entity s : siblings)
-			{
-				if (s == e) { new_order.push_back(e); break; }
-			}
-		}
+		// Validate that source_entity belongs to this sibling group before touching the map
+		bool source_in_siblings = false;
 		for (Entity s : siblings)
 		{
-			bool found = false;
-			for (Entity e : new_order) { if (e == s) { found = true; break; } }
-			if (!found) new_order.push_back(s);
+			if (s == source_entity) { source_in_siblings = true; break; }
 		}
-		order = new_order;
+		if (!source_in_siblings)
+			return;
+
+		// Build (or refresh) the ordered list for this parent, preserving existing custom order
+		wi::vector<Entity> new_order;
+		new_order.reserve(siblings.size());
+		{
+			// Build a lookup set so merging is O(n) not O(n²)
+			wi::unordered_set<Entity> sibling_set(siblings.begin(), siblings.end());
+			auto order_it = entity_user_order.find(parent_entity);
+			if (order_it != entity_user_order.end())
+			{
+				for (Entity e : order_it->second)
+				{
+					if (sibling_set.count(e)) { new_order.push_back(e); sibling_set.erase(e); }
+				}
+			}
+			for (Entity s : siblings)
+			{
+				if (sibling_set.count(s)) new_order.push_back(s);
+			}
+		}
+		if (siblings.empty())
+			entity_user_order.erase(parent_entity);
+		else
+			entity_user_order[parent_entity] = new_order;
+
+		wi::vector<Entity>& order = entity_user_order[parent_entity];
 
 		// Find which sibling is just above the drop point (same parent)
 		Entity entity_above = INVALID_ENTITY;
@@ -1484,21 +1506,26 @@ void ComponentsWindow::ApplyUserOrder(wi::vector<wi::ecs::Entity>& entities, wi:
 	wi::vector<Entity> result;
 	result.reserve(entities.size());
 
+	// Build lookup sets for O(1) membership checks
+	wi::unordered_set<Entity> entity_set(entities.begin(), entities.end());
+	wi::unordered_set<Entity> result_set;
+	result_set.reserve(entities.size());
+
 	// First, add entities that appear in the custom order (in that order)
 	for (Entity e : order)
 	{
-		for (Entity s : entities)
+		if (entity_set.count(e))
 		{
-			if (s == e) { result.push_back(e); break; }
+			result.push_back(e);
+			result_set.insert(e);
 		}
 	}
 
-	// Then append any new entities not yet in the custom order
+	// Then append any new entities not yet in the custom order, preserving original order
 	for (Entity s : entities)
 	{
-		bool found = false;
-		for (Entity e : result) { if (e == s) { found = true; break; } }
-		if (!found) result.push_back(s);
+		if (!result_set.count(s))
+			result.push_back(s);
 	}
 
 	entities = result;

--- a/Editor/ComponentsWindow.h
+++ b/Editor/ComponentsWindow.h
@@ -129,9 +129,11 @@ public:
 	wi::unordered_set<wi::ecs::Entity> entitytree_added_items;
 	wi::unordered_set<wi::ecs::Entity> entitytree_opened_items;
 	wi::ecs::Entity entitytree_pending_focus = wi::ecs::INVALID_ENTITY;
+	wi::unordered_map<wi::ecs::Entity, wi::vector<wi::ecs::Entity>> entity_user_order; // custom display order per parent (INVALID_ENTITY = top-level)
 	void PushToEntityTree(wi::ecs::Entity entity, int level);
 	void RefreshEntityTree();
 	bool CheckEntityFilter(wi::ecs::Entity entity) const;
+	void ApplyUserOrder(wi::vector<wi::ecs::Entity>& entities, wi::ecs::Entity parent_entity) const;
 
 private:
 	static int GetEntityTypePriority(wi::ecs::Entity entity, const wi::scene::Scene& scene);

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -5940,6 +5940,7 @@ if (onReorder && dragging && click_down)
     // Clamp to list area
     drag_indicator_y = std::max(drag_indicator_y, itemlist_box.pos.y);
     drag_indicator_y = std::min(drag_indicator_y, itemlist_box.pos.y + itemlist_box.siz.y - 2.0f);
+    drag_pointer_pos = pointerHitbox.pos;
 }
         }
 
@@ -6143,6 +6144,26 @@ if (state == IDLE && resize_blink_timer > 0)
 			);
 			fp.style = font.params.style;
 			wi::font::Draw(item.name, fp, cmd);
+			// Drag handle dots on the right side of each item
+			if (onReorder)
+			{
+				float ds = std::max(2.0f, std::round(item_height() * 0.12f));
+				float dg = ds * 1.5f;
+				float hx = name_box.pos.x + name_box.siz.x - ds * 2 - dg - ds;
+				float hy = name_box.pos.y + (name_box.siz.y - (ds * 3 + dg * 2)) * 0.5f;
+				XMFLOAT4 dot_color = drag_source == i ? sprites[ACTIVE].params.color : sprites[FOCUS].params.color;
+				if (drag_source != i)
+					dot_color.w *= 0.45f;
+				for (int row = 0; row < 3; ++row)
+				{
+					for (int col = 0; col < 2; ++col)
+					{
+						wi::image::Draw(nullptr,
+						    wi::image::Params(hx + col * (ds + dg), hy + row * (ds + dg), ds, ds, dot_color),
+						    cmd);
+					}
+				}
+			}
 		}
 
 		// Drop indicator line for drag-and-drop reorder
@@ -6152,6 +6173,30 @@ if (state == IDLE && resize_blink_timer > 0)
 			indicator_fx.pos = XMFLOAT3(itemlist_box.pos.x, drag_indicator_y - 1.0f, 0);
 			indicator_fx.siz = XMFLOAT2(itemlist_box.siz.x, 2.0f);
 			wi::image::Draw(nullptr, indicator_fx, cmd);
+		}
+		// Floating ghost: semi-transparent label following the cursor while dragging
+		if (dragging && drag_source >= 0 && drag_source < (int)items.size())
+		{
+			const Item& src_item = items[drag_source];
+			float ghost_h = item_height();
+			float ghost_w = itemlist_box.siz.x * 0.65f;
+			float ghost_x = drag_pointer_pos.x + 18.0f;
+			float ghost_y = drag_pointer_pos.y - ghost_h * 0.5f;
+			wi::image::Params ghost_bg = sprites[ACTIVE].params;
+			ghost_bg.pos = XMFLOAT3(ghost_x, ghost_y, 0);
+			ghost_bg.siz = XMFLOAT2(ghost_w, ghost_h);
+			ghost_bg.color.w *= 0.75f;
+			wi::image::Draw(nullptr, ghost_bg, cmd);
+			wi::font::Params gfp(
+				ghost_x + 6.0f,
+				ghost_y + ghost_h * 0.5f,
+				wi::font::WIFONTSIZE_DEFAULT,
+				wi::font::WIFALIGN_LEFT,
+				wi::font::WIFALIGN_CENTER,
+				font.params.color,
+				font.params.shadowColor);
+			gfp.style = font.params.style;
+			wi::font::Draw(src_item.name, gfp, cmd);
 		}
 	}
 	void TreeList::OnSelect(std::function<void(const EventArgs& args)> func)

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -5780,7 +5780,8 @@ namespace wi::gui
 				{
 					EventArgs args;
 					args.iValue = drag_source;
-					args.userdata = (uint64_t)drag_target;
+					args.iValue2 = drag_target;
+					args.userdata = items[drag_source].userdata;
 					onReorder(args);
 				}
 				dragging = false;
@@ -5892,58 +5893,57 @@ namespace wi::gui
 					}
 				}
 			}
-// Activate drag mode after movement threshold
-if (onReorder && drag_source >= 0 && click_down && !dragging)
-{
-float dx = pointerHitbox.pos.x - drag_start_pos.x;
-float dy = pointerHitbox.pos.y - drag_start_pos.y;
-if (dx * dx + dy * dy > 16.0f) // 4 px threshold
-{
-dragging = true;
-}
-}
+			// Activate drag mode after movement threshold
+			if (onReorder && drag_source >= 0 && click_down && !dragging)
+			{
+				float dx = pointerHitbox.pos.x - drag_start_pos.x;
+				float dy = pointerHitbox.pos.y - drag_start_pos.y;
+				if (dx * dx + dy * dy > 16.0f) // 4 px threshold
+				{
+					dragging = true;
+				}
+			}
 
-// Compute drag_target and drag_indicator_y while dragging
-if (onReorder && dragging && click_down)
-{
-    item_highlight = drag_source;
-    drag_target = (int)items.size(); // default: after all items
-    drag_indicator_y = 0;
+			// Compute drag_target and drag_indicator_y while dragging
+			if (onReorder && dragging && click_down)
+			{
+				item_highlight = drag_source;
+				drag_target = (int)items.size(); // default: after all items
+				drag_indicator_y = 0;
 
-    int dc = 0;
-    int dp = 0;
-    bool dpo = true;
-    int di = -1;
-    int last_visible = 0;
-    for (const Item &item : items)
-    {
-        di++;
-        if (!dpo && item.level > dp)
-            continue;
-        dc++;
-        dpo = item.open;
-        dp = item.level;
-        last_visible = dc;
+				int dc = 0;
+				int dp = 0;
+				bool dpo = true;
+				int di = -1;
+				int last_visible = 0;
+				for (const Item& item : items)
+				{
+					di++;
+					if (!dpo && item.level > dp)
+						continue;
+					dc++;
+					dpo = item.open;
+					dp = item.level;
+					last_visible = dc;
 
-        float item_top_y = translation.y + GetItemOffset(dc);
-        if (pointerHitbox.pos.y < item_top_y + item_height() * 0.5f)
-        {
-            drag_target = di;
-            drag_indicator_y = item_top_y;
-            break;
-        }
-    }
-    if (drag_target == (int)items.size())
-    {
-        drag_indicator_y = translation.y + GetItemOffset(last_visible) + item_height();
-    }
-    // Clamp to list area
-    drag_indicator_y = std::max(drag_indicator_y, itemlist_box.pos.y);
-    drag_indicator_y = std::min(drag_indicator_y, itemlist_box.pos.y + itemlist_box.siz.y - 2.0f);
-    drag_pointer_pos = pointerHitbox.pos;
-}
-        }
-
+					float item_top_y = translation.y + GetItemOffset(dc);
+					if (pointerHitbox.pos.y < item_top_y + item_height() * 0.5f)
+					{
+						drag_target = di;
+						drag_indicator_y = item_top_y;
+						break;
+					}
+				}
+				if (drag_target == (int)items.size())
+				{
+					drag_indicator_y = translation.y + GetItemOffset(last_visible) + item_height();
+				}
+				// Clamp to list area
+				drag_indicator_y = std::max(drag_indicator_y, itemlist_box.pos.y);
+				drag_indicator_y = std::min(drag_indicator_y, itemlist_box.pos.y + itemlist_box.siz.y - 2.0f);
+				drag_pointer_pos = pointerHitbox.pos;
+			}
+		}
 if (state == IDLE && resize_blink_timer > 0)
 			state = FOCUS;
 

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -5906,42 +5906,42 @@ dragging = true;
 // Compute drag_target and drag_indicator_y while dragging
 if (onReorder && dragging && click_down)
 {
-item_highlight = drag_source;
-drag_target = (int)items.size(); // default: after all items
-drag_indicator_y = 0;
+    item_highlight = drag_source;
+    drag_target = (int)items.size(); // default: after all items
+    drag_indicator_y = 0;
 
-int dc = 0;
-int dp = 0;
-bool dpo = true;
-int di = -1;
-int last_visible = 0;
-for (const Item& item : items)
-{
-di++;
-if (!dpo && item.level > dp)
-continue;
-dc++;
-dpo = item.open;
-dp = item.level;
-last_visible = dc;
+    int dc = 0;
+    int dp = 0;
+    bool dpo = true;
+    int di = -1;
+    int last_visible = 0;
+    for (const Item &item : items)
+    {
+        di++;
+        if (!dpo && item.level > dp)
+            continue;
+        dc++;
+        dpo = item.open;
+        dp = item.level;
+        last_visible = dc;
 
-float item_top_y = translation.y + GetItemOffset(dc);
-if (pointerHitbox.pos.y < item_top_y + item_height() * 0.5f)
-{
-drag_target = di;
-drag_indicator_y = item_top_y;
-break;
+        float item_top_y = translation.y + GetItemOffset(dc);
+        if (pointerHitbox.pos.y < item_top_y + item_height() * 0.5f)
+        {
+            drag_target = di;
+            drag_indicator_y = item_top_y;
+            break;
+        }
+    }
+    if (drag_target == (int)items.size())
+    {
+        drag_indicator_y = translation.y + GetItemOffset(last_visible) + item_height();
+    }
+    // Clamp to list area
+    drag_indicator_y = std::max(drag_indicator_y, itemlist_box.pos.y);
+    drag_indicator_y = std::min(drag_indicator_y, itemlist_box.pos.y + itemlist_box.siz.y - 2.0f);
 }
-}
-if (drag_target == (int)items.size())
-{
-drag_indicator_y = translation.y + GetItemOffset(last_visible) + item_height();
-}
-// Clamp to list area
-drag_indicator_y = std::max(drag_indicator_y, itemlist_box.pos.y);
-drag_indicator_y = std::min(drag_indicator_y, itemlist_box.pos.y + itemlist_box.siz.y - 2.0f);
-}
-}
+        }
 
 if (state == IDLE && resize_blink_timer > 0)
 			state = FOCUS;

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -5772,6 +5772,28 @@ namespace wi::gui
 
 			Hitbox2D itemlist_box = GetHitbox_ListArea();
 
+			// Finalize drag-and-drop when mouse is released
+			if (onReorder && dragging && !click_down)
+			{
+				if (drag_source >= 0 && drag_target >= 0 &&
+					drag_target != drag_source && drag_target != drag_source + 1)
+				{
+					EventArgs args;
+					args.iValue = drag_source;
+					args.userdata = (uint64_t)drag_target;
+					onReorder(args);
+				}
+				dragging = false;
+				drag_source = -1;
+				drag_target = -1;
+			}
+			if (!click_down && !clicked)
+			{
+				// Reset potential drag if mouse was released without dragging
+				if (!dragging)
+					drag_source = -1;
+			}
+
 			tooltipFont.text.clear();
 
 			// control-list
@@ -5825,6 +5847,13 @@ namespace wi::gui
 							SetTooltip(item.name);
 							if (clicked)
 							{
+								// Start potential drag (activated on movement threshold)
+								if (onReorder)
+								{
+									drag_source = i;
+									drag_start_pos = pointerHitbox.pos;
+								}
+
 								if (wi::input::IsDoubleClicked() && onDoubleClick != nullptr)
 								{
 									EventArgs args;
@@ -5863,9 +5892,58 @@ namespace wi::gui
 					}
 				}
 			}
-		}
+// Activate drag mode after movement threshold
+if (onReorder && drag_source >= 0 && click_down && !dragging)
+{
+float dx = pointerHitbox.pos.x - drag_start_pos.x;
+float dy = pointerHitbox.pos.y - drag_start_pos.y;
+if (dx * dx + dy * dy > 16.0f) // 4 px threshold
+{
+dragging = true;
+}
+}
 
-		if (state == IDLE && resize_blink_timer > 0)
+// Compute drag_target and drag_indicator_y while dragging
+if (onReorder && dragging && click_down)
+{
+item_highlight = drag_source;
+drag_target = (int)items.size(); // default: after all items
+drag_indicator_y = 0;
+
+int dc = 0;
+int dp = 0;
+bool dpo = true;
+int di = -1;
+int last_visible = 0;
+for (const Item& item : items)
+{
+di++;
+if (!dpo && item.level > dp)
+continue;
+dc++;
+dpo = item.open;
+dp = item.level;
+last_visible = dc;
+
+float item_top_y = translation.y + GetItemOffset(dc);
+if (pointerHitbox.pos.y < item_top_y + item_height() * 0.5f)
+{
+drag_target = di;
+drag_indicator_y = item_top_y;
+break;
+}
+}
+if (drag_target == (int)items.size())
+{
+drag_indicator_y = translation.y + GetItemOffset(last_visible) + item_height();
+}
+// Clamp to list area
+drag_indicator_y = std::max(drag_indicator_y, itemlist_box.pos.y);
+drag_indicator_y = std::min(drag_indicator_y, itemlist_box.pos.y + itemlist_box.siz.y - 2.0f);
+}
+}
+
+if (state == IDLE && resize_blink_timer > 0)
 			state = FOCUS;
 
 		sprites[state].params.siz.y = item_height();
@@ -6066,6 +6144,15 @@ namespace wi::gui
 			fp.style = font.params.style;
 			wi::font::Draw(item.name, fp, cmd);
 		}
+
+		// Drop indicator line for drag-and-drop reorder
+		if (dragging && drag_source >= 0 && drag_target >= 0)
+		{
+			wi::image::Params indicator_fx = sprites[ACTIVE].params;
+			indicator_fx.pos = XMFLOAT3(itemlist_box.pos.x, drag_indicator_y - 1.0f, 0);
+			indicator_fx.siz = XMFLOAT2(itemlist_box.siz.x, 2.0f);
+			wi::image::Draw(nullptr, indicator_fx, cmd);
+		}
 	}
 	void TreeList::OnSelect(std::function<void(const EventArgs& args)> func)
 	{
@@ -6078,6 +6165,10 @@ namespace wi::gui
 	void TreeList::OnDoubleClick(std::function<void(const EventArgs& args)> func)
 	{
 		onDoubleClick = std::move(func);
+	}
+	void TreeList::OnReorder(std::function<void(const EventArgs& args)> func)
+	{
+		onReorder = std::move(func);
 	}
 	void TreeList::AddItem(const Item& item)
 	{

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -5943,9 +5943,10 @@ namespace wi::gui
 				drag_indicator_y = std::min(drag_indicator_y, itemlist_box.pos.y + itemlist_box.siz.y - 2.0f);
 				drag_pointer_pos = pointerHitbox.pos;
 			}
+
+			if (state == IDLE && resize_blink_timer > 0)
+				state = FOCUS;
 		}
-if (state == IDLE && resize_blink_timer > 0)
-			state = FOCUS;
 
 		sprites[state].params.siz.y = item_height();
 		font.params.posX = translation.x + 2;

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -1051,6 +1051,14 @@ namespace wi::gui
 		XMFLOAT2 resize_begin = XMFLOAT2(0, 0);
 		float resize_blink_timer = 0;
 
+		// Drag-and-drop reorder state
+		std::function<void(const EventArgs& args)> onReorder;
+		int drag_source = -1;       // items[] index being dragged (-1 = none)
+		int drag_target = -1;       // items[] index to insert before (items.size() = end)
+		bool dragging = false;
+		XMFLOAT2 drag_start_pos = {};
+		float drag_indicator_y = 0; // screen Y for drop indicator line (updated in Update)
+
 		void ComputeScrollbarLength();
 
 	public:
@@ -1078,6 +1086,7 @@ namespace wi::gui
 		void OnSelect(std::function<void(const EventArgs& args)> func);
 		void OnDelete(std::function<void(const EventArgs& args)> func);
 		void OnDoubleClick(std::function<void(const EventArgs& args)> func);
+		void OnReorder(std::function<void(const EventArgs& args)> func);
 
 		ScrollBar scrollbar;
 	};

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -1057,8 +1057,8 @@ namespace wi::gui
 		int drag_target = -1;       // items[] index to insert before (items.size() = end)
 		bool dragging = false;
 		XMFLOAT2 drag_start_pos = {};
-		float drag_indicator_y = 0; // screen Y for drop indicator line (updated in Update)
-
+                float drag_indicator_y = 0;    // screen Y for drop indicator line (updated in Update)
+                XMFLOAT2 drag_pointer_pos = {}; // current pointer pos while dragging (for ghost rendering)
 		void ComputeScrollbarLength();
 
 	public:

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -25,6 +25,7 @@ namespace wi::gui
 		float fValue = 0;		// generic float value of operation
 		bool bValue = false;	// generic boolean value of operation
 		int iValue = 0;			// generic integer value of operation
+		int iValue2 = 0;		// secondary generic integer value of operation
 		wi::Color color;		// color value of color picker operation
 		std::string sValue;		// generic string value of operation
 		uint64_t userdata = 0;	// this will provide the userdata value that was set to a widget (or part of a widget)


### PR DESCRIPTION
- Extend wi::gui::TreeList with drag-and-drop support:
  - Track drag start on item click with 4px activation threshold
  - Compute drop target position and render a horizontal indicator line
  - Fire OnReorder callback with source/target indices on mouse release

- ComponentsWindow: maintain per-parent custom entity display order
  - entity_user_order stores custom ordering keyed by parent entity
  - ApplyUserOrder() applies stored order when sorting mode is None (0)
  - OnReorder callback reorders siblings and refreshes the tree
  - Auto-sorting modes (by name / by type) are unaffected

Fixes #1084