### PR TITLE
Fix/issue 1464 drag drop entities

### DIFF
--- a/Editor/ComponentsWindow.cpp
+++ b/Editor/ComponentsWindow.cpp
@@ -123,6 +123,58 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 		editor->FocusCameraOnSelected();
 		});
 	entityTree.OnReorder([this](wi::gui::EventArgs args) {
+		// Re-parent: drop ON another entity (bValue == true)
+		if (args.bValue)
+		{
+			int source_idx = args.iValue;
+			int target_idx = args.iValue2;
+			if (source_idx < 0 || source_idx >= entityTree.GetItemCount())
+				return;
+			if (target_idx < 0 || target_idx >= entityTree.GetItemCount())
+				return;
+
+			Scene& scene = editor->GetCurrentScene();
+			Entity source_entity = (Entity)entityTree.GetItem(source_idx).userdata;
+			Entity target_entity = (Entity)entityTree.GetItem(target_idx).userdata;
+
+			if (source_entity == target_entity)
+				return;
+
+			// Prevent circular hierarchy: target must not be a descendant of source
+			bool is_circular = false;
+			const HierarchyComponent* check = scene.hierarchy.GetComponent(target_entity);
+			while (check != nullptr)
+			{
+				if (check->parentID == source_entity)
+				{
+					is_circular = true;
+					break;
+				}
+				check = scene.hierarchy.GetComponent(check->parentID);
+			}
+			if (is_circular)
+				return;
+
+			// Skip if already a direct child of target
+			const HierarchyComponent* source_hier = scene.hierarchy.GetComponent(source_entity);
+			if (source_hier != nullptr && source_hier->parentID == target_entity)
+				return;
+
+			// Record undo history
+			wi::Archive& archive = editor->AdvanceHistory();
+			archive << EditorComponent::HISTORYOP_COMPONENT_DATA;
+			editor->RecordEntity(archive, source_entity);
+
+			scene.Component_Attach(source_entity, target_entity);
+
+			editor->RecordEntity(archive, source_entity);
+
+			// Expand the new parent so the dropped child is visible
+			entitytree_opened_items.insert(target_entity);
+			RefreshEntityTree();
+			return;
+		}
+
 		// Only apply custom ordering when sortingMode==0 and no text filter is active
 		if (editor->main->config.GetSection("options").GetInt("entity_tree_sorting") != 0)
 			return;

--- a/Editor/ComponentsWindow.cpp
+++ b/Editor/ComponentsWindow.cpp
@@ -130,11 +130,28 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 			int target_idx = args.iValue2;
 			if (source_idx < 0 || source_idx >= entityTree.GetItemCount())
 				return;
-			if (target_idx < 0 || target_idx >= entityTree.GetItemCount())
-				return;
 
 			Scene& scene = editor->GetCurrentScene();
 			Entity source_entity = (Entity)entityTree.GetItem(source_idx).userdata;
+
+			// Detach: dropped outside the list -> remove from parent
+			if (target_idx == -1)
+			{
+				const HierarchyComponent* source_hier2 = scene.hierarchy.GetComponent(source_entity);
+				if (source_hier2 == nullptr)
+					return; // already a root entity, nothing to do
+				wi::Archive& archive2 = editor->AdvanceHistory();
+				archive2 << EditorComponent::HISTORYOP_COMPONENT_DATA;
+				editor->RecordEntity(archive2, source_entity);
+				scene.Component_Detach(source_entity);
+				editor->RecordEntity(archive2, source_entity);
+				RefreshEntityTree();
+				return;
+			}
+
+			if (target_idx < 0 || target_idx >= entityTree.GetItemCount())
+				return;
+
 			Entity target_entity = (Entity)entityTree.GetItem(target_idx).userdata;
 
 			if (source_entity == target_entity)

--- a/Editor/ComponentsWindow.cpp
+++ b/Editor/ComponentsWindow.cpp
@@ -134,16 +134,26 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 			Scene& scene = editor->GetCurrentScene();
 			Entity source_entity = (Entity)entityTree.GetItem(source_idx).userdata;
 
-			// Detach: dropped outside the list -> remove from parent
+			// Dropped outside the widget -> go one level up in hierarchy
 			if (target_idx == -1)
 			{
 				const HierarchyComponent* source_hier2 = scene.hierarchy.GetComponent(source_entity);
 				if (source_hier2 == nullptr)
-					return; // already a root entity, nothing to do
+					return; // already root, nothing to do
+
+				// Find grandparent: parent's parent (INVALID_ENTITY if parent is root)
+				Entity grandparent = INVALID_ENTITY;
+				const HierarchyComponent* parent_hier = scene.hierarchy.GetComponent(source_hier2->parentID);
+				if (parent_hier != nullptr)
+					grandparent = parent_hier->parentID;
+
 				wi::Archive& archive2 = editor->AdvanceHistory();
 				archive2 << EditorComponent::HISTORYOP_COMPONENT_DATA;
 				editor->RecordEntity(archive2, source_entity);
-				scene.Component_Detach(source_entity);
+				if (grandparent != INVALID_ENTITY)
+					scene.Component_Attach(source_entity, grandparent); // one level up
+				else
+					scene.Component_Detach(source_entity); // already at depth 1, become root
 				editor->RecordEntity(archive2, source_entity);
 				RefreshEntityTree();
 				return;

--- a/Editor/ComponentsWindow.cpp
+++ b/Editor/ComponentsWindow.cpp
@@ -155,6 +155,7 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 				else
 					scene.Component_Detach(source_entity); // already at depth 1, become root
 				editor->RecordEntity(archive2, source_entity);
+				hierarchyWnd.SetEntity(source_entity);
 				RefreshEntityTree();
 				return;
 			}
@@ -195,6 +196,7 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 			scene.Component_Attach(source_entity, target_entity);
 
 			editor->RecordEntity(archive, source_entity);
+			hierarchyWnd.SetEntity(source_entity);
 
 			// Expand the new parent so the dropped child is visible
 			entitytree_opened_items.insert(target_entity);
@@ -215,36 +217,82 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 		if (target_idx < 0 || target_idx > entityTree.GetItemCount())
 			return;
 
-		const Scene& scene = editor->GetCurrentScene();
+		Scene& scene = editor->GetCurrentScene();
 		Entity source_entity = (Entity)entityTree.GetItem(source_idx).userdata;
 
-		// Determine parent entity of the source (INVALID_ENTITY = top-level)
-		Entity parent_entity = INVALID_ENTITY;
-		const HierarchyComponent* hier = scene.hierarchy.GetComponent(source_entity);
-		if (hier != nullptr && hier->parentID != INVALID_ENTITY && entitytree_temp_items.count(hier->parentID) != 0)
+		auto get_visible_parent = [&](Entity entity) {
+			const HierarchyComponent* hier = scene.hierarchy.GetComponent(entity);
+			if (hier != nullptr && hier->parentID != INVALID_ENTITY && entitytree_temp_items.count(hier->parentID) != 0)
+			{
+				return hier->parentID;
+			}
+			return INVALID_ENTITY;
+		};
+
+		auto is_descendant_of = [&](Entity entity, Entity potential_ancestor) {
+			const HierarchyComponent* check = scene.hierarchy.GetComponent(entity);
+			while (check != nullptr)
+			{
+				if (check->parentID == potential_ancestor)
+				{
+					return true;
+				}
+				check = scene.hierarchy.GetComponent(check->parentID);
+			}
+			return false;
+		};
+
+		auto collect_siblings = [&](Entity parent_entity) {
+			wi::vector<Entity> siblings;
+			if (parent_entity == INVALID_ENTITY)
+			{
+				for (auto& e : entitytree_temp_items)
+				{
+					if (get_visible_parent(e) == INVALID_ENTITY)
+						siblings.push_back(e);
+				}
+			}
+			else
+			{
+				for (size_t i = 0; i < scene.hierarchy.GetCount(); ++i)
+				{
+					if (scene.hierarchy[i].parentID == parent_entity)
+						siblings.push_back(scene.hierarchy.GetEntity(i));
+				}
+			}
+			return siblings;
+		};
+
+		auto remove_from_order = [&](Entity parent_entity, Entity entity) {
+			auto order_it = entity_user_order.find(parent_entity);
+			if (order_it == entity_user_order.end())
+				return;
+			wi::vector<Entity>& order = order_it->second;
+			order.erase(std::remove(order.begin(), order.end(), entity), order.end());
+			if (order.empty())
+				entity_user_order.erase(order_it);
+		};
+
+		Entity parent_entity = get_visible_parent(source_entity);
+		const int target_level = std::max(0, (int)args.fValue);
+		Entity target_parent_entity = INVALID_ENTITY;
+		if (target_level > 0)
 		{
-			parent_entity = hier->parentID;
+			for (int i = target_idx - 1; i >= 0; --i)
+			{
+				const wi::gui::TreeList::Item& item = entityTree.GetItem(i);
+				if (item.level == target_level - 1)
+				{
+					target_parent_entity = (Entity)item.userdata;
+					break;
+				}
+			}
 		}
 
-		// Collect all current siblings of source_entity
-		wi::vector<Entity> siblings;
-		if (parent_entity == INVALID_ENTITY)
-		{
-			for (auto& e : entitytree_temp_items)
-			{
-				const HierarchyComponent* h = scene.hierarchy.GetComponent(e);
-				if (h == nullptr || h->parentID == INVALID_ENTITY || entitytree_temp_items.count(h->parentID) == 0)
-					siblings.push_back(e);
-			}
-		}
-		else
-		{
-			for (size_t i = 0; i < scene.hierarchy.GetCount(); ++i)
-			{
-				if (scene.hierarchy[i].parentID == parent_entity)
-					siblings.push_back(scene.hierarchy.GetEntity(i));
-			}
-		}
+		if (target_parent_entity == source_entity || is_descendant_of(target_parent_entity, source_entity))
+			return;
+
+		wi::vector<Entity> siblings = collect_siblings(parent_entity);
 
 		// Validate that source_entity belongs to this sibling group before touching the map
 		bool source_in_siblings = false;
@@ -254,6 +302,26 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 		}
 		if (!source_in_siblings)
 			return;
+
+		if (parent_entity != target_parent_entity)
+		{
+			wi::Archive& archive = editor->AdvanceHistory();
+			archive << EditorComponent::HISTORYOP_COMPONENT_DATA;
+			editor->RecordEntity(archive, source_entity);
+
+			remove_from_order(parent_entity, source_entity);
+			if (target_parent_entity == INVALID_ENTITY)
+				scene.Component_Detach(source_entity);
+			else
+				scene.Component_Attach(source_entity, target_parent_entity);
+
+			editor->RecordEntity(archive, source_entity);
+			hierarchyWnd.SetEntity(source_entity);
+			if (target_parent_entity != INVALID_ENTITY)
+				entitytree_opened_items.insert(target_parent_entity);
+			parent_entity = target_parent_entity;
+			siblings = collect_siblings(parent_entity);
+		}
 
 		// Build (or refresh) the ordered list for this parent, preserving existing custom order
 		wi::vector<Entity> new_order;
@@ -285,11 +353,13 @@ void ComponentsWindow::Create(EditorComponent* _editor)
 		Entity entity_above = INVALID_ENTITY;
 		for (int i = target_idx - 1; i >= 0; --i)
 		{
-			Entity e = (Entity)entityTree.GetItem(i).userdata;
-			const HierarchyComponent* h = scene.hierarchy.GetComponent(e);
-			Entity p = (h != nullptr && h->parentID != INVALID_ENTITY && entitytree_temp_items.count(h->parentID) != 0)
-				? h->parentID : INVALID_ENTITY;
-			if (p == parent_entity)
+			const wi::gui::TreeList::Item& item = entityTree.GetItem(i);
+			if (item.level != target_level)
+				continue;
+			Entity e = (Entity)item.userdata;
+			if (e == source_entity)
+				continue;
+			if (get_visible_parent(e) == parent_entity)
 			{
 				entity_above = e;
 				break;

--- a/Editor/HierarchyWindow.cpp
+++ b/Editor/HierarchyWindow.cpp
@@ -64,8 +64,6 @@ void HierarchyWindow::Create(EditorComponent* _editor)
 
 void HierarchyWindow::SetEntity(Entity entity)
 {
-	if (this->entity == entity)
-		return;
 	this->entity = entity;
 
 	const Scene& scene = editor->GetCurrentScene();

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -5787,9 +5787,9 @@ namespace wi::gui
 						args.bValue = true;
 						onReorder(args);
 					}
-					else if (!itemlist_box.intersects(pointerHitbox))
+					else if (!hitbox.intersects(GetPointerHitbox(false)))
 					{
-						// Detach: dropped outside the list area -> remove from parent
+						// Dropped outside the widget -> go one level up in hierarchy
 						EventArgs args;
 						args.iValue = drag_source;
 						args.iValue2 = -1;

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -5775,18 +5775,34 @@ namespace wi::gui
 			// Finalize drag-and-drop when mouse is released
 			if (onReorder && dragging && !click_down)
 			{
-				if (drag_source >= 0 && drag_target >= 0 &&
-					drag_target != drag_source && drag_target != drag_source + 1)
+				if (drag_source >= 0)
 				{
-					EventArgs args;
-					args.iValue = drag_source;
-					args.iValue2 = drag_target;
-					args.userdata = items[drag_source].userdata;
-					onReorder(args);
+					if (drag_reparent_target >= 0 && drag_reparent_target != drag_source)
+					{
+						// Re-parent: drop ON another item
+						EventArgs args;
+						args.iValue = drag_source;
+						args.iValue2 = drag_reparent_target;
+						args.userdata = items[drag_source].userdata;
+						args.bValue = true;
+						onReorder(args);
+					}
+					else if (drag_reparent_target < 0 && drag_target >= 0 &&
+						drag_target != drag_source && drag_target != drag_source + 1)
+					{
+						// Reorder: drop BETWEEN items
+						EventArgs args;
+						args.iValue = drag_source;
+						args.iValue2 = drag_target;
+						args.userdata = items[drag_source].userdata;
+						args.bValue = false;
+						onReorder(args);
+					}
 				}
 				dragging = false;
 				drag_source = -1;
 				drag_target = -1;
+				drag_reparent_target = -1;
 			}
 			if (!click_down && !clicked)
 			{
@@ -5904,11 +5920,12 @@ namespace wi::gui
 				}
 			}
 
-			// Compute drag_target and drag_indicator_y while dragging
+			// Compute drag_target, drag_reparent_target, and drag_indicator_y while dragging
 			if (onReorder && dragging && click_down)
 			{
 				item_highlight = drag_source;
-				drag_target = (int)items.size(); // default: after all items
+				drag_target = (int)items.size(); // default: insert after all items
+				drag_reparent_target = -1;
 				drag_indicator_y = 0;
 
 				int dc = 0;
@@ -5927,20 +5944,45 @@ namespace wi::gui
 					last_visible = dc;
 
 					float item_top_y = translation.y + GetItemOffset(dc);
-					if (pointerHitbox.pos.y < item_top_y + item_height() * 0.5f)
+					float item_bot_y = item_top_y + item_height();
+					if (pointerHitbox.pos.y < item_top_y + item_height() * 0.25f)
 					{
+						// Top 25%: insert BEFORE this item
 						drag_target = di;
+						drag_reparent_target = -1;
 						drag_indicator_y = item_top_y;
 						break;
 					}
+					else if (pointerHitbox.pos.y < item_bot_y - item_height() * 0.25f)
+					{
+						// Middle 50%: drop ON this item (re-parent)
+						if (di != drag_source)
+						{
+							drag_reparent_target = di;
+							drag_target = (int)items.size();
+							drag_indicator_y = 0;
+						}
+						break;
+					}
+					else if (pointerHitbox.pos.y < item_bot_y)
+					{
+						// Bottom 25%: insert AFTER this item
+						drag_target = di + 1;
+						drag_reparent_target = -1;
+						drag_indicator_y = item_bot_y;
+						break;
+					}
 				}
-				if (drag_target == (int)items.size())
+				if (drag_reparent_target < 0 && drag_target == (int)items.size())
 				{
 					drag_indicator_y = translation.y + GetItemOffset(last_visible) + item_height();
 				}
-				// Clamp to list area
-				drag_indicator_y = std::max(drag_indicator_y, itemlist_box.pos.y);
-				drag_indicator_y = std::min(drag_indicator_y, itemlist_box.pos.y + itemlist_box.siz.y - 2.0f);
+				// Clamp indicator line to list area (only when not re-parenting)
+				if (drag_reparent_target < 0)
+				{
+					drag_indicator_y = std::max(drag_indicator_y, itemlist_box.pos.y);
+					drag_indicator_y = std::min(drag_indicator_y, itemlist_box.pos.y + itemlist_box.siz.y - 2.0f);
+				}
 				drag_pointer_pos = pointerHitbox.pos;
 			}
 
@@ -6109,6 +6151,16 @@ namespace wi::gui
 						sprites[item.selected ? FOCUS : IDLE].params.color), cmd);
 			}
 
+			// Re-parent drop target highlight
+			if (drag_reparent_target == i)
+			{
+				wi::image::Params rp_fx = sprites[ACTIVE].params;
+				rp_fx.pos = XMFLOAT3(name_box.pos.x, name_box.pos.y, 0);
+				rp_fx.siz = XMFLOAT2(name_box.siz.x, name_box.siz.y);
+				rp_fx.color.w *= 0.5f;
+				wi::image::Draw(nullptr, rp_fx, cmd);
+			}
+
 			// opened flag triangle:
 			if(DoesItemHaveChildren(i))
 			{
@@ -6167,8 +6219,8 @@ namespace wi::gui
 			}
 		}
 
-		// Drop indicator line for drag-and-drop reorder
-		if (dragging && drag_source >= 0 && drag_target >= 0)
+		// Drop indicator line for drag-and-drop reorder (not shown when re-parenting)
+		if (dragging && drag_source >= 0 && drag_target >= 0 && drag_reparent_target < 0)
 		{
 			wi::image::Params indicator_fx = sprites[ACTIVE].params;
 			indicator_fx.pos = XMFLOAT3(itemlist_box.pos.x, drag_indicator_y - 1.0f, 0);

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -5787,6 +5787,16 @@ namespace wi::gui
 						args.bValue = true;
 						onReorder(args);
 					}
+					else if (!itemlist_box.intersects(pointerHitbox))
+					{
+						// Detach: dropped outside the list area -> remove from parent
+						EventArgs args;
+						args.iValue = drag_source;
+						args.iValue2 = -1;
+						args.userdata = items[drag_source].userdata;
+						args.bValue = true;
+						onReorder(args);
+					}
 					else if (drag_reparent_target < 0 && drag_target >= 0 &&
 						drag_target != drag_source && drag_target != drag_source + 1)
 					{

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -5993,6 +5993,7 @@ namespace wi::gui
 						else
 						{
 							drag_target = drag_source;
+							drag_target_level = item.level;
 							drag_indicator_y = 0;
 						}
 						break;

--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -5798,12 +5798,14 @@ namespace wi::gui
 						onReorder(args);
 					}
 					else if (drag_reparent_target < 0 && drag_target >= 0 &&
-						drag_target != drag_source && drag_target != drag_source + 1)
+						((drag_target != drag_source && drag_target != drag_source + 1) ||
+							(drag_source >= 0 && drag_source < (int)items.size() && drag_target_level != items[drag_source].level)))
 					{
 						// Reorder: drop BETWEEN items
 						EventArgs args;
 						args.iValue = drag_source;
 						args.iValue2 = drag_target;
+						args.fValue = (float)drag_target_level;
 						args.userdata = items[drag_source].userdata;
 						args.bValue = false;
 						onReorder(args);
@@ -5813,6 +5815,7 @@ namespace wi::gui
 				drag_source = -1;
 				drag_target = -1;
 				drag_reparent_target = -1;
+				drag_target_level = 0;
 			}
 			if (!click_down && !clicked)
 			{
@@ -5936,13 +5939,25 @@ namespace wi::gui
 				item_highlight = drag_source;
 				drag_target = (int)items.size(); // default: insert after all items
 				drag_reparent_target = -1;
+				drag_target_level = 0;
 				drag_indicator_y = 0;
+				auto compute_drag_target_level = [&](int max_level) {
+					int source_level = 0;
+					if (drag_source >= 0 && drag_source < (int)items.size())
+					{
+						source_level = items[drag_source].level;
+					}
+					const float level_delta = (pointerHitbox.pos.x - drag_start_pos.x) / item_height();
+					const int level = source_level + (int)std::round(level_delta);
+					return std::max(0, std::min(level, max_level));
+				};
 
 				int dc = 0;
 				int dp = 0;
 				bool dpo = true;
 				int di = -1;
 				int last_visible = 0;
+				int last_visible_level = 0;
 				for (const Item& item : items)
 				{
 					di++;
@@ -5952,6 +5967,7 @@ namespace wi::gui
 					dpo = item.open;
 					dp = item.level;
 					last_visible = dc;
+					last_visible_level = item.level;
 
 					float item_top_y = translation.y + GetItemOffset(dc);
 					float item_bot_y = item_top_y + item_height();
@@ -5960,6 +5976,7 @@ namespace wi::gui
 						// Top 25%: insert BEFORE this item
 						drag_target = di;
 						drag_reparent_target = -1;
+						drag_target_level = item.level;
 						drag_indicator_y = item_top_y;
 						break;
 					}
@@ -5970,6 +5987,12 @@ namespace wi::gui
 						{
 							drag_reparent_target = di;
 							drag_target = (int)items.size();
+							drag_target_level = item.level + 1;
+							drag_indicator_y = 0;
+						}
+						else
+						{
+							drag_target = drag_source;
 							drag_indicator_y = 0;
 						}
 						break;
@@ -5979,12 +6002,14 @@ namespace wi::gui
 						// Bottom 25%: insert AFTER this item
 						drag_target = di + 1;
 						drag_reparent_target = -1;
+						drag_target_level = item.level;
 						drag_indicator_y = item_bot_y;
 						break;
 					}
 				}
 				if (drag_reparent_target < 0 && drag_target == (int)items.size())
 				{
+					drag_target_level = compute_drag_target_level(last_visible_level);
 					drag_indicator_y = translation.y + GetItemOffset(last_visible) + item_height();
 				}
 				// Clamp indicator line to list area (only when not re-parenting)
@@ -6233,8 +6258,9 @@ namespace wi::gui
 		if (dragging && drag_source >= 0 && drag_target >= 0 && drag_reparent_target < 0)
 		{
 			wi::image::Params indicator_fx = sprites[ACTIVE].params;
-			indicator_fx.pos = XMFLOAT3(itemlist_box.pos.x, drag_indicator_y - 1.0f, 0);
-			indicator_fx.siz = XMFLOAT2(itemlist_box.siz.x, 2.0f);
+			const float indicator_indent = std::max(0, drag_target_level) * item_height();
+			indicator_fx.pos = XMFLOAT3(itemlist_box.pos.x + indicator_indent, drag_indicator_y - 1.0f, 0);
+			indicator_fx.siz = XMFLOAT2(std::max(2.0f, itemlist_box.siz.x - indicator_indent), 2.0f);
 			wi::image::Draw(nullptr, indicator_fx, cmd);
 		}
 		// Floating ghost: semi-transparent label following the cursor while dragging

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -1054,8 +1054,9 @@ namespace wi::gui
 
 		// Drag-and-drop reorder state
 		std::function<void(const EventArgs& args)> onReorder;
-		int drag_source = -1;       // items[] index being dragged (-1 = none)
-		int drag_target = -1;       // items[] index to insert before (items.size() = end)
+		int drag_source = -1;           // items[] index being dragged (-1 = none)
+		int drag_target = -1;           // items[] index to insert before (items.size() = end)
+		int drag_reparent_target = -1;  // items[] index to drop ON (re-parent), -1 = none
 		bool dragging = false;
 		XMFLOAT2 drag_start_pos = {};
                 float drag_indicator_y = 0;    // screen Y for drop indicator line (updated in Update)

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -1057,6 +1057,7 @@ namespace wi::gui
 		int drag_source = -1;           // items[] index being dragged (-1 = none)
 		int drag_target = -1;           // items[] index to insert before (items.size() = end)
 		int drag_reparent_target = -1;  // items[] index to drop ON (re-parent), -1 = none
+		int drag_target_level = 0;      // item level for BETWEEN drops (0 = root)
 		bool dragging = false;
 		XMFLOAT2 drag_start_pos = {};
                 float drag_indicator_y = 0;    // screen Y for drop indicator line (updated in Update)


### PR DESCRIPTION
Extend wi::gui::TreeList drag-and-drop with hierarchy re-parenting:

Track drop-on item targets separately from between-item reorder targets
Use a three-zone item drop area:
- top: insert before item
- middle: re-parent as child of item
- bottom: insert after item
Track target hierarchy level for between-item drops and draw the indicator at that level
Allow child entities to be moved up one level by dragging to the indicated outdent line
Avoid treating level-changing drops as no-op reorders

ComponentsWindow: apply hierarchy changes from tree drag-and-drop:

Drop-on attaches the dragged entity to the target entity
Between-item drops reorder within the resolved parent/sibling group
Between-item outdent drops detach or attach to the resolved parent level
Prevent circular hierarchy drops
Skip no-op direct-child reattachments
Record hierarchy changes in undo/redo history
Auto-expand newly assigned parent nodes after drop

HierarchyWindow: refresh parent display after drag-and-drop:

Rebuild the parent combo even when the selected entity stays the same
Keep the Hierarchy component parent field in sync after tree re-parenting

Fixes #1464