### PR TITLE
Editor: additional screenshot modes

### DIFF
--- a/Content/Documentation/ScriptingAPI-Documentation.md
+++ b/Content/Documentation/ScriptingAPI-Documentation.md
@@ -146,6 +146,7 @@ The scripting API provides some functions which manipulate the BackLog. These fu
 This is the graphics renderer, which is also responsible for managing the scene graph which consists of keeping track of
 parent-child relationships between the scene hierarchy, updating the world, animating armatures.
 You can use the Renderer with the following functions, all of which are in the global scope:
+- SetDebugDrawEnabled(bool value)	-- Toggle debug draw by renderer on/off
 - GetGameSpeed() : float result
 - SetGameSpeed(float speed)
 - IsRaytracingSupported() : bool	-- check whether graphics device supports hardware accelerated ray tracing features

--- a/Editor/DummyVisualizer.cpp
+++ b/Editor/DummyVisualizer.cpp
@@ -69,6 +69,8 @@ void DummyVisualizer::Draw(
 
 	device->BindPipelineState(&pso[depth], cmd);
 
+	device->BindStencilRef(wi::enums::STENCILREF_DEFAULT, cmd);
+
 	MiscCB sb;
 	XMStoreFloat4x4(&sb.g_xTransform, matrix);
 	sb.g_xColor = color;

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -1669,23 +1669,23 @@ void EditorComponent::Update(float dt)
 	}
 
 	// screenshot is done next frame update to capture current frame render and the alpha modes also disable debug draw for just this frame
-	if (CheckInput(EditorActions::SCREENSHOT))
-	{
-		screenshot = true;
-	}
-	if (CheckInput(EditorActions::SCREENSHOT_NOGUI))
+	if (CheckInput(EditorActions::SCREENSHOT_NOGUI)) // shift priority
 	{
 		screenshot_nogui = true;
 		wi::renderer::SetDebugDrawEnabled(false);
 	}
-	if (CheckInput(EditorActions::SCREENSHOT_ALPHA))
-	{
-		screenshot_alpha = true;
-		wi::renderer::SetDebugDrawEnabled(false);
-	}
-	if (CheckInput(EditorActions::SCREENSHOT_ALPHA_SELECTION))
+	else if (CheckInput(EditorActions::SCREENSHOT_ALPHA_SELECTION)) // shift priority
 	{
 		screenshot_alpha_selection = true;
+		wi::renderer::SetDebugDrawEnabled(false);
+	}
+	else if (CheckInput(EditorActions::SCREENSHOT))
+	{
+		screenshot = true;
+	}
+	else if (CheckInput(EditorActions::SCREENSHOT_ALPHA))
+	{
+		screenshot_alpha = true;
 		wi::renderer::SetDebugDrawEnabled(false);
 	}
 

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -146,7 +146,7 @@ HotkeyInfo hotkeyActions[size_t(EditorActions::COUNT)] = {
 	{wi::input::BUTTON('4'),					/*press=*/ true,		/*control=*/ false,		/*shift=*/ false},	//LOCAL_GLOBAL_TOGGLE_ACTION,
 	{wi::input::BUTTON::KEYBOARD_BUTTON_F3,		/*press=*/ true,		/*control=*/ false,		/*shift=*/ false},	//SCREENSHOT,
 	{wi::input::BUTTON::KEYBOARD_BUTTON_F4,		/*press=*/ true,		/*control=*/ false,		/*shift=*/ false},	//SCREENSHOT_ALPHA,
-	{wi::input::BUTTON::KEYBOARD_BUTTON_F5,		/*press=*/ true,		/*control=*/ false,		/*shift=*/ false},	//SCREENSHOT_ALPHA_SELECTION,
+	{wi::input::BUTTON::KEYBOARD_BUTTON_F4,		/*press=*/ true,		/*control=*/ false,		/*shift=*/ true},	//SCREENSHOT_ALPHA_SELECTION,
 	{wi::input::BUTTON('I'),					/*press=*/ false,		/*control=*/ false,		/*shift=*/ false},	//INSPECTOR_MODE,
 	{wi::input::BUTTON::MOUSE_BUTTON_LEFT,		/*press=*/ true,		/*control=*/ true,		/*shift=*/ true},	//PLACE_INSTANCES,
 	{wi::input::BUTTON('S'),					/*press=*/ true,		/*control=*/ true,		/*shift=*/ true},	//SAVE_SCENE_AS,
@@ -1381,7 +1381,7 @@ void EditorComponent::Load()
 		ss += "Wireframe mode: " + GetInputString(EditorActions::WIREFRAME_MODE) + "\n";
 		ss += "Screenshot (saved into Editor's screenshots folder): " + GetInputString(EditorActions::SCREENSHOT) + "\n";
 		ss += "Screenshot with background as transparency (saved into Editor's screenshots folder): " + GetInputString(EditorActions::SCREENSHOT_ALPHA) + "\n";
-		ss += "Screenshot selection with everything else as transparency (saved into Editor's screenshots folder): " + GetInputString(EditorActions::SCREENSHOT_ALPHA) + "\n";
+		ss += "Screenshot selection with everything else as transparency (saved into Editor's screenshots folder): " + GetInputString(EditorActions::SCREENSHOT_ALPHA_SELECTION) + "\n";
 		ss += "Depth of field refocus to point: " + GetInputString(EditorActions::DEPTH_OF_FIELD_REFOCUS_TO_POINT) + " + left mouse button" + "\n";
 		ss += "Color grading reference: " + GetInputString(EditorActions::COLOR_GRADING_REFERENCE) + " (color grading palette reference will be displayed in top left corner)\n";
 		ss += "Focus on selected: " + GetInputString(EditorActions::FOCUS_ON_SELECTION) + " button, this will make the camera jump to selection.\n";

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -88,6 +88,7 @@ enum class EditorActions
 	// Engine actions
 	SCREENSHOT,
 	SCREENSHOT_ALPHA,
+	SCREENSHOT_ALPHA_SELECTION,
 	INSPECTOR_MODE,
 	PLACE_INSTANCES,
 
@@ -145,6 +146,7 @@ HotkeyInfo hotkeyActions[size_t(EditorActions::COUNT)] = {
 	{wi::input::BUTTON('4'),					/*press=*/ true,		/*control=*/ false,		/*shift=*/ false},	//LOCAL_GLOBAL_TOGGLE_ACTION,
 	{wi::input::BUTTON::KEYBOARD_BUTTON_F3,		/*press=*/ true,		/*control=*/ false,		/*shift=*/ false},	//SCREENSHOT,
 	{wi::input::BUTTON::KEYBOARD_BUTTON_F4,		/*press=*/ true,		/*control=*/ false,		/*shift=*/ false},	//SCREENSHOT_ALPHA,
+	{wi::input::BUTTON::KEYBOARD_BUTTON_F5,		/*press=*/ true,		/*control=*/ false,		/*shift=*/ false},	//SCREENSHOT_ALPHA_SELECTION,
 	{wi::input::BUTTON('I'),					/*press=*/ false,		/*control=*/ false,		/*shift=*/ false},	//INSPECTOR_MODE,
 	{wi::input::BUTTON::MOUSE_BUTTON_LEFT,		/*press=*/ true,		/*control=*/ true,		/*shift=*/ true},	//PLACE_INSTANCES,
 	{wi::input::BUTTON('S'),					/*press=*/ true,		/*control=*/ true,		/*shift=*/ true},	//SAVE_SCENE_AS,
@@ -222,6 +224,7 @@ void HotkeyRemap(Editor* main)
 		{"LOCAL_GLOBAL_TOGGLE_ACTION", EditorActions::LOCAL_GLOBAL_TOGGLE_ACTION},
 		{"MAKE_NEW_SCREENSHOT", EditorActions::SCREENSHOT},
 		{"MAKE_NEW_SCREENSHOT_ALPHA", EditorActions::SCREENSHOT_ALPHA},
+		{"MAKE_NEW_SCREENSHOT_ALPHA_SELECTION", EditorActions::SCREENSHOT_ALPHA_SELECTION},
 		{"INSPECTOR_MODE", EditorActions::INSPECTOR_MODE},
 		{"PLACE_INSTANCES", EditorActions::PLACE_INSTANCES},
 		{"SAVE_SCENE_AS", EditorActions::SAVE_SCENE_AS},
@@ -1377,7 +1380,8 @@ void EditorComponent::Load()
 		ss += "Reload terrain props: " + GetInputString(EditorActions::RELOAD_TERRAIN_PROPS) + "\n";
 		ss += "Wireframe mode: " + GetInputString(EditorActions::WIREFRAME_MODE) + "\n";
 		ss += "Screenshot (saved into Editor's screenshots folder): " + GetInputString(EditorActions::SCREENSHOT) + "\n";
-		ss += "Screenshot with background as alpha (saved into Editor's screenshots folder): " + GetInputString(EditorActions::SCREENSHOT_ALPHA) + "\n";
+		ss += "Screenshot with background as transparency (saved into Editor's screenshots folder): " + GetInputString(EditorActions::SCREENSHOT_ALPHA) + "\n";
+		ss += "Screenshot selection with everything else as transparency (saved into Editor's screenshots folder): " + GetInputString(EditorActions::SCREENSHOT_ALPHA) + "\n";
 		ss += "Depth of field refocus to point: " + GetInputString(EditorActions::DEPTH_OF_FIELD_REFOCUS_TO_POINT) + " + left mouse button" + "\n";
 		ss += "Color grading reference: " + GetInputString(EditorActions::COLOR_GRADING_REFERENCE) + " (color grading palette reference will be displayed in top left corner)\n";
 		ss += "Focus on selected: " + GetInputString(EditorActions::FOCUS_ON_SELECTION) + " button, this will make the camera jump to selection.\n";
@@ -1602,31 +1606,9 @@ void EditorComponent::Update(float dt)
 
 	main->canvas.scaling = float(guiScalingCombo.GetSelectedUserdata()) / 100.0f;
 
-	if (CheckInput(EditorActions::SCREENSHOT))
+	if (CheckInput(EditorActions::SCREENSHOT_ALPHA) || CheckInput(EditorActions::SCREENSHOT_ALPHA_SELECTION))
 	{
-		std::string filename = wi::helper::screenshot(main->swapChain);
-		PostSaveText(filename);
-		if (filename.empty())
-		{
-			PostSaveText("Error! Screenshot was not successful!");
-		}
-		else
-		{
-			PostSaveText("Screenshot saved: ", filename);
-		}
-	}
-	if (CheckInput(EditorActions::SCREENSHOT_ALPHA))
-	{
-		std::string filename = wi::helper::screenshot(renderPath->CreateScreenshotWithAlphaBackground());
-		PostSaveText(filename);
-		if (filename.empty())
-		{
-			PostSaveText("Error! Screenshot was not successful!");
-		}
-		else
-		{
-			PostSaveText("Screenshot saved: ", filename);
-		}
+		wi::renderer::SetDebugDrawEnabled(false);
 	}
 
 	loadmodel_font.SetHidden(!wi::jobsystem::IsBusy(loadmodel_workload));
@@ -4718,6 +4700,47 @@ void EditorComponent::Render() const
 
 	RenderPath2D::Render();
 
+	// screenshot is done after render to capture most current state and the alpha modes also disable debug draw for just this frame
+	if (CheckInput(EditorActions::SCREENSHOT))
+	{
+		std::string filename = wi::helper::screenshot(main->swapChain);
+		PostSaveText(filename);
+		if (filename.empty())
+		{
+			PostSaveText("Error! Screenshot was not successful!");
+		}
+		else
+		{
+			PostSaveText("Screenshot saved: ", filename);
+		}
+	}
+	if (CheckInput(EditorActions::SCREENSHOT_ALPHA))
+	{
+		std::string filename = wi::helper::screenshot(renderPath->CreateScreenshotWithAlphaBackground());
+		PostSaveText(filename);
+		if (filename.empty())
+		{
+			PostSaveText("Error! Screenshot was not successful!");
+		}
+		else
+		{
+			PostSaveText("Screenshot saved: ", filename);
+		}
+	}
+	if (CheckInput(EditorActions::SCREENSHOT_ALPHA_SELECTION))
+	{
+		std::string filename = wi::helper::screenshot(renderPath->CreateScreenshotWithAlphaBackground(EDITORSTENCILREF_HIGHLIGHT_OBJECT, wi::image::STENCILMODE_EQUAL, wi::image::STENCILREFMODE_USER));
+		PostSaveText(filename);
+		if (filename.empty())
+		{
+			PostSaveText("Error! Screenshot was not successful!");
+		}
+		else
+		{
+			PostSaveText("Screenshot saved: ", filename);
+		}
+	}
+	wi::renderer::SetDebugDrawEnabled(true);
 }
 void EditorComponent::Compose(CommandList cmd) const
 {
@@ -5889,7 +5912,7 @@ bool EditorComponent::SetupThumbnailCamera(wi::RenderPath3D& thumbnailRenderPath
 	return true;
 }
 
-void EditorComponent::PostSaveText(const std::string& message, const std::string& filename, float time_seconds)
+void EditorComponent::PostSaveText(const std::string& message, const std::string& filename, float time_seconds) const
 {
 	save_text_message = message;
 	save_text_filename = filename;

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -87,6 +87,7 @@ enum class EditorActions
 
 	// Engine actions
 	SCREENSHOT,
+	SCREENSHOT_NOGUI,
 	SCREENSHOT_ALPHA,
 	SCREENSHOT_ALPHA_SELECTION,
 	INSPECTOR_MODE,
@@ -145,6 +146,7 @@ HotkeyInfo hotkeyActions[size_t(EditorActions::COUNT)] = {
 	{wi::input::BUTTON('3'),					/*press=*/ true,		/*control=*/ false,		/*shift=*/ false},	//SCALE_TOGGLE_ACTION,
 	{wi::input::BUTTON('4'),					/*press=*/ true,		/*control=*/ false,		/*shift=*/ false},	//LOCAL_GLOBAL_TOGGLE_ACTION,
 	{wi::input::BUTTON::KEYBOARD_BUTTON_F3,		/*press=*/ true,		/*control=*/ false,		/*shift=*/ false},	//SCREENSHOT,
+	{wi::input::BUTTON::KEYBOARD_BUTTON_F3,		/*press=*/ true,		/*control=*/ false,		/*shift=*/ true},	//SCREENSHOT_NOGUI,
 	{wi::input::BUTTON::KEYBOARD_BUTTON_F4,		/*press=*/ true,		/*control=*/ false,		/*shift=*/ false},	//SCREENSHOT_ALPHA,
 	{wi::input::BUTTON::KEYBOARD_BUTTON_F4,		/*press=*/ true,		/*control=*/ false,		/*shift=*/ true},	//SCREENSHOT_ALPHA_SELECTION,
 	{wi::input::BUTTON('I'),					/*press=*/ false,		/*control=*/ false,		/*shift=*/ false},	//INSPECTOR_MODE,
@@ -223,6 +225,7 @@ void HotkeyRemap(Editor* main)
 		{"SCALE_TOGGLE_ACTION", EditorActions::SCALE_TOGGLE_ACTION},
 		{"LOCAL_GLOBAL_TOGGLE_ACTION", EditorActions::LOCAL_GLOBAL_TOGGLE_ACTION},
 		{"MAKE_NEW_SCREENSHOT", EditorActions::SCREENSHOT},
+		{"MAKE_NEW_SCREENSHOT_NOGUI", EditorActions::SCREENSHOT_NOGUI},
 		{"MAKE_NEW_SCREENSHOT_ALPHA", EditorActions::SCREENSHOT_ALPHA},
 		{"MAKE_NEW_SCREENSHOT_ALPHA_SELECTION", EditorActions::SCREENSHOT_ALPHA_SELECTION},
 		{"INSPECTOR_MODE", EditorActions::INSPECTOR_MODE},
@@ -1380,6 +1383,7 @@ void EditorComponent::Load()
 		ss += "Reload terrain props: " + GetInputString(EditorActions::RELOAD_TERRAIN_PROPS) + "\n";
 		ss += "Wireframe mode: " + GetInputString(EditorActions::WIREFRAME_MODE) + "\n";
 		ss += "Screenshot (saved into Editor's screenshots folder): " + GetInputString(EditorActions::SCREENSHOT) + "\n";
+		ss += "Screenshot without GUI (saved into Editor's screenshots folder): " + GetInputString(EditorActions::SCREENSHOT_NOGUI) + "\n";
 		ss += "Screenshot with background as transparency (saved into Editor's screenshots folder): " + GetInputString(EditorActions::SCREENSHOT_ALPHA) + "\n";
 		ss += "Screenshot selection with everything else as transparency (saved into Editor's screenshots folder): " + GetInputString(EditorActions::SCREENSHOT_ALPHA_SELECTION) + "\n";
 		ss += "Depth of field refocus to point: " + GetInputString(EditorActions::DEPTH_OF_FIELD_REFOCUS_TO_POINT) + " + left mouse button" + "\n";
@@ -1621,6 +1625,20 @@ void EditorComponent::Update(float dt)
 			PostSaveText("Screenshot saved: ", filename);
 		}
 	}
+	if (screenshot_nogui)
+	{
+		screenshot_nogui = false;
+		std::string filename = wi::helper::screenshot(renderPath->GetRenderResult3D());
+		PostSaveText(filename);
+		if (filename.empty())
+		{
+			PostSaveText("Error! Screenshot was not successful!");
+		}
+		else
+		{
+			PostSaveText("Screenshot saved: ", filename);
+		}
+	}
 	if (screenshot_alpha)
 	{
 		screenshot_alpha = false;
@@ -1654,6 +1672,11 @@ void EditorComponent::Update(float dt)
 	if (CheckInput(EditorActions::SCREENSHOT))
 	{
 		screenshot = true;
+	}
+	if (CheckInput(EditorActions::SCREENSHOT_NOGUI))
+	{
+		screenshot_nogui = true;
+		wi::renderer::SetDebugDrawEnabled(false);
 	}
 	if (CheckInput(EditorActions::SCREENSHOT_ALPHA))
 	{

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -1606,8 +1606,63 @@ void EditorComponent::Update(float dt)
 
 	main->canvas.scaling = float(guiScalingCombo.GetSelectedUserdata()) / 100.0f;
 
-	if (CheckInput(EditorActions::SCREENSHOT_ALPHA) || CheckInput(EditorActions::SCREENSHOT_ALPHA_SELECTION))
+	wi::renderer::SetDebugDrawEnabled(true);
+	if (screenshot)
 	{
+		screenshot = false;
+		std::string filename = wi::helper::screenshot(main->swapChain);
+		PostSaveText(filename);
+		if (filename.empty())
+		{
+			PostSaveText("Error! Screenshot was not successful!");
+		}
+		else
+		{
+			PostSaveText("Screenshot saved: ", filename);
+		}
+	}
+	if (screenshot_alpha)
+	{
+		screenshot_alpha = false;
+		std::string filename = wi::helper::screenshot(renderPath->CreateScreenshotWithAlphaBackground());
+		PostSaveText(filename);
+		if (filename.empty())
+		{
+			PostSaveText("Error! Screenshot was not successful!");
+		}
+		else
+		{
+			PostSaveText("Screenshot saved: ", filename);
+		}
+	}
+	if (screenshot_alpha_selection)
+	{
+		screenshot_alpha_selection = false;
+		std::string filename = wi::helper::screenshot(renderPath->CreateScreenshotWithAlphaBackground(EDITORSTENCILREF_HIGHLIGHT_OBJECT, wi::image::STENCILMODE_EQUAL, wi::image::STENCILREFMODE_USER));
+		PostSaveText(filename);
+		if (filename.empty())
+		{
+			PostSaveText("Error! Screenshot was not successful!");
+		}
+		else
+		{
+			PostSaveText("Screenshot saved: ", filename);
+		}
+	}
+
+	// screenshot is done next frame update to capture current frame render and the alpha modes also disable debug draw for just this frame
+	if (CheckInput(EditorActions::SCREENSHOT))
+	{
+		screenshot = true;
+	}
+	if (CheckInput(EditorActions::SCREENSHOT_ALPHA))
+	{
+		screenshot_alpha = true;
+		wi::renderer::SetDebugDrawEnabled(false);
+	}
+	if (CheckInput(EditorActions::SCREENSHOT_ALPHA_SELECTION))
+	{
+		screenshot_alpha_selection = true;
 		wi::renderer::SetDebugDrawEnabled(false);
 	}
 
@@ -4700,46 +4755,6 @@ void EditorComponent::Render() const
 
 	RenderPath2D::Render();
 
-	// screenshot is done after render to capture most current state and the alpha modes also disable debug draw for just this frame
-	if (CheckInput(EditorActions::SCREENSHOT))
-	{
-		std::string filename = wi::helper::screenshot(main->swapChain);
-		PostSaveText(filename);
-		if (filename.empty())
-		{
-			PostSaveText("Error! Screenshot was not successful!");
-		}
-		else
-		{
-			PostSaveText("Screenshot saved: ", filename);
-		}
-	}
-	if (CheckInput(EditorActions::SCREENSHOT_ALPHA))
-	{
-		std::string filename = wi::helper::screenshot(renderPath->CreateScreenshotWithAlphaBackground());
-		PostSaveText(filename);
-		if (filename.empty())
-		{
-			PostSaveText("Error! Screenshot was not successful!");
-		}
-		else
-		{
-			PostSaveText("Screenshot saved: ", filename);
-		}
-	}
-	if (CheckInput(EditorActions::SCREENSHOT_ALPHA_SELECTION))
-	{
-		std::string filename = wi::helper::screenshot(renderPath->CreateScreenshotWithAlphaBackground(EDITORSTENCILREF_HIGHLIGHT_OBJECT, wi::image::STENCILMODE_EQUAL, wi::image::STENCILREFMODE_USER));
-		PostSaveText(filename);
-		if (filename.empty())
-		{
-			PostSaveText("Error! Screenshot was not successful!");
-		}
-		else
-		{
-			PostSaveText("Screenshot saved: ", filename);
-		}
-	}
 	wi::renderer::SetDebugDrawEnabled(true);
 }
 void EditorComponent::Compose(CommandList cmd) const
@@ -5912,7 +5927,7 @@ bool EditorComponent::SetupThumbnailCamera(wi::RenderPath3D& thumbnailRenderPath
 	return true;
 }
 
-void EditorComponent::PostSaveText(const std::string& message, const std::string& filename, float time_seconds) const
+void EditorComponent::PostSaveText(const std::string& message, const std::string& filename, float time_seconds)
 {
 	save_text_message = message;
 	save_text_filename = filename;

--- a/Editor/Editor.h
+++ b/Editor/Editor.h
@@ -214,6 +214,7 @@ public:
 	void PostSaveText(const std::string& message, const std::string& filename = "", float time_seconds = 4);
 
 	bool screenshot = false;
+	bool screenshot_nogui = false;
 	bool screenshot_alpha = false;
 	bool screenshot_alpha_selection = false;
 

--- a/Editor/Editor.h
+++ b/Editor/Editor.h
@@ -207,11 +207,11 @@ public:
 	bool SetupThumbnailCamera(wi::RenderPath3D& thumbnailRenderPath);
 	wi::scene::CameraComponent thumbnail_saved_camera;
 
-	std::string save_text_message = "";
-	std::string save_text_filename = "";
-	float save_text_alpha = 0; // seconds until save text disappears
+	mutable std::string save_text_message = "";
+	mutable std::string save_text_filename = "";
+	mutable float save_text_alpha = 0; // seconds until save text disappears
 	wi::Color save_text_color = wi::Color::White();
-	void PostSaveText(const std::string& message, const std::string& filename = "", float time_seconds = 4);
+	void PostSaveText(const std::string& message, const std::string& filename = "", float time_seconds = 4) const;
 
 	std::string last_script_path;
 

--- a/Editor/Editor.h
+++ b/Editor/Editor.h
@@ -207,11 +207,15 @@ public:
 	bool SetupThumbnailCamera(wi::RenderPath3D& thumbnailRenderPath);
 	wi::scene::CameraComponent thumbnail_saved_camera;
 
-	mutable std::string save_text_message = "";
-	mutable std::string save_text_filename = "";
-	mutable float save_text_alpha = 0; // seconds until save text disappears
+	std::string save_text_message = "";
+	std::string save_text_filename = "";
+	float save_text_alpha = 0; // seconds until save text disappears
 	wi::Color save_text_color = wi::Color::White();
-	void PostSaveText(const std::string& message, const std::string& filename = "", float time_seconds = 4) const;
+	void PostSaveText(const std::string& message, const std::string& filename = "", float time_seconds = 4);
+
+	bool screenshot = false;
+	bool screenshot_alpha = false;
+	bool screenshot_alpha_selection = false;
 
 	std::string last_script_path;
 

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -4232,7 +4232,7 @@ using namespace vulkan_internal;
 					{
 						VkBufferImageCopy copyRegion = {};
 						copyRegion.bufferOffset = copyOffset;
-						copyRegion.bufferRowLength = 0;
+						copyRegion.bufferRowLength = src_rowpitch / data_stride * block_size;
 						copyRegion.bufferImageHeight = 0;
 
 						copyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -4232,7 +4232,7 @@ using namespace vulkan_internal;
 					{
 						VkBufferImageCopy copyRegion = {};
 						copyRegion.bufferOffset = copyOffset;
-						copyRegion.bufferRowLength = 0;
+						copyRegion.bufferRowLength = src_rowpitch / data_stride / block_size;
 						copyRegion.bufferImageHeight = 0;
 
 						copyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -7914,12 +7914,15 @@ using namespace vulkan_internal;
 					uint32_t mip_depth = dst_desc.depth;
 					for (uint32_t mip = 0; mip < dst_desc.mip_levels; ++mip)
 					{
+						const uint32_t src_subresource = ComputeSubresource(mip, slice, wi::graphics::ImageAspect::COLOR, src_desc.mip_levels, src_desc.array_size);
+						const SubresourceData& src_subresourcedata = internal_state_dst->mapped_subresources[src_subresource];
 						const uint32_t num_blocks_x = mip_width / block_size;
 						const uint32_t num_blocks_y = mip_height / block_size;
 						copy.imageExtent.width = mip_width;
 						copy.imageExtent.height = mip_height;
 						copy.imageExtent.depth = mip_depth;
 						copy.imageSubresource.mipLevel = mip;
+						copy.bufferRowLength = src_subresourcedata.row_pitch / data_stride / block_size;
 						vkCmdCopyBufferToImage(
 							commandlist.GetCommandBuffer(),
 							internal_state_src->staging_resource,
@@ -7952,12 +7955,15 @@ using namespace vulkan_internal;
 					uint32_t mip_depth = dst_desc.depth;
 					for (uint32_t mip = 0; mip < dst_desc.mip_levels; ++mip)
 					{
+						const uint32_t dst_subresource = ComputeSubresource(mip, slice, wi::graphics::ImageAspect::COLOR, dst_desc.mip_levels, dst_desc.array_size);
+						const SubresourceData& dst_subresourcedata = internal_state_dst->mapped_subresources[dst_subresource];
 						const uint32_t num_blocks_x = mip_width / block_size;
 						const uint32_t num_blocks_y = mip_height / block_size;
 						copy.imageExtent.width = mip_width;
 						copy.imageExtent.height = mip_height;
 						copy.imageExtent.depth = mip_depth;
 						copy.imageSubresource.mipLevel = mip;
+						copy.bufferRowLength = dst_subresourcedata.row_pitch / data_stride / block_size;
 						vkCmdCopyImageToBuffer(
 							commandlist.GetCommandBuffer(),
 							internal_state_src->resource,
@@ -8097,8 +8103,10 @@ using namespace vulkan_internal;
 			assert(src->mapped_subresource_count > subresource_index);
 			const SubresourceData& data0 = src->mapped_subresources[0];
 			const SubresourceData& data = src->mapped_subresources[subresource_index];
+			const uint32_t data_stride = GetFormatStride(src_desc.format);
+			const uint32_t block_size = GetFormatBlockSize(src_desc.format);
 			copy.bufferOffset = (uint64_t)data.data_ptr - (uint64_t)data0.data_ptr;
-			copy.bufferRowLength = std::max(1u, src_desc.width >> srcMip);
+			copy.bufferRowLength = data.row_pitch / data_stride / block_size;
 			copy.bufferImageHeight = std::max(1u, src_desc.height >> srcMip);
 			copy.imageSubresource.mipLevel = dstMip;
 			copy.imageSubresource.baseArrayLayer = dstSlice;
@@ -8130,8 +8138,10 @@ using namespace vulkan_internal;
 			assert(dst->mapped_subresource_count > subresource_index);
 			const SubresourceData& data0 = dst->mapped_subresources[0];
 			const SubresourceData& data = dst->mapped_subresources[subresource_index];
+			const uint32_t data_stride = GetFormatStride(dst_desc.format);
+			const uint32_t block_size = GetFormatBlockSize(dst_desc.format);
 			copy.bufferOffset = (uint64_t)data.data_ptr - (uint64_t)data0.data_ptr;
-			copy.bufferRowLength = std::max(1u, dst_desc.width >> dstMip);
+			copy.bufferRowLength = data.row_pitch / data_stride / block_size;
 			copy.bufferImageHeight = std::max(1u, dst_desc.height >> dstMip);
 			copy.imageSubresource.mipLevel = srcMip;
 			copy.imageSubresource.baseArrayLayer = srcSlice;

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -4232,7 +4232,7 @@ using namespace vulkan_internal;
 					{
 						VkBufferImageCopy copyRegion = {};
 						copyRegion.bufferOffset = copyOffset;
-						copyRegion.bufferRowLength = src_rowpitch / data_stride / block_size;
+						copyRegion.bufferRowLength = 0;
 						copyRegion.bufferImageHeight = 0;
 
 						copyRegion.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;

--- a/WickedEngine/wiGraphicsDevice_Vulkan.cpp
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.cpp
@@ -7922,7 +7922,7 @@ using namespace vulkan_internal;
 						copy.imageExtent.height = mip_height;
 						copy.imageExtent.depth = mip_depth;
 						copy.imageSubresource.mipLevel = mip;
-						copy.bufferRowLength = src_subresourcedata.row_pitch / data_stride / block_size;
+						copy.bufferRowLength = src_subresourcedata.row_pitch / data_stride * block_size;
 						vkCmdCopyBufferToImage(
 							commandlist.GetCommandBuffer(),
 							internal_state_src->staging_resource,
@@ -7963,7 +7963,7 @@ using namespace vulkan_internal;
 						copy.imageExtent.height = mip_height;
 						copy.imageExtent.depth = mip_depth;
 						copy.imageSubresource.mipLevel = mip;
-						copy.bufferRowLength = dst_subresourcedata.row_pitch / data_stride / block_size;
+						copy.bufferRowLength = dst_subresourcedata.row_pitch / data_stride * block_size;
 						vkCmdCopyImageToBuffer(
 							commandlist.GetCommandBuffer(),
 							internal_state_src->resource,
@@ -8106,7 +8106,7 @@ using namespace vulkan_internal;
 			const uint32_t data_stride = GetFormatStride(src_desc.format);
 			const uint32_t block_size = GetFormatBlockSize(src_desc.format);
 			copy.bufferOffset = (uint64_t)data.data_ptr - (uint64_t)data0.data_ptr;
-			copy.bufferRowLength = data.row_pitch / data_stride / block_size;
+			copy.bufferRowLength = data.row_pitch / data_stride * block_size;
 			copy.bufferImageHeight = std::max(1u, src_desc.height >> srcMip);
 			copy.imageSubresource.mipLevel = dstMip;
 			copy.imageSubresource.baseArrayLayer = dstSlice;
@@ -8141,7 +8141,7 @@ using namespace vulkan_internal;
 			const uint32_t data_stride = GetFormatStride(dst_desc.format);
 			const uint32_t block_size = GetFormatBlockSize(dst_desc.format);
 			copy.bufferOffset = (uint64_t)data.data_ptr - (uint64_t)data0.data_ptr;
-			copy.bufferRowLength = data.row_pitch / data_stride / block_size;
+			copy.bufferRowLength = data.row_pitch / data_stride * block_size;
 			copy.bufferImageHeight = std::max(1u, dst_desc.height >> dstMip);
 			copy.imageSubresource.mipLevel = srcMip;
 			copy.imageSubresource.baseArrayLayer = srcSlice;

--- a/WickedEngine/wiRenderPath3D.cpp
+++ b/WickedEngine/wiRenderPath3D.cpp
@@ -3240,7 +3240,7 @@ namespace wi
 		}
 	}
 
-	Texture RenderPath3D::CreateScreenshotWithAlphaBackground()
+	Texture RenderPath3D::CreateScreenshotWithAlphaBackground(uint8_t stencilref, wi::image::STENCILMODE stencilmode, wi::image::STENCILREFMODE stencilrefmode)
 	{
 		TextureDesc desc = rtMain_render.GetDesc();
 		desc.format = Format::R8G8B8A8_UNORM;
@@ -3270,9 +3270,9 @@ namespace wi
 		vp.height = (float)desc.height;
 		device->BindViewports(1, &vp, cmd);
 		wi::image::Params fx;
-		fx.stencilComp = wi::image::STENCILMODE_NOT;
-		fx.stencilRef = 0;
-		fx.stencilRefMode = wi::image::STENCILREFMODE_ALL;
+		fx.stencilComp = stencilmode;
+		fx.stencilRef = stencilref;
+		fx.stencilRefMode = stencilrefmode;
 		fx.enableFullScreen();
 		wi::image::Draw(GetLastPostprocessRT(), fx, cmd);
 		device->RenderPassEnd(cmd);

--- a/WickedEngine/wiRenderPath3D.h
+++ b/WickedEngine/wiRenderPath3D.h
@@ -380,7 +380,8 @@ namespace wi
 		void Start() override;
 
 		// Creates screenshot of the render result and replaces background (sky) pixels with transparency
-		wi::graphics::Texture CreateScreenshotWithAlphaBackground();
+		//	The stencil parameters let you configure other stencil ops instead of making sky transparent which is default
+		wi::graphics::Texture CreateScreenshotWithAlphaBackground(uint8_t stencilref = 0, wi::image::STENCILMODE stencilmode = wi::image::STENCILMODE_NOT, wi::image::STENCILREFMODE stencilrefmode = wi::image::STENCILREFMODE_ALL);
 
 		// This is an identifier of RenderPath subtype that is used for lua binding.
 		static constexpr const auto script_check_identifier = relative_path_storage(__FILE__);

--- a/WickedEngine/wiRenderPath3D.h
+++ b/WickedEngine/wiRenderPath3D.h
@@ -381,7 +381,7 @@ namespace wi
 
 		// Creates screenshot of the render result and replaces background (sky) pixels with transparency
 		//	The stencil parameters let you configure other stencil ops instead of making sky transparent which is default
-		wi::graphics::Texture CreateScreenshotWithAlphaBackground(uint8_t stencilref = 0, wi::image::STENCILMODE stencilmode = wi::image::STENCILMODE_NOT, wi::image::STENCILREFMODE stencilrefmode = wi::image::STENCILREFMODE_ALL);
+		wi::graphics::Texture CreateScreenshotWithAlphaBackground(uint8_t stencilref = wi::enums::STENCILREF_EMPTY, wi::image::STENCILMODE stencilmode = wi::image::STENCILMODE_NOT, wi::image::STENCILREFMODE stencilrefmode = wi::image::STENCILREFMODE_ALL);
 
 		// This is an identifier of RenderPath subtype that is used for lua binding.
 		static constexpr const auto script_check_identifier = relative_path_storage(__FILE__);

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -157,6 +157,7 @@ bool CAPSULE_SHADOW_ENABLED = false;
 float CAPSULE_SHADOW_ANGLE = XM_PIDIV4;
 float CAPSULE_SHADOW_FADE = 0.2f;
 bool SHADOW_LOD_OVERRIDE = true;
+bool DEBUG_DRAW_ENABLED = true;
 
 Texture shadowMapAtlas;
 Texture shadowMapAtlas_Transparent;
@@ -7455,6 +7456,32 @@ void DrawDebugWorld(
 	CommandList cmd
 )
 {
+	if (!IsDebugDrawEnabled())
+	{
+		renderableBoxes.clear();
+		renderableBoxes_depth.clear();
+		renderableSpheres.clear();
+		renderableSpheres_depth.clear();
+		renderableCapsules.clear();
+		renderableCapsules_depth.clear();
+		renderableLines.clear();
+		renderableLines_depth.clear();
+		renderableLines2D.clear();
+		renderablePoints.clear();
+		renderablePoints_depth.clear();
+		renderableTriangles_solid.clear();
+		renderableTriangles_wireframe.clear();
+		renderableTriangles_solid_depth.clear();
+		renderableTriangles_wireframe_depth.clear();
+		debugTextStorage.clear();
+		paintrads.clear();
+		painttextures.clear();
+		paintdecals.clear();
+		renderableVoxelgrids.clear();
+		renderablePathqueries.clear();
+		renderableTrails.clear();
+		return;
+	}
 	static GPUBuffer wirecubeVB;
 	static GPUBuffer wirecubeIB;
 	if (!wirecubeVB.IsValid())
@@ -19385,6 +19412,15 @@ void SetShadowLODOverrideEnabled(bool value)
 bool IsShadowLODOverrideEnabled()
 {
 	return SHADOW_LOD_OVERRIDE;
+}
+
+void SetDebugDrawEnabled(bool value)
+{
+	DEBUG_DRAW_ENABLED = value;
+}
+bool IsDebugDrawEnabled()
+{
+	return DEBUG_DRAW_ENABLED;
 }
 
 wi::Resource CreatePaintableTexture(uint32_t width, uint32_t height, uint32_t mips, wi::Color initialColor)

--- a/WickedEngine/wiRenderer.h
+++ b/WickedEngine/wiRenderer.h
@@ -1279,6 +1279,10 @@ namespace wi::renderer
 	void SetShadowLODOverrideEnabled(bool value); // Allow shadowmap rendering to request custom LOD for objects (can result in shadow mismatch, but increased GPU performance)
 	bool IsShadowLODOverrideEnabled();
 
+	// Switch all debug rendering on/off globally
+	void SetDebugDrawEnabled(bool value);
+	bool IsDebugDrawEnabled();
+
 	// Gets pick ray according to the current screen resolution and pointer coordinates. Can be used as input into RayIntersectWorld()
 	wi::primitive::Ray GetPickRay(long cursorX, long cursorY, const wi::Canvas& canvas, const wi::scene::CameraComponent& camera = wi::scene::GetCamera());
 

--- a/WickedEngine/wiRenderer_BindLua.cpp
+++ b/WickedEngine/wiRenderer_BindLua.cpp
@@ -347,6 +347,19 @@ namespace wi::lua::renderer
 		}
 		return 0;
 	}
+	int SetDebugDrawEnabled(lua_State* L)
+	{
+		int argc = wi::lua::SGetArgCount(L);
+		if (argc > 0)
+		{
+			wi::renderer::SetDebugDrawEnabled(wi::lua::SGetBool(L, 1));
+		}
+		else
+		{
+			wi::lua::SError(L, "SetDebugDrawEnabled(bool value) not enough arguments!");
+		}
+		return 0;
+	}
 
 	int DrawLine(lua_State* L)
 	{
@@ -1062,6 +1075,7 @@ namespace wi::lua::renderer
 			wi::lua::RegisterFunc("SetCapsuleShadowFade", SetCapsuleShadowFade);
 			wi::lua::RegisterFunc("SetCapsuleShadowAngle", SetCapsuleShadowAngle);
 			wi::lua::RegisterFunc("SetShadowLODOverrideEnabled", SetShadowLODOverrideEnabled);
+			wi::lua::RegisterFunc("SetDebugDrawEnabled", SetDebugDrawEnabled);
 
 			wi::lua::RegisterFunc("DrawLine", DrawLine);
 			wi::lua::RegisterFunc("DrawPoint", DrawPoint);

--- a/WickedEngine/wiVersion.cpp
+++ b/WickedEngine/wiVersion.cpp
@@ -9,7 +9,7 @@ namespace wi::version
 	// minor features, major updates, breaking compatibility changes
 	const int minor = 72;
 	// minor bug fixes, alterations, refactors, updates
-	const int revision = 60;
+	const int revision = 61;
 
 	const std::string version_string = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(revision);
 


### PR DESCRIPTION
- Added screenshot mode that only saves the selected objects, everything else will be filled with transparency.
- Added screenshot mode that makes normal screenshot without gui
- Vulkan optimal image copy fixes for Intel GPU