### PR TITLE
Grass particle fixes

### DIFF
--- a/WickedEngine/shaders/hairparticle_simulateCS.hlsl
+++ b/WickedEngine/shaders/hairparticle_simulateCS.hlsl
@@ -99,7 +99,7 @@ void main(uint3 DTid : SV_DispatchThreadID, uint3 Gid : SV_GroupID, uint groupIn
 	float3 diff = GetCamera().position - base;
 	const float distsq = dot(diff, diff);
 	const bool distance_culled = distsq > sqr(xHairViewDistance);
-	
+
 	// Frustum culling the whole strand at once:
 	//	intentionally overestimated, to not disappear as soon in different views (shadow map, etc)
 	ShaderSphere sphere;
@@ -155,8 +155,12 @@ void main(uint3 DTid : SV_DispatchThreadID, uint3 Gid : SV_GroupID, uint groupIn
 		bend = GetCamera().up * (1 - saturate(dot(target, GetCamera().up))) * 0.8;
 	}
 
+	// Compute the actual billboard normal direction (matching geometry
+	// orientation)
+	half3 billboard_normal = normalize(target + bend);
+
 	// Bottom vertices:
-	half3x3 TBN = half3x3(tangent, normalize(target + bend), binormal);
+	half3x3 TBN = half3x3(tangent, billboard_normal, binormal);
 	if (distance_culled)
 	{
 		// Strand is beyond the view distance, so it is never rendered: no
@@ -235,7 +239,7 @@ void main(uint3 DTid : SV_DispatchThreadID, uint3 Gid : SV_GroupID, uint groupIn
 				}
 
 				vertexBuffer_POS[v0] = float4(position, 0);
-				vertexBuffer_NOR[v0] = half4(target, 0);
+				vertexBuffer_NOR[v0] = half4(billboard_normal, 0);
 				vertexBuffer_UVS[v0] = uv.xyxy; // a second uv set could be used here
 				if (xHairFlags & HAIR_FLAG_RAYTRACED)
 				{
@@ -496,7 +500,14 @@ void main(uint3 DTid : SV_DispatchThreadID, uint3 Gid : SV_GroupID, uint groupIn
 					}
 
 					vertexBuffer_POS[v0] = float4(position, 0);
-					vertexBuffer_NOR[v0] = half4(normal, 0);
+					// Store the bent normal (matching the billboard's actual
+					// orientation, TBN above), not the raw strand direction.
+					// Otherwise a wind/gravity-bent card is shaded as if it
+					// still pointed along the strand, which reads as a dark,
+					// pulsating patch when viewed from above (normal facing
+					// away from both the view and the light). Kept consistent
+					// with the root vertices, which also store the bent normal.
+					vertexBuffer_NOR[v0] = half4(normal_bend, 0);
 					vertexBuffer_UVS[v0] = uv.xyxy; // a second uv set could be used here
 					if (xHairFlags & HAIR_FLAG_RAYTRACED)
 					{

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -5752,7 +5752,14 @@ void UpdateRaytracingAccelerationStructures(const Scene& scene, CommandList cmd)
 
 				if (hair.meshID != INVALID_ENTITY && hair.BLAS.IsValid())
 				{
-					device->BuildRaytracingAccelerationStructure(&hair.BLAS, cmd, nullptr);
+					// Full rebuild when the structure is new/dirty or the
+					// camera has moved far enough to warrant refreshing BVH
+					// quality; otherwise refit in place (much cheaper) to track
+					// per-frame strand animation.
+					const bool rebuild = hair.must_rebuild_blas || motion_rebuild;
+					device->BuildRaytracingAccelerationStructure(
+						&hair.BLAS, cmd, rebuild ? nullptr : &hair.BLAS
+					);
 					hair.must_rebuild_blas = false;
 				}
 			}


### PR DESCRIPTION
Optimize grass/hair particle rendering and fix visual artifacts when viewed from above.

- **Hair BLAS refit optimization**: Wire the `motion_rebuild` heuristic to refit instead of full-rebuild every frame when the camera is settled. Full rebuilds only trigger on camera motion or structure changes, matching the documented design. Reduces per-frame BLAS cost for grass-heavy scenes from full rebuild to cheap refit during idle camera movement.

- **Grass billboard normal consistency fix**: Root and cap/segment vertices were using inconsistent normals (bent vs. unbent), causing incorrect lighting when wind/gravity bent the grass. Now all vertices store the bent normal matching the actual billboard orientation. Eliminates dark pulsating patches visible when camera is directly above grass.