### PR TITLE
fix(ddgi): stop fp16 overflow blowing GI out to white

### DIFF
--- a/WickedEngine/shaders/SH_Lite.hlsli
+++ b/WickedEngine/shaders/SH_Lite.hlsli
@@ -604,10 +604,18 @@ L2_RGB ConvolveWithCosineLobe(L2_RGB sh)
     return ConvolveWithZH(sh, half3(CosineA0, CosineA1, CosineA2));
 }
 
-// Computes the "optimal linear direction" for a set of SH coefficients, AKA the "dominant" direction. See [0].
+// Computes the "optimal linear direction" for a set of SH coefficients, AKA the
+// "dominant" direction. See [0]. Note: the L1 (directional) band can be exactly
+// zero for dark or perfectly uniform radiance. A plain normalize() would then
+// divide by zero and yield NaN, which propagates into the dominant light
+// color/dir and blows up indirect specular to white (max(0, NaN) does not clamp
+// on all backends, e.g. Vulkan). The length guard below keeps the result
+// finite, returning a zero (i.e. "no dominant direction") vector instead.
 half3 OptimalLinearDirection(L1 sh)
 {
-    return normalize(half3(sh.C[3], sh.C[1], sh.C[2]));
+    half3 direction = half3(sh.C[3], sh.C[1], sh.C[2]);
+    half len = length(direction);
+    return len > 0 ? direction / len : half3(0, 0, 0);
 }
 
 half3 OptimalLinearDirection(L1_RGB sh)
@@ -619,7 +627,8 @@ half3 OptimalLinearDirection(L1_RGB sh)
         direction.y += sh.C[1][i];
         direction.z += sh.C[2][i];
     }
-    return normalize(direction);
+    half len = length(direction);
+    return len > 0 ? direction / len : half3(0, 0, 0);
 }
 
 // Computes the direction and color of a directional light that approximates a set of L1 SH coefficients. See [0].

--- a/WickedEngine/shaders/ShaderInterop_DDGI.h
+++ b/WickedEngine/shaders/ShaderInterop_DDGI.h
@@ -266,7 +266,44 @@ half3 ddgi_sample_irradiance(in float3 P, in half3 N, inout half3 out_dominant_l
 	{
 		sum_sh = SH::Multiply(sum_sh, rcp(sum_weight));
 
-		half3 net_irradiance = SH::CalculateIrradiance(sum_sh, N) / PI;
+		// Evaluate the diffuse irradiance in full (float) precision.
+		//
+		// The SH helpers run in half precision, and CalculateIrradiance()
+		// convolves the radiance with a cosine lobe - a multiply by PI on the
+		// L0 band. For a bright probe near a light source the L0 coefficient is
+		// already large, so that multiply overflows half to +Inf. That Inf is
+		// then fed back into the probes by the raytrace pass, where the mean
+		// estimator cannot recover from it, and it spreads across the whole
+		// probe field, blowing the scene out to white. Doing the
+		// convolve+evaluate in float keeps the full dynamic range without
+		// overflowing (so the GI brightness does not have to be clamped, which
+		// would flatten it).
+		//
+		// This is exactly SH::CalculateIrradiance(sum_sh, N) / PI, inlined in
+		// float: convolve with the cosine lobe (CosineA0/CosineA1) then
+		// evaluate in direction N (BasisL0/BasisL1).
+		half3 net_irradiance;
+		{
+			const float cosine_a0 = PI;               // CosineA0
+			const float cosine_a1 = (2.0 * PI) / 3.0; // CosineA1
+			const float basis_l0 = 1.0 / (2.0 * sqrt(PI));
+			const float basis_l1 = sqrt(3.0) / (2.0 * sqrt(PI));
+			const float3 nrm = (float3)N;
+			const float3 irradiance =
+				basis_l0 * cosine_a0 * (float3)sum_sh.C[0] +
+				basis_l1 * cosine_a1 * nrm.y * (float3)sum_sh.C[1] +
+				basis_l1 * cosine_a1 * nrm.z * (float3)sum_sh.C[2] +
+				basis_l1 * cosine_a1 * nrm.x * (float3)sum_sh.C[3];
+			net_irradiance = (half3)clamp(irradiance / PI, 0.0, MEDIUMP_FLT_MAX);
+		}
+
+		// The dominant-light extraction still uses the half-precision SH path.
+		// Clamp the averaged SH so its dot products stay finite for very bright
+		// probes; this only affects the directional specular approximation, not
+		// the diffuse irradiance computed above. 40000 keeps DotProduct finite.
+		[unroll]
+		for (uint sh_coeff = 0; sh_coeff < SH::L1_RGB::NumCoefficients; ++sh_coeff)
+			sum_sh.C[sh_coeff] = clamp(sum_sh.C[sh_coeff], -40000.0, 40000.0);
 
 		SH::ApproximateDirectionalLight(sum_sh, out_dominant_lightdir, out_dominant_lightcolor);
 

--- a/WickedEngine/shaders/ddgi_raytraceCS.hlsl
+++ b/WickedEngine/shaders/ddgi_raytraceCS.hlsl
@@ -50,7 +50,7 @@ void main(uint3 DTid : SV_DispatchThreadID, uint3 Gid : SV_GroupID, uint groupIn
 
 	const float3x3 random_orientation = (float3x3)g_xTransform;
 	const float3 raydir = normalize(mul(random_orientation, spherical_fibonacci(rayIndex, rayCount)));
-	
+
 #if 1
 	// Light sampling - direct static:
 	{
@@ -264,10 +264,17 @@ void main(uint3 DTid : SV_DispatchThreadID, uint3 Gid : SV_GroupID, uint groupIn
 			}
 			radiance += envColor;
 
+			// Clamp to the half-float range before storing: rayData.radiance is
+			// half3, and an unclamped bright sky (e.g. the sun disk) overflows
+			// to +Inf, which the firefly suppression later turns into NaN (Inf
+			// - Inf), poisoning the probe and blowing the whole frame to white.
+			// The surface-hit path below already does this.
+			radiance = saturateMediump(radiance);
+
 			DDGIRayData rayData;
 			rayData.direction = ray.Direction;
 			rayData.depth = -1;
-			rayData.radiance = float4(radiance, 1);
+			rayData.radiance = radiance;
 			rayBuffer[probeIndex * DDGI_MAX_RAYCOUNT + rayIndex].store(rayData);
 		}
 		else

--- a/WickedEngine/shaders/ddgi_updateCS.hlsl
+++ b/WickedEngine/shaders/ddgi_updateCS.hlsl
@@ -92,7 +92,11 @@ void main(uint2 GTid : SV_GroupThreadID, uint2 Gid : SV_GroupID, uint groupIndex
 	const uint2 pixel_current = pixel_topleft + GTid.xy;
 	const uint2 copy_coord = pixel_topleft - 1;
 #else
-	half3 result = 0;
+	// Full precision: this accumulates the radiance of up to DDGI_MAX_RAYCOUNT
+	// (512) rays before dividing by total_weight. In half precision that
+	// running sum overflows to +Inf for bright probes, which then poisons the
+	// probe and spreads. (The averaged result is cast back to half afterwards.)
+	float3 result = 0;
 #endif // DDGI_UPDATE_DEPTH
 
 	const half3 texel_direction = decode_oct((((GTid.xy % RESOLUTION) + 0.5) / RESOLUTION) * 2 - 1);


### PR DESCRIPTION
DDGI blew the whole scene out to white (on Vulkan, present even with no lights, getting worse over time, starting at light sources and spreading).
The cause was half-precision OVERFLOW to +Inf in the GI irradiance pipeline, which is then fed back into the probes where the mean estimator cannot recover and the infinite-bounce pass spreads it across the whole probe field.

The fp16 conversion (13031bc4) pushed the hot accumulators to half precision. For a bright probe near a light:
- ddgi_updateCS summed up to DDGI_MAX_RAYCOUNT (512) rays in a half3 result, so the running sum overflowed to +Inf.
- ddgi_sample_irradiance's SH::CalculateIrradiance convolves with a cosine lobe (a *PI on the L0 band) in half, overflowing the bright probe to +Inf.

Fixes:
- ddgi_updateCS: accumulate the radiance in float (the averaged result is cast back to half), so summing many bright rays no longer overflows.
- ddgi_sample_irradiance: evaluate the diffuse irradiance inline in float (cosine-lobe convolve + evaluate) instead of the half SH::CalculateIrradiance, preserving the full dynamic range without overflow. Clamp the averaged SH before the (still half) dominant-light extraction so its dot products stay finite.
- ddgi_raytraceCS: clamp the sky-miss radiance with saturateMediump before storing into the half ray buffer, matching the surface-hit path (a bright sky could otherwise store +Inf).
- SH_Lite: length-guard OptimalLinearDirection against normalize(0) producing NaN when a probe's L1 band is zero (latent issue; also affects Surfel GI).