### PR TITLE
restored decal wrap sampling

### DIFF
--- a/WickedEngine/shaders/ShaderInterop_Renderer.h
+++ b/WickedEngine/shaders/ShaderInterop_Renderer.h
@@ -505,7 +505,7 @@ struct PrimitiveVisibilityTile
 
 struct VisibilityTile
 {
-	uint64_t execution_mask_or_primitiveID; // divergent tiles: execution mask | uniform tiles primitiveID
+	uint64_t execution_mask_or_primitiveID; // divergent tiles: execution mask | uniform tiles: primitiveID
 	uint visibility_tile_id;
 
 	inline bool check_thread_valid(uint groupIndex)

--- a/WickedEngine/shaders/ShaderInterop_Renderer.h
+++ b/WickedEngine/shaders/ShaderInterop_Renderer.h
@@ -390,8 +390,7 @@ struct alignas(32) ShaderMaterial
 	uint2 transmission_sheenroughness_clearcoat_clearcoatroughness;
 	uint2 aniso_anisosin_anisocos_terrainblend;
 
-	int sampler_descriptor : 16;
-	int sampler_clamp_descriptor : 16;
+	int sampler_descriptor;
 	uint options_stencilref;
 	uint layerMask;
 	uint shaderType_meshblend;
@@ -422,7 +421,6 @@ struct alignas(32) ShaderMaterial
 		aniso_anisosin_anisocos_terrainblend = uint2(0, 0);
 
 		sampler_descriptor = -1;
-		sampler_clamp_descriptor = -1;
 		options_stencilref = 0;
 		layerMask = ~0u;
 		shaderType_meshblend = 0;
@@ -823,9 +821,8 @@ struct ShaderMeshInstancePointer
 struct ObjectPushConstants
 {
 	uint geometryIndex : 24;
-	uint wrapSamplerIndex : 8;
+	uint samplerIndex : 8;
 	uint materialIndex : 24;
-	uint clampSamplerIndex : 8;
 	int instances;
 	uint instance_offset;
 };

--- a/WickedEngine/shaders/ShaderInterop_Renderer.h
+++ b/WickedEngine/shaders/ShaderInterop_Renderer.h
@@ -820,9 +820,9 @@ struct ShaderMeshInstancePointer
 
 struct ObjectPushConstants
 {
-	uint geometryIndex : 24;
-	uint samplerIndex : 8;
+	uint geometryIndex;
 	uint materialIndex : 24;
+	uint samplerIndex : 8;
 	int instances;
 	uint instance_offset;
 };

--- a/WickedEngine/shaders/objectHF.hlsli
+++ b/WickedEngine/shaders/objectHF.hlsli
@@ -57,8 +57,7 @@ PUSHCONSTANT(push, ObjectPushConstants);
 #define GetMaterial() (load_material(push.materialIndex))
 
 //#define sampler_objectshader bindless_samplers[descriptor_index(GetMaterial().sampler_descriptor)]
-#define sampler_objectshader bindless_samplers[descriptor_index(push.wrapSamplerIndex)] // This one loads it faster from push constant than the above that loads from material struct but it must be fed per draw call
-#define sampler_objectshader_clamp bindless_samplers[descriptor_index(push.clampSamplerIndex)]
+#define sampler_objectshader bindless_samplers[descriptor_index(push.samplerIndex)] // This one loads it faster from push constant than the above that loads from material struct but it must be fed per draw call
 
 // Use these to compile this file as shader prototype:
 //#define OBJECTSHADER_COMPILE_VS				- compile vertex shader prototype
@@ -777,11 +776,11 @@ float4 main(PixelInput input, in bool is_frontface : SV_IsFrontFace APPEND_COVER
 #ifndef PREPASS
 #ifndef WATER
 #ifdef FORWARD
-	ForwardDecals(surface, surfaceMap, sampler_objectshader_clamp);
+	ForwardDecals(surface, surfaceMap, sampler_objectshader);
 #endif // FORWARD
 
 #ifdef TILEDFORWARD
-	TiledDecals(surface, flat_tile_index, surfaceMap, sampler_objectshader_clamp);
+	TiledDecals(surface, flat_tile_index, surfaceMap, sampler_objectshader);
 #endif // TILEDFORWARD
 #endif // WATER
 #endif // PREPASS

--- a/WickedEngine/shaders/surfaceHF.hlsli
+++ b/WickedEngine/shaders/surfaceHF.hlsli
@@ -382,7 +382,6 @@ struct Surface
 	void load_internal(uint flatTileIndex = 0)
 	{
 		SamplerState sam = bindless_samplers[MakeUniformResourceIndex(material.sampler_descriptor)];
-		SamplerState sam_clamp = bindless_samplers[MakeUniformResourceIndex(material.sampler_clamp_descriptor)];
 
 		const bool is_hairparticle = geometry.flags & SHADERMESH_FLAG_HAIRPARTICLE;
 		const bool is_emittedparticle = geometry.flags & SHADERMESH_FLAG_EMITTEDPARTICLE;
@@ -849,7 +848,7 @@ struct Surface
 						[branch]
 						if (decalTexture >= 0)
 						{
-							decalColor *= bindless_textures_half4[descriptor_index(decalTexture)].SampleGrad(sam_clamp, uvw.xy, decalDX, decalDY);
+							decalColor *= bindless_textures_half4[descriptor_index(decalTexture)].SampleGrad(sam, uvw.xy, decalDX, decalDY);
 							if ((decal.GetFlags() & ENTITY_FLAG_DECAL_BASECOLOR_ONLY_ALPHA) == 0)
 							{
 								// perform manual blending of decals:
@@ -861,7 +860,7 @@ struct Surface
 						[branch]
 						if (decalNormal >= 0)
 						{
-							half3 decalBumpColor = half3(bindless_textures_half4[descriptor_index(decalNormal)].SampleGrad(sam_clamp, uvw.xy, decalDX, decalDY).rg, 1);
+							half3 decalBumpColor = half3(bindless_textures_half4[descriptor_index(decalNormal)].SampleGrad(sam, uvw.xy, decalDX, decalDY).rg, 1);
 							decalBumpColor = decalBumpColor * 2 - 1;
 							decalBumpColor.rg *= decal.GetAngleScale();
 							decalBumpAccumulation.rgb = mad(1 - decalBumpAccumulation.a, decalColor.a * decalBumpColor.rgb, decalBumpAccumulation.rgb);
@@ -870,7 +869,7 @@ struct Surface
 						[branch]
 						if (decalSurfacemap >= 0)
 						{
-							half4 decalSurfaceColor = bindless_textures_half4[descriptor_index(decalSurfacemap)].SampleGrad(sam_clamp, uvw.xy, decalDX, decalDY);
+							half4 decalSurfaceColor = bindless_textures_half4[descriptor_index(decalSurfacemap)].SampleGrad(sam, uvw.xy, decalDX, decalDY);
 							decalSurfaceAccumulation = mad(1 - decalSurfaceAccumulationAlpha, decalColor.a * decalSurfaceColor, decalSurfaceAccumulation);
 							decalSurfaceAccumulationAlpha = mad(1 - decalColor.a, decalSurfaceAccumulationAlpha, decalColor.a);
 						}

--- a/WickedEngine/shaders/surfaceHF.hlsli
+++ b/WickedEngine/shaders/surfaceHF.hlsli
@@ -811,7 +811,7 @@ struct Surface
 					if ((decal.layerMask & layerMask) == 0)
 						continue;
 					const float3 clipSpacePos = mul(decalProjection, float4(P, 1)).xyz;
-					float3 uvw = clipspace_to_uv(clipSpacePos.xyz);
+					float3 uvw = box_to_uv(clipSpacePos.xyz);
 					[branch]
 					if (is_saturated(uvw))
 					{

--- a/WickedEngine/shaders/visibility_resolveCS.hlsl
+++ b/WickedEngine/shaders/visibility_resolveCS.hlsl
@@ -3,9 +3,10 @@
 #include "surfaceHF.hlsli"
 #include "raytracingHF.hlsli"
 
-// This shader reads primitiveID and writes depth and linear depth and a simple mipchain for them
+// This shader reads primitiveID and resolves depth mipchain from it
+//	resolved depth can mismatch from hardware depth where viewport squishing was applied. Resolved depth can be unprojected to true positions
 //	It also does material binning when requested
-//	It can run in uniform and divergent manner based on previous primitiveID classification
+//	It can run in uniform and divergent manner based on previous primitiveID classification of visibility_analyzeCS
 
 StructuredBuffer<PrimitiveVisibilityTile> primitive_binned_tiles : register(t0);
 

--- a/WickedEngine/wiEnums.h
+++ b/WickedEngine/wiEnums.h
@@ -509,7 +509,6 @@ namespace wi::enums
 	{
 		// Can be changed by user
 		SAMPLER_OBJECTSHADER,
-		SAMPLER_OBJECTSHADER_CLAMP,
 
 		// Persistent samplers
 		// These are bound once and are alive forever

--- a/WickedEngine/wiEnums.h
+++ b/WickedEngine/wiEnums.h
@@ -510,8 +510,7 @@ namespace wi::enums
 		// Can be changed by user
 		SAMPLER_OBJECTSHADER,
 
-		// Persistent samplers
-		// These are bound once and are alive forever
+		// Common sampler types
 		SAMPLER_LINEAR_CLAMP,
 		SAMPLER_LINEAR_WRAP,
 		SAMPLER_LINEAR_MIRROR,

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -3427,6 +3427,8 @@ void RenderMeshes(
 			push.materialIndex = subset.materialIndex;
 			push.instances = instanceBufferDescriptorIndex;
 			push.instance_offset = (uint)instancedBatch.dataOffset;
+			static_assert(BINDLESS_SAMPLER_CAPACITY <= 256); // It is assumed for this structure that samplers can be indexed with 8 bits
+			assert(material.cached_wrapSampler >= 0 && material.cached_wrapSampler < 256);
 			push.samplerIndex = material.cached_wrapSampler;
 
 			const MeshComponent::BufferView& ibv = provokingIBRequired ? mesh.ib_provoke : mesh.ib;

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -2689,13 +2689,6 @@ void SetUpStates()
 	samplerDesc.max_anisotropy = 16;
 	device->CreateSampler(&samplerDesc, &samplers[SAMPLER_OBJECTSHADER]);
 
-	samplerDesc.filter = Filter::ANISOTROPIC;
-	samplerDesc.address_u = TextureAddressMode::CLAMP;
-	samplerDesc.address_v = TextureAddressMode::CLAMP;
-	samplerDesc.address_w = TextureAddressMode::CLAMP;
-	samplerDesc.max_anisotropy = 16;
-	device->CreateSampler(&samplerDesc, &samplers[SAMPLER_OBJECTSHADER_CLAMP]);
-
 	samplerDesc.filter = Filter::COMPARISON_MIN_MAG_LINEAR_MIP_POINT;
 	samplerDesc.address_u = TextureAddressMode::CLAMP;
 	samplerDesc.address_v = TextureAddressMode::CLAMP;
@@ -2880,12 +2873,6 @@ void ModifyObjectSampler(const SamplerDesc& desc)
 	if (initialized.load())
 	{
 		device->CreateSampler(&desc, &samplers[SAMPLER_OBJECTSHADER]);
-
-		SamplerDesc desc2 = desc;
-		desc2.address_u = TextureAddressMode::CLAMP;
-		desc2.address_v = TextureAddressMode::CLAMP;
-		desc2.address_w = TextureAddressMode::CLAMP;
-		device->CreateSampler(&desc, &samplers[SAMPLER_OBJECTSHADER_CLAMP]);
 	}
 }
 
@@ -3440,11 +3427,7 @@ void RenderMeshes(
 			push.materialIndex = subset.materialIndex;
 			push.instances = instanceBufferDescriptorIndex;
 			push.instance_offset = (uint)instancedBatch.dataOffset;
-			assert(material.cached_wrapSampler >= 0 && material.cached_wrapSampler < 256);
-			assert(material.cached_clampSampler >= 0 && material.cached_clampSampler < 256);
-			static_assert(BINDLESS_SAMPLER_CAPACITY <= 256); // It is assumed for this structure that samplers can be indexed with 8 bits
-			push.wrapSamplerIndex = material.cached_wrapSampler;
-			push.clampSamplerIndex = material.cached_clampSampler;
+			push.samplerIndex = material.cached_wrapSampler;
 
 			const MeshComponent::BufferView& ibv = provokingIBRequired ? mesh.ib_provoke : mesh.ib;
 			const size_t ib_stride = provokingIBRequired ? mesh.GetProvokingIndexStride() : mesh.GetIndexStride();
@@ -8857,8 +8840,7 @@ void DrawDebugWorld(
 			push.materialIndex = subset.materialIndex;
 			push.instances = device->GetDescriptorIndex(&mem.buffer, SubresourceType::SRV);
 			push.instance_offset = (uint)mem.offset;
-			push.wrapSamplerIndex = device->GetDescriptorIndex(wi::renderer::GetSampler(wi::enums::SAMPLER_OBJECTSHADER));
-			push.clampSamplerIndex = device->GetDescriptorIndex(wi::renderer::GetSampler(wi::enums::SAMPLER_OBJECTSHADER_CLAMP));
+			push.samplerIndex = device->GetDescriptorIndex(wi::renderer::GetSampler(wi::enums::SAMPLER_OBJECTSHADER));
 			device->PushConstants(&push, sizeof(push), cmd);
 
 			device->DrawIndexedInstanced(subset.indexCount, 1, subset.indexOffset, 0, 0, cmd);
@@ -9973,8 +9955,7 @@ void RefreshImpostors(const Scene& scene, CommandList cmd)
 				push.materialIndex = subset.materialIndex;
 				push.instances = -1;
 				push.instance_offset = 0;
-				push.wrapSamplerIndex = device->GetDescriptorIndex(wi::renderer::GetSampler(wi::enums::SAMPLER_OBJECTSHADER));
-				push.clampSamplerIndex = device->GetDescriptorIndex(wi::renderer::GetSampler(wi::enums::SAMPLER_OBJECTSHADER_CLAMP));
+				push.samplerIndex = device->GetDescriptorIndex(wi::renderer::GetSampler(wi::enums::SAMPLER_OBJECTSHADER));
 				device->PushConstants(&push, sizeof(push), cmd);
 
 				device->DrawIndexedInstanced(subset.indexCount, 1, subset.indexOffset, 0, 0, cmd);

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -4204,7 +4204,6 @@ namespace wi::scene
 			{
 				material.cached_wrapSampler = material.sampler_descriptor;
 			}
-			material.cached_clampSampler = device->GetDescriptorIndex(wi::renderer::GetSampler(wi::enums::SAMPLER_OBJECTSHADER_CLAMP));
 
 			material.WriteShaderMaterial(materialArrayMapped + args.jobIndex);
 

--- a/WickedEngine/wiScene_Components.cpp
+++ b/WickedEngine/wiScene_Components.cpp
@@ -435,7 +435,6 @@ namespace wi::scene
 		{
 			material.sampler_descriptor = sampler_descriptor;
 		}
-		material.sampler_clamp_descriptor = device->GetDescriptorIndex(wi::renderer::GetSampler(wi::enums::SAMPLER_OBJECTSHADER_CLAMP));
 
 		if (shaderType == SHADERTYPE_INTERIORMAPPING && textures[BASECOLORMAP].resource.IsValid() && !has_flag(textures[BASECOLORMAP].resource.GetTexture().GetDesc().misc_flags, ResourceMiscFlag::TEXTURECUBE))
 		{

--- a/WickedEngine/wiScene_Components.h
+++ b/WickedEngine/wiScene_Components.h
@@ -266,7 +266,6 @@ namespace wi::scene
 		uint32_t layerMask = ~0u;
 		int sampler_descriptor = -1; // optional, you can modify this to overwrite global sampler for this material
 		int cached_wrapSampler = -1; // do not modify, system will write this
-		int cached_clampSampler = -1; // do not modify, system will write this
 
 		// User stencil value can be in range [0, 15]
 		constexpr void SetUserStencilRef(uint8_t value) { userStencilRef = value & 0x0F; }

--- a/WickedEngine/wiVersion.cpp
+++ b/WickedEngine/wiVersion.cpp
@@ -9,7 +9,7 @@ namespace wi::version
 	// minor features, major updates, breaking compatibility changes
 	const int minor = 72;
 	// minor bug fixes, alterations, refactors, updates
-	const int revision = 75;
+	const int revision = 76;
 
 	const std::string version_string = std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(revision);
 


### PR DESCRIPTION
Sampling decals will use the wrap sampler as before, this allows more options how the texcoords of them can be manipulated. Fixes missing mirrored footprint decals (issue #1634)