### PR TITLE
refactor: change enable_bitmask_ops to follow c++17 conventions a bit more

### DIFF
--- a/Editor/ComponentsWindow.h
+++ b/Editor/ComponentsWindow.h
@@ -142,6 +142,4 @@ private:
 };
 
 template<>
-struct enable_bitmask_operators<ComponentsWindow::Filter> {
-	static constexpr bool enable = true;
-};
+struct enable_bitmask_operators<ComponentsWindow::Filter> : std::true_type {};

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -350,45 +350,42 @@ inline long long AtomicLoad(const volatile long long* ptr)
 // Enable enum flags:
 //	https://www.justsoftwaresolutions.co.uk/cplusplus/using-enum-classes-as-bitfields.html
 template<typename E>
-struct enable_bitmask_operators {
-	static constexpr bool enable = false;
-};
+struct enable_bitmask_operators : std::false_type {};
+
 template<typename E>
-constexpr typename std::enable_if<enable_bitmask_operators<E>::enable, E>::type operator|(E lhs, E rhs)
+using EnableIfBitmaskOps = std::enable_if_t<enable_bitmask_operators<E>::value, int>;
+
+template<typename E, EnableIfBitmaskOps<E> = 0>
+constexpr E operator|(E lhs, E rhs)
 {
-	typedef typename std::underlying_type<E>::type underlying;
-	return static_cast<E>(
-		static_cast<underlying>(lhs) | static_cast<underlying>(rhs));
+	using U = std::underlying_type_t<E>;
+	return static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
 }
-template<typename E>
-constexpr typename std::enable_if<enable_bitmask_operators<E>::enable, E&>::type operator|=(E& lhs, E rhs)
+template<typename E, EnableIfBitmaskOps<E> = 0>
+constexpr E operator|=(E& lhs, E rhs)
 {
-	typedef typename std::underlying_type<E>::type underlying;
-	lhs = static_cast<E>(
-		static_cast<underlying>(lhs) | static_cast<underlying>(rhs));
+	using U = std::underlying_type_t<E>;
+	lhs = static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
 	return lhs;
 }
-template<typename E>
-constexpr typename std::enable_if<enable_bitmask_operators<E>::enable, E>::type operator&(E lhs, E rhs)
+template<typename E, EnableIfBitmaskOps<E> = 0>
+constexpr E operator&(E lhs, E rhs)
 {
-	typedef typename std::underlying_type<E>::type underlying;
-	return static_cast<E>(
-		static_cast<underlying>(lhs) & static_cast<underlying>(rhs));
+	using U = std::underlying_type_t<E>;
+	return static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
 }
-template<typename E>
-constexpr typename std::enable_if<enable_bitmask_operators<E>::enable, E&>::type operator&=(E& lhs, E rhs)
+template<typename E, EnableIfBitmaskOps<E> = 0>
+constexpr E operator&=(E& lhs, E rhs)
 {
-	typedef typename std::underlying_type<E>::type underlying;
-	lhs = static_cast<E>(
-		static_cast<underlying>(lhs) & static_cast<underlying>(rhs));
+	using U = std::underlying_type_t<E>;
+	lhs = static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
 	return lhs;
 }
-template<typename E>
-constexpr typename std::enable_if<enable_bitmask_operators<E>::enable, E>::type operator~(E rhs)
+template<typename E, EnableIfBitmaskOps<E> = 0>
+constexpr E operator~(E rhs)
 {
-	typedef typename std::underlying_type<E>::type underlying;
-	rhs = static_cast<E>(
-		~static_cast<underlying>(rhs));
+	using U = std::underlying_type_t<E>;
+	rhs = static_cast<E>(~static_cast<U>(rhs));
 	return rhs;
 }
 template<typename E>

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -1097,16 +1097,10 @@ namespace wi::gui
 }
 
 template<>
-struct enable_bitmask_operators<wi::gui::Window::WindowControls> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::gui::Window::WindowControls> : std::true_type {};
 
 template<>
-struct enable_bitmask_operators<wi::gui::Window::AttachmentOptions> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::gui::Window::AttachmentOptions> : std::true_type {};
 
 template<>
-struct enable_bitmask_operators<wi::gui::LocalizationEnabled> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::gui::LocalizationEnabled> : std::true_type {};

--- a/WickedEngine/wiGraphics.h
+++ b/WickedEngine/wiGraphics.h
@@ -2289,39 +2289,23 @@ namespace wi::graphics
 }
 
 template<>
-struct enable_bitmask_operators<wi::graphics::ColorWrite> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::graphics::ColorWrite> : std::true_type {};
 template<>
-struct enable_bitmask_operators<wi::graphics::BindFlag> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::graphics::BindFlag> : std::true_type {};
 template<>
-struct enable_bitmask_operators<wi::graphics::ResourceMiscFlag> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::graphics::ResourceMiscFlag> : std::true_type {};
 template<>
-struct enable_bitmask_operators<wi::graphics::GraphicsDeviceCapability> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::graphics::GraphicsDeviceCapability> : std::true_type {};
 template<>
-struct enable_bitmask_operators<wi::graphics::ResourceState> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::graphics::ResourceState> : std::true_type {};
 WI_DISABLE_DEPRECATED_BEGIN
 template<>
-struct enable_bitmask_operators<wi::graphics::RenderPassDesc::Flags> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::graphics::RenderPassDesc::Flags> : std::true_type {};
 WI_DISABLE_DEPRECATED_END
 template<>
-struct enable_bitmask_operators<wi::graphics::RenderPassFlags> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::graphics::RenderPassFlags> : std::true_type {};
 template<>
-struct enable_bitmask_operators<wi::graphics::VideoDecoderSupportFlags> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::graphics::VideoDecoderSupportFlags> : std::true_type {};
 
 namespace std
 {

--- a/WickedEngine/wiResourceManager.h
+++ b/WickedEngine/wiResourceManager.h
@@ -144,10 +144,6 @@ namespace wi
 }
 
 template<>
-struct enable_bitmask_operators<wi::resourcemanager::Flags> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::resourcemanager::Flags> : std::true_type {};
 template<>
-struct enable_bitmask_operators<wi::resourcemanager::ResourceType> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::resourcemanager::ResourceType> : std::true_type {};

--- a/WickedEngine/wiScene.h
+++ b/WickedEngine/wiScene.h
@@ -717,6 +717,4 @@ namespace wi::scene
 }
 
 template<>
-struct enable_bitmask_operators<wi::scene::Scene::EntitySerializeFlags> {
-	static constexpr bool enable = true;
-};
+struct enable_bitmask_operators<wi::scene::Scene::EntitySerializeFlags> : std::true_type {};

--- a/WickedEngine/wiShaderCompiler.h
+++ b/WickedEngine/wiShaderCompiler.h
@@ -50,6 +50,4 @@ namespace wi::shadercompiler
 }
 
 template<>
-struct enable_bitmask_operators<wi::shadercompiler::Flags> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::shadercompiler::Flags> : std::true_type {};

--- a/WickedEngine/wiTextureHelper.h
+++ b/WickedEngine/wiTextureHelper.h
@@ -87,6 +87,4 @@ namespace wi::texturehelper
 };
 
 template<>
-struct enable_bitmask_operators<wi::texturehelper::GradientFlags> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::texturehelper::GradientFlags> : std::true_type {};

--- a/WickedEngine/wiVideo.h
+++ b/WickedEngine/wiVideo.h
@@ -119,6 +119,4 @@ namespace wi::video
 }
 
 template<>
-struct enable_bitmask_operators<wi::video::VideoInstance::Flags> {
-	static const bool enable = true;
-};
+struct enable_bitmask_operators<wi::video::VideoInstance::Flags> : std::true_type {};


### PR DESCRIPTION
no functional change, this also is closer to what it would look like with C++20 concepts, which makes it easier to update once we change to C++20