### PR TITLE
use ISO 8601(-ish) format for screenshot filenames

### DIFF
--- a/WickedEngine/wiHelper.cpp
+++ b/WickedEngine/wiHelper.cpp
@@ -1120,7 +1120,7 @@ namespace wi::helper
 		tmptr = localtime(&t);
 #endif
 		std::stringstream ss("");
-		ss << std::put_time(tmptr, "%d-%m-%Y %H-%M-%S");
+		ss << std::put_time(tmptr, "%Y-%m-%d %H-%M-%S");
 		return ss.str();
 	}
 


### PR DESCRIPTION
The advantage is that sorting files alphabetically will also sort them by date. Before this change, a file eg. created on Feb 1st would be sorted before a file created on Jan 2nd