### PR TITLE
add deprecated attribute

### DIFF
--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -21,6 +21,14 @@
 #define NO_SANITIZE(x)
 #endif // defined(__GNUC__) || defined(__clang__)
 
+#ifdef _MSC_VER
+#define WI_DISABLE_DEPRECATED_BEGIN __pragma(warning(push)) __pragma(warning(disable: 4996))
+#define WI_DISABLE_DEPRECATED_END __pragma(warning(pop))
+#else
+#define WI_DISABLE_DEPRECATED_BEGIN _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define WI_DISABLE_DEPRECATED_END _Pragma("GCC diagnostic pop")
+#endif // _MSC_VER
+
 // Simple common math helpers:
 
 template<typename T>

--- a/WickedEngine/wiGraphics.h
+++ b/WickedEngine/wiGraphics.h
@@ -2049,7 +2049,7 @@ namespace wi::graphics
 
 
 	// Deprecated, kept for back-compat:
-	struct RenderPassAttachment
+	struct [[deprecated]] RenderPassAttachment
 	{
 		enum class Type
 		{
@@ -2240,7 +2240,7 @@ namespace wi::graphics
 		}
 	};
 	// Deprecated, kept for back-compat:
-	struct RenderPassDesc
+	struct [[deprecated]] RenderPassDesc
 	{
 		enum class Flags
 		{
@@ -2248,10 +2248,12 @@ namespace wi::graphics
 			ALLOW_UAV_WRITES = 1 << 0,
 		};
 		Flags flags = Flags::EMPTY;
+		WI_DISABLE_DEPRECATED_BEGIN
 		wi::vector<RenderPassAttachment> attachments;
+		WI_DISABLE_DEPRECATED_END
 	};
 	// Deprecated, kept for back-compat:
-	struct RenderPass
+	struct [[deprecated]] RenderPass
 	{
 		bool valid = false;
 		RenderPassDesc desc;

--- a/WickedEngine/wiGraphicsDevice.h
+++ b/WickedEngine/wiGraphicsDevice.h
@@ -422,6 +422,7 @@ namespace wi::graphics
 		}
 
 		// Deprecated, kept for back-compat:
+		[[deprecated]]
 		bool CreateRenderPass(const RenderPassDesc* desc, RenderPass* renderpass) const
 		{
 			renderpass->valid = true;
@@ -429,6 +430,7 @@ namespace wi::graphics
 			return true;
 		}
 		// Deprecated, kept for back-compat:
+		[[deprecated]]
 		void RenderPassBegin(const RenderPass* renderpass, CommandList cmd)
 		{
 			RenderPassFlags flags = {};


### PR DESCRIPTION
Add `[[ deprecated ]]` to deprecated stuff so the IDE will warn.

The `WI_DISABLE_DEPRECATED` macro is not strictly necessary, as we only need it in one place, but it might be used more than once in the future; without it, we'd still need the `#ifdef` and `#pragma`s at that one location to prevent a warning, so we don't save any LOC.