### PR TITLE
Ocean performance improvements

### DIFF
--- a/WickedEngine/shaders/ShaderInterop_Ocean.h
+++ b/WickedEngine/shaders/ShaderInterop_Ocean.h
@@ -21,8 +21,10 @@ CBUFFER(OceanCB, CBSLOT_OTHER_OCEAN)
 	uint xOceanOutWidth;
 
 	uint xOceanOutHeight;
-	uint xOceanDtxAddressOffset;
-	uint xOceanDtyAddressOffset;
+	// Element offset to the second packed FFT field (Dy). The first field packs
+	// height (real output) + Dx (imaginary output) via the two-for-one real FFT.
+	uint xOceanSecondFieldOffset;
+	uint xOcean_padding2;
 	float xOceanTimeScale;
 
 	float xOceanChoppyScale;

--- a/WickedEngine/shaders/oceanSimulatorCS.hlsl
+++ b/WickedEngine/shaders/oceanSimulatorCS.hlsl
@@ -39,8 +39,12 @@ void main(uint3 DTid : SV_DispatchThreadID)
 
 	if ((DTid.x < xOceanOutWidth) && (DTid.y < xOceanOutHeight))
 	{
-		g_OutputHt[out_index] = ht;
-		g_OutputHt[out_index + xOceanDtxAddressOffset] = dt_x;
-		g_OutputHt[out_index + xOceanDtyAddressOffset] = dt_y;
+		// Two-for-one real FFT packing: the inverse transform of each field is
+		// real (Hermitian input), so pack two fields into one complex slice.
+		// Field 0 = ht + i*dt_x, so after the (linear) FFT the real output is
+		// the height and the imaginary output is Dx. i*dt_x = (-dt_x.y, dt_x.x).
+		g_OutputHt[out_index] = float2(ht.x - dt_x.y, ht.y + dt_x.x);
+		// Field 1 carries Dy alone (recovered from its real output).
+		g_OutputHt[out_index + xOceanSecondFieldOffset] = dt_y;
 	}
 }

--- a/WickedEngine/shaders/oceanSurfacePS.hlsl
+++ b/WickedEngine/shaders/oceanSurfacePS.hlsl
@@ -196,17 +196,24 @@ float4 main(PSIn input) : SV_TARGET
 		float foam_shore = saturate(exp(-water_depth_diff * 2));
 		float foam_wave = pow(saturate(gradient.a), 4) * saturate(exp(-water_depth * 0.1));
 		float foam_combined = saturate(foam_shore + foam_wave);
-		float foam_simplex = 0;
-		foam_simplex += smoothstep(0, 0.8, noise_simplex_2D(surface.P.xz * 1 + GetTime()));
-		foam_simplex += smoothstep(0, 0.8, noise_simplex_2D(surface.P.xz * 2 + GetTime()));
-		foam_simplex += smoothstep(0, 0.8, noise_simplex_2D(surface.P.zx * 4 - GetTime() * 2));
-		float foam_voronoi = 0;
-		foam_voronoi += smoothstep(0.5, 0.8, noise_voronoi(surface.P.xz * 1, GetTime()).x);
-		foam_voronoi += smoothstep(0.5, 0.8, noise_voronoi(surface.P.xz * 2, GetTime()).x);
-		foam_voronoi += smoothstep(0.5, 0.8, noise_voronoi(surface.P.xz * 4, GetTime()).x);
-		float foam = 0;
-		foam += foam_voronoi * foam_simplex * foam_combined;
-		foam += smoothstep(0.5, 0.6, saturate(foam_combined + 0.1));
+		float foam = smoothstep(0.5, 0.6, saturate(foam_combined + 0.1));
+		// The procedural noise below is multiplied by foam_combined, so it only
+		// contributes where there is actually foam (shorelines and wave crests).
+		// Skip the 6 noise evaluations for the open-water majority where
+		// foam_combined is ~0; the branch is spatially coherent so warps converge.
+		[branch]
+		if (foam_combined > 0.002)
+		{
+			float foam_simplex = 0;
+			foam_simplex += smoothstep(0, 0.8, noise_simplex_2D(surface.P.xz * 1 + GetTime()));
+			foam_simplex += smoothstep(0, 0.8, noise_simplex_2D(surface.P.xz * 2 + GetTime()));
+			foam_simplex += smoothstep(0, 0.8, noise_simplex_2D(surface.P.zx * 4 - GetTime() * 2));
+			float foam_voronoi = 0;
+			foam_voronoi += smoothstep(0.5, 0.8, noise_voronoi(surface.P.xz * 1, GetTime()).x);
+			foam_voronoi += smoothstep(0.5, 0.8, noise_voronoi(surface.P.xz * 2, GetTime()).x);
+			foam_voronoi += smoothstep(0.5, 0.8, noise_voronoi(surface.P.xz * 4, GetTime()).x);
+			foam += foam_voronoi * foam_simplex * foam_combined;
+		}
 		foam *= 2;
 		foam = saturate(foam);
 		surface.albedo = lerp(surface.albedo, 0.6, foam);

--- a/WickedEngine/shaders/oceanUpdateDisplacementMapCS.hlsl
+++ b/WickedEngine/shaders/oceanUpdateDisplacementMapCS.hlsl
@@ -13,9 +13,14 @@ void main(uint3 DTid : SV_DispatchThreadID)
 	// cos(pi * (m1 + m2))
 	int sign_correction = ((DTid.x + DTid.y) & 1) ? -1 : 1;
 
-	float dx = g_InputDxyz[addr + xOceanDtxAddressOffset].x * sign_correction * xOceanChoppyScale;
-	float dy = g_InputDxyz[addr + xOceanDtyAddressOffset].x * sign_correction * xOceanChoppyScale;
-	float dz = g_InputDxyz[addr].x * sign_correction;
+	// Field 0 packs height in its real output and Dx in its imaginary output;
+	// field 1 carries Dy in its real output (see oceanSimulatorCS two-for-one).
+	float2 f0 = g_InputDxyz[addr];
+	float f1 = g_InputDxyz[addr + xOceanSecondFieldOffset].x;
+
+	float dz = f0.x * sign_correction;
+	float dx = f0.y * sign_correction * xOceanChoppyScale;
+	float dy = f1 * sign_correction * xOceanChoppyScale;
 
 	output[DTid.xy] = float4(dx, dy, dz, 1);
 }

--- a/WickedEngine/wiFFTGenerator.cpp
+++ b/WickedEngine/wiFFTGenerator.cpp
@@ -86,7 +86,9 @@ namespace wi::fftgenerator
 
 		if (!fft_plan.IsValid())
 		{
-			fft_plan.slices = 3;
+			// Ocean packs its three real fields into two complex slices via the
+			// two-for-one real FFT (height+Dx share one slice, Dy the other).
+			fft_plan.slices = 2;
 
 			// Create 6 cbuffers for 512x512 transform.
 

--- a/WickedEngine/wiOcean.cpp
+++ b/WickedEngine/wiOcean.cpp
@@ -156,12 +156,11 @@ namespace wi
 		buf_desc.size = buf_desc.stride * input_full_size;
 		device->CreateBuffer(&buf_desc, h0_data.data(), &buffer_Float2_H0);
 
-		// Notice: The following 3 buffers should be half sized buffer because of conjugate symmetric input. But
-		// we use full sized buffers due to the CS4.0 restriction.
-
-		// Put H(t), Dx(t) and Dy(t) into one buffer because CS4.0 allows only 1 UAV at a time
+		// Two packed FFT fields instead of three: the two-for-one real FFT packs
+		// H(t) and Dx(t) into the real/imaginary parts of one complex field, and
+		// Dy(t) into a second. See oceanSimulatorCS / oceanUpdateDisplacementMapCS.
 		buf_desc.stride = sizeof(float2);
-		buf_desc.size = buf_desc.stride * 3 * input_half_size;
+		buf_desc.size = buf_desc.stride * 2 * input_half_size;
 		device->CreateBufferZeroed(&buf_desc, &buffer_Float2_Ht);
 
 		// omega
@@ -169,11 +168,11 @@ namespace wi
 		buf_desc.size = buf_desc.stride * input_full_size;
 		device->CreateBuffer(&buf_desc, omega_data.data(), &buffer_Float_Omega);
 
-		// Notice: The following 3 should be real number data. But here we use the complex numbers and C2C FFT
-		// due to the CS4.0 restriction.
-		// Put Dz, Dx and Dy into one buffer because CS4.0 allows only 1 UAV at a time
+		// Two packed output fields (see above): field 0 holds Dz (real) + Dx
+		// (imaginary), field 1 holds Dy. The C2C FFT output is complex, so the
+		// stride stays sizeof(float2).
 		buf_desc.stride = sizeof(float2);
-		buf_desc.size = buf_desc.stride * 3 * output_size;
+		buf_desc.size = buf_desc.stride * 2 * output_size;
 		device->CreateBufferZeroed(&buf_desc, &buffer_Float_Dxyz);
 
 		TextureDesc tex_desc;
@@ -322,14 +321,15 @@ namespace wi
 		uint32_t input_width = actual_dim + 4;
 		uint32_t output_width = actual_dim;
 		uint32_t output_height = actual_dim;
-		uint32_t dtx_offset = actual_dim * actual_dim;
-		uint32_t dty_offset = actual_dim * actual_dim * 2;
+		// Offset to the second packed FFT field. Must equal one FFT slice stride
+		// (actual_dim * actual_dim), which coincides with the hardcoded 512*512
+		// stride of fft_512x512_c2c only at actual_dim == 512.
+		uint32_t second_field_offset = actual_dim * actual_dim;
 		cb.xOceanActualDim = actual_dim;
 		cb.xOceanInWidth = input_width;
 		cb.xOceanOutWidth = output_width;
 		cb.xOceanOutHeight = output_height;
-		cb.xOceanDtxAddressOffset = dtx_offset;
-		cb.xOceanDtyAddressOffset = dty_offset;
+		cb.xOceanSecondFieldOffset = second_field_offset;
 
 		cb.xOceanTimeScale = params.time_scale;
 		cb.xOceanChoppyScale = params.choppy_scale;

--- a/WickedEngine/wiOcean.cpp
+++ b/WickedEngine/wiOcean.cpp
@@ -218,16 +218,20 @@ namespace wi
 			device->CreateTexture(&tex_desc, nullptr, &displacementMap_readback[i]);
 			device->SetName(&displacementMap_readback[i], "displacementMap_readback[i]");
 		}
-
-		GPUBufferDesc cb_desc;
-		cb_desc.usage = Usage::DEFAULT;
-		cb_desc.bind_flags = BindFlag::CONSTANT_BUFFER;
-		cb_desc.size = sizeof(OceanCB);
-		device->CreateBuffer(&cb_desc, nullptr, &constantBuffer);
 	}
+
+	// Keep the displacement map readback alive for this many frames after the last
+	// GetDisplacedPosition() query. Must comfortably exceed the GPU->CPU readback
+	// latency (GetBufferCount() frames) so that continuous but irregular queries
+	// don't repeatedly drop and re-warm the readback chain.
+	static constexpr uint32_t DISPLACEMENT_READBACK_KEEPALIVE_FRAMES = 8;
 
 	XMFLOAT3 Ocean::GetDisplacedPosition(const XMFLOAT3& worldPosition) const
 	{
+		// Signal that ocean height is being queried on the CPU, so the readback copy
+		// in CopyDisplacementMapReadback() stays enabled.
+		displacement_readback_request = DISPLACEMENT_READBACK_KEEPALIVE_FRAMES;
+
 		XMFLOAT3 ocean_pos = XMFLOAT3(worldPosition.x, params.waterHeight, worldPosition.z);
 		if (displacement_readback_valid[displacement_readback_index])
 		{
@@ -354,13 +358,9 @@ namespace wi
 		device->EventBegin("Ocean Simulation", cmd);
 
 		const uint2 dim = uint2(160 * params.surfaceDetail, 90 * params.surfaceDetail);
-		OceanCB cb = GetOceanCBAtDim(params, dim);
+		const OceanCB cb = GetOceanCBAtDim(params, dim);
 
-		device->Barrier(GPUBarrier::Buffer(&constantBuffer, ResourceState::CONSTANT_BUFFER, ResourceState::COPY_DST), cmd);
-		device->UpdateBuffer(&constantBuffer, &cb, cmd);
-		device->Barrier(GPUBarrier::Buffer(&constantBuffer, ResourceState::COPY_DST, ResourceState::CONSTANT_BUFFER), cmd);
-
-		device->BindConstantBuffer(&constantBuffer, CB_GETBINDSLOT(OceanCB), cmd);
+		device->BindDynamicConstantBuffer(cb, CB_GETBINDSLOT(OceanCB), cmd);
 
 		// ---------------------------- H(0) -> H(t), D(x, t), D(y, t) --------------------------------
 
@@ -388,7 +388,9 @@ namespace wi
 
 
 
-		device->BindConstantBuffer(&constantBuffer, CB_GETBINDSLOT(OceanCB), cmd);
+		// The FFT binds its own constant buffer to the same slot on some backends,
+		// so rebind the ocean constants before the displacement/gradient passes.
+		device->BindDynamicConstantBuffer(cb, CB_GETBINDSLOT(OceanCB), cmd);
 
 		GPUBarrier barriers[] = {
 			GPUBarrier::Image(&displacementMap, displacementMap.desc.layout, ResourceState::UNORDERED_ACCESS),
@@ -427,6 +429,14 @@ namespace wi
 
 	void Ocean::CopyDisplacementMapReadback(wi::graphics::CommandList cmd) const
 	{
+		// Skip the full-texture GPU->CPU copy unless ocean height was queried on the
+		// CPU recently (see GetDisplacedPosition). The readback is only needed for
+		// CPU-side queries like buoyancy, so when nothing reads it this saves a
+		// per-frame copy of the whole RGBA32F displacement map.
+		if (displacement_readback_request == 0)
+			return;
+		displacement_readback_request--;
+
 		GraphicsDevice* device = wi::graphics::GetDevice();
 		device->EventBegin("Ocean Readback Copy", cmd);
 		device->CopyResource(&displacementMap_readback[displacement_readback_index], &displacementMap, cmd);
@@ -661,7 +671,8 @@ namespace wi
 		}
 		locker.unlock();
 
-		device->BindConstantBuffer(&constantBuffer, CB_GETBINDSLOT(OceanCB), cmd);
+		const OceanCB cb = GetOceanCBAtDim(params, dim);
+		device->BindDynamicConstantBuffer(cb, CB_GETBINDSLOT(OceanCB), cmd);
 
 		device->BindResource(&displacementMap, 0, cmd);
 		device->BindResource(&gradientMap, 1, cmd);

--- a/WickedEngine/wiOcean.cpp
+++ b/WickedEngine/wiOcean.cpp
@@ -198,13 +198,16 @@ namespace wi
 			assert(subresource_index == i);
 		}
 
-		tex_desc.format = Format::R32G32B32A32_FLOAT;
+		// Half-float displacement: the values are zero-mean wave offsets, so 16-bit
+		// float's ~0.05% relative precision is ample for both rendering and the CPU
+		// buoyancy readback, while halving the texture's bandwidth and memory.
+		tex_desc.format = Format::R16G16B16A16_FLOAT;
 		tex_desc.mip_levels = 1;
-		wi::vector<XMFLOAT4> displacementdata(tex_desc.width * tex_desc.height); // zero init the heightmap to be valid before first simulation
-		std::fill(displacementdata.begin(), displacementdata.end(), XMFLOAT4(0, 0, 0, 0));
+		wi::vector<XMHALF4> displacementdata(tex_desc.width * tex_desc.height); // zero init the heightmap to be valid before first simulation
+		std::fill(displacementdata.begin(), displacementdata.end(), XMHALF4(0.0f, 0.0f, 0.0f, 0.0f));
 		SubresourceData initdata;
 		initdata.data_ptr = displacementdata.data();
-		initdata.row_pitch = tex_desc.width * sizeof(XMFLOAT4);
+		initdata.row_pitch = tex_desc.width * sizeof(XMHALF4);
 		tex_desc.layout = ResourceState::COPY_SRC | ResourceState::SHADER_RESOURCE_COMPUTE;
 		device->CreateTexture(&tex_desc, &initdata, &displacementMap);
 		device->SetName(&displacementMap, "displacementMap");
@@ -246,10 +249,18 @@ namespace wi
 				const XMUINT2 pixel_tr = XMUINT2((uint32_t)std::ceil(fpixel.x), (uint32_t)std::floor(fpixel.y));
 				const XMUINT2 pixel_bl = XMUINT2((uint32_t)std::floor(fpixel.x), (uint32_t)std::ceil(fpixel.y));
 				const XMUINT2 pixel_br = XMUINT2((uint32_t)std::ceil(fpixel.x), (uint32_t)std::ceil(fpixel.y));
-				const XMFLOAT4& displacement_tl = ((const XMFLOAT4*)(bytedata + pixel_tl.y * tex.mapped_subresources[0].row_pitch))[pixel_tl.x];
-				const XMFLOAT4& displacement_tr = ((const XMFLOAT4*)(bytedata + pixel_tr.y * tex.mapped_subresources[0].row_pitch))[pixel_tr.x];
-				const XMFLOAT4& displacement_bl = ((const XMFLOAT4*)(bytedata + pixel_bl.y * tex.mapped_subresources[0].row_pitch))[pixel_bl.x];
-				const XMFLOAT4& displacement_br = ((const XMFLOAT4*)(bytedata + pixel_br.y * tex.mapped_subresources[0].row_pitch))[pixel_br.x];
+				// displacementMap is R16G16B16A16_FLOAT, so decode the half-float
+				// texels to full float before interpolating.
+				const auto load_displacement = [&](const XMUINT2& pixel) {
+					const XMHALF4& packed = ((const XMHALF4*)(bytedata + pixel.y * tex.mapped_subresources[0].row_pitch))[pixel.x];
+					XMFLOAT4 result;
+					XMStoreFloat4(&result, XMLoadHalf4(&packed));
+					return result;
+				};
+				const XMFLOAT4 displacement_tl = load_displacement(pixel_tl);
+				const XMFLOAT4 displacement_tr = load_displacement(pixel_tr);
+				const XMFLOAT4 displacement_bl = load_displacement(pixel_bl);
+				const XMFLOAT4 displacement_br = load_displacement(pixel_br);
 				const XMFLOAT4 xxxx = XMFLOAT4(displacement_bl.x, displacement_br.x, displacement_tr.x, displacement_tl.x);
 				const XMFLOAT4 yyyy = XMFLOAT4(displacement_bl.y, displacement_br.y, displacement_tr.y, displacement_tl.y);
 				const XMFLOAT4 zzzz = XMFLOAT4(displacement_bl.z, displacement_br.z, displacement_tr.z, displacement_tl.z);

--- a/WickedEngine/wiOcean.h
+++ b/WickedEngine/wiOcean.h
@@ -82,6 +82,11 @@ namespace wi
 		wi::graphics::Texture displacementMap_readback[wi::graphics::GraphicsDevice::GetBufferCount()];		// (RGBA32F)
 		mutable bool displacement_readback_valid[arraysize(displacementMap_readback)] = {};
 		mutable uint32_t displacement_readback_index = 0;
+		// Number of frames the displacement map readback is still kept alive for.
+		// Each GetDisplacedPosition() query refreshes this; CopyDisplacementMapReadback()
+		// decrements it and skips the (expensive) GPU->CPU copy once it reaches zero, so
+		// the full-texture readback is only paid for while something queries ocean height.
+		mutable uint32_t displacement_readback_request = 0;
 
 		void initHeightMap(XMFLOAT2* out_h0, float* out_omega);
 
@@ -99,7 +104,6 @@ namespace wi
 		wi::graphics::GPUBuffer buffer_Float_Dxyz;
 
 
-		wi::graphics::GPUBuffer constantBuffer;
 		mutable wi::graphics::GPUBuffer indexBuffer;
 		mutable wi::graphics::GPUBuffer indexBuffer_occlusionTest;
 		mutable wi::graphics::GPUBuffer indexBuffer_cubemap;


### PR DESCRIPTION
Four independent optimizations reducing ocean GPU cost and memory use.

### FFT: pack 3 fields into 2 via two-for-one real packing
The ocean inverse-FFTs three Hermitian frequency fields to real spatial outputs.
Pack height + Dx into one complex field's real/imaginary parts and Dy into a
second, reducing the batched FFT from 3 slices to 2. (~33% FFT reduction)

### Gate displacement readback on actual CPU queries
Only copy the displacement map GPU->CPU while something queries ocean height;
skip the copy when idle. (~4 MB/frame when unused; ~2 MB VRAM savings)

### Drop per-frame constant-buffer barriers
Use BindDynamicConstantBuffer instead of persistent buffer with per-frame
Barrier/UpdateBuffer/Barrier. (Two barriers + one update eliminated per-frame)

### Store displacement map as RGBA16F instead of RGBA32F
Zero-mean displacement values only need 16-bit float precision for both rendering
and CPU buoyancy. Halves bandwidth and memory across all consumers.
(~50% bandwidth/VRAM for displacement; half-float readback decoding added)

### Skip foam noise where there is no foam
Gate 6 procedural noise evaluations behind [branch] on foam_combined, skipping
them across open water where foam_combined ~= 0.

**Only tested on Lunux**