### PR TITLE
Fix shader metadata version mismatch crash in worker threads

### DIFF
--- a/WickedEngine/wiArchive.cpp
+++ b/WickedEngine/wiArchive.cpp
@@ -25,8 +25,8 @@ namespace wi
 	{
 		CreateEmpty();
 	}
-	Archive::Archive(const std::string& fileName, bool readMode)
-		: readMode(readMode), fileName(fileName)
+	Archive::Archive(const std::string& fileName, bool readMode, bool report_errors)
+		: readMode(readMode), report_errors(report_errors), fileName(fileName)
 	{
 		if (!fileName.empty())
 		{
@@ -73,13 +73,19 @@ namespace wi
 			(*this) >> header.version;
 			if (header.version < __archiveVersionBarrier)
 			{
-				wi::helper::messageBox("File is not supported!\nReason: The archive version (" + std::to_string(header.version) + ") is no longer supported! This is likely because trying to open a file that was created by a version of Wicked Engine that is too old.", "Error!");
+				if (report_errors)
+				{
+					wi::helper::messageBox("File is not supported!\nReason: The archive version (" + std::to_string(header.version) + ") is no longer supported! This is likely because trying to open a file that was created by a version of Wicked Engine that is too old.", "Error!");
+				}
 				Close();
 				return;
 			}
 			if (header.version > __archiveVersion)
 			{
-				wi::helper::messageBox("File is not supported!\nReason: The archive version (" + std::to_string(header.version) + ") is higher than the program's (" + std::to_string(__archiveVersion) + ")!\nThis is likely due to trying to open an Archive file that was not created by Wicked Engine.", "Error!");
+				if (report_errors)
+				{
+					wi::helper::messageBox("File is not supported!\nReason: The archive version (" + std::to_string(header.version) + ") is higher than the program's (" + std::to_string(__archiveVersion) + ")!\nThis is likely due to trying to open an Archive file that was not created by Wicked Engine.", "Error!");
+				}
 				Close();
 				return;
 			}

--- a/WickedEngine/wiArchive.h
+++ b/WickedEngine/wiArchive.h
@@ -35,6 +35,7 @@ namespace wi
 	private:
 		Header header;
 		bool readMode = false; // archive can be either read or write mode, but not both
+		bool report_errors = true; // if false, version-incompatibility is silent (IsOpen() stays false) instead of popping a message box; used for internal/automatic reads (e.g. shader cache) that should regenerate rather than alert the user
 		size_t pos = 0; // position of the next memory operation, relative to the data's beginning
 		wi::vector<uint8_t> DATA; // data suitable for read/write operations
 		const uint8_t* data_ptr = nullptr; // this can either be a memory mapped pointer (read only), or the DATA's pointer
@@ -59,7 +60,8 @@ namespace wi
 		// Create archive from a file.
 		//	If readMode == true, the whole file will be loaded into the archive in read mode
 		//	If readMode == false, the file will be written when the archive is destroyed or Close() is called
-		Archive(const std::string& fileName, bool readMode = true);
+		//	If report_errors == false, an incompatible archive version fails silently (IsOpen() == false) instead of popping a message box
+		Archive(const std::string& fileName, bool readMode = true, bool report_errors = true);
 		// Creates a memory mapped archive in read mode
 		Archive(const uint8_t* data, size_t size);
 		~Archive() { Close(); }

--- a/WickedEngine/wiShaderCompiler.cpp
+++ b/WickedEngine/wiShaderCompiler.cpp
@@ -1093,25 +1093,30 @@ namespace wi::shadercompiler
 
 		const uint64_t tim = wi::helper::FileTimestamp(filepath);
 
-		wi::Archive dependencyLibrary(dependencylibrarypath);
-		if (dependencyLibrary.IsOpen())
+		// Open the metadata silently: an incompatible (e.g. newer) cache must
+		// not pop an error box from this worker thread - it just means the
+		// cached shader is stale and should be rebuilt.
+		wi::Archive dependencyLibrary(dependencylibrarypath, true, false);
+		if (!dependencyLibrary.IsOpen())
 		{
-			std::string rootdir = dependencyLibrary.GetSourceDirectory();
-			wi::vector<std::string> dependencies;
-			dependencyLibrary >> dependencies;
+			return true; // unreadable/incompatible metadata = outdated, rebuild it
+		}
 
-			for (auto& x : dependencies)
+		std::string rootdir = dependencyLibrary.GetSourceDirectory();
+		wi::vector<std::string> dependencies;
+		dependencyLibrary >> dependencies;
+
+		for (auto& x : dependencies)
+		{
+			std::string dependencypath = rootdir + x;
+			wi::helper::MakePathAbsolute(dependencypath);
+			if (wi::helper::FileExists(dependencypath))
 			{
-				std::string dependencypath = rootdir + x;
-				wi::helper::MakePathAbsolute(dependencypath);
-				if (wi::helper::FileExists(dependencypath))
-				{
-					const uint64_t dep_tim = wi::helper::FileTimestamp(dependencypath);
+				const uint64_t dep_tim = wi::helper::FileTimestamp(dependencypath);
 
-					if (tim < dep_tim)
-					{
-						return true;
-					}
+				if (tim < dep_tim)
+				{
+					return true;
 				}
 			}
 		}


### PR DESCRIPTION
The Archive constructor was calling messageBox when encountering a version mismatch. When IsShaderOutdated was invoked from a Vulkan job thread to check shader metadata compatibility, this resulted in a GUI call from a worker thread, causing a segfault in the editor.

Solution: add opt-in error reporting to Archive. When loading metadata for shader cache validation, open silently with report_errors=false. If incompatible metadata cannot be opened, return true (rebuild) instead of keeping a stale cache. This allows worker threads to fail gracefully and trigger a rebuild without crashing the editor.

Changes:
- wiArchive.h/cpp: add bool report_errors parameter (default true)
- Gate messageBox calls on if(report_errors) check
- wiShaderCompiler.cpp: open metadata silently in IsShaderOutdated with report_errors=false
- Return true on incompatible read to trigger cache rebuild