### PR TITLE
Fix/stable instance slots

### DIFF
--- a/WickedEngine/shaders/impostor_prepareCS.hlsl
+++ b/WickedEngine/shaders/impostor_prepareCS.hlsl
@@ -29,6 +29,11 @@ void main(uint3 DTid : SV_DispatchThreadID)
 	if (DTid.x >= push.count)
 		return;
 
+	// The thread index is a stable instance slot, which spans the whole [0,
+	// objectInstanceCapacity) range and can contain gaps (slots whose object
+	// was removed). A gap is initialized invalid (geometryCount == 0); skip it
+	// so it is not mistaken for a real impostor object (load_geometry below
+	// would otherwise read geometry 0's slice offset for it).
 	const uint instanceIndex = DTid.x;
 	ShaderMeshInstance instance = load_instance(instanceIndex);
 	ShaderGeometry geometry = load_geometry(instance.geometryOffset);
@@ -41,7 +46,8 @@ void main(uint3 DTid : SV_DispatchThreadID)
 	sphere.center = instance.center;
 	sphere.radius = instance.radius;
 
-	const bool visible = geometry.impostorSliceOffset >= 0 && !distance_culled && GetCamera().frustum.intersects(sphere);
+	const bool valid = instance.geometryCount > 0;
+	const bool visible = valid && geometry.impostorSliceOffset >= 0 && !distance_culled && GetCamera().frustum.intersects(sphere);
 
 	// Optimization: reduce to 1 atomic operation per wave
 	const uint waveAppendCount = WaveActiveCountBits(visible);

--- a/WickedEngine/wiGPUBVH.cpp
+++ b/WickedEngine/wiGPUBVH.cpp
@@ -166,7 +166,7 @@ namespace wi
 						const MeshComponent::MeshSubset& subset = mesh.subsets[subsetIndex];
 
 						BVHPushConstants push;
-						push.instanceIndex = (uint)i;
+						push.instanceIndex = object.gpuInstanceIndex; // stable GPU instance slot
 						push.subsetIndex = subsetIndex;
 						push.primitiveCount = subset.indexCount / 3;
 						push.primitiveOffset = primitiveCount;
@@ -192,7 +192,7 @@ namespace wi
 				if (hair.meshID != INVALID_ENTITY)
 				{
 					BVHPushConstants push;
-					push.instanceIndex = (uint)(scene.objects.GetCount() + i);
+					push.instanceIndex = (uint)(scene.objectInstanceCapacity + i);
 					push.subsetIndex = 0;
 					push.primitiveCount = hair.segmentCount * hair.strandCount * 2;
 					push.primitiveOffset = primitiveCount;
@@ -216,7 +216,7 @@ namespace wi
 				if (emitter.GetMaxParticleCount() > 0)
 				{
 					BVHPushConstants push;
-					push.instanceIndex = (uint)(scene.objects.GetCount() + i);
+					push.instanceIndex = (uint)(scene.objectInstanceCapacity + i);
 					push.subsetIndex = 0;
 					push.primitiveCount = emitter.GetMaxParticleCount() * 2;
 					push.primitiveOffset = primitiveCount;

--- a/WickedEngine/wiRenderer.cpp
+++ b/WickedEngine/wiRenderer.cpp
@@ -3433,7 +3433,9 @@ void RenderMeshes(
 				continue;
 
 			ShaderMeshInstancePointer poi;
-			poi.Create(instanceIndex, camera_index, dither);
+			// Hand the GPU the object's stable instance slot, not the
+			// ComponentManager index used for the CPU-side lookups above.
+			poi.Create(instance.gpuInstanceIndex, camera_index, dither);
 
 			// Write into actual GPU-buffer:
 			std::memcpy((ShaderMeshInstancePointer*)instances.data + instanceCount, &poi, sizeof(poi)); // memcpy whole structure into mapped pointer to avoid read from uncached memory
@@ -5336,7 +5338,7 @@ void UpdateRenderData(
 					const MaterialComponent& material = vis.scene->materials[materialIndex];
 					auto& hair_update = hair_updates.emplace_back();
 					hair_update.hair = &hair;
-					hair_update.instanceIndex = (uint32_t)vis.scene->objects.GetCount() + hairIndex;
+					hair_update.instanceIndex = vis.scene->objectInstanceCapacity + hairIndex;
 					hair_update.mesh = mesh;
 					hair_update.material = &material;
 				}
@@ -5372,10 +5374,13 @@ void UpdateRenderData(
 		device->BindUAV(&vis.scene->impostorBuffer, 3, cmd, vis.scene->impostor_data.subresource_uav);
 		device->BindUAV(&vis.scene->impostorBuffer, 4, cmd, vis.scene->impostor_indirect.subresource_uav);
 
-		uint object_count = (uint)vis.scene->objects.GetCount();
-		device->PushConstants(&object_count, sizeof(object_count), cmd);
+		// Iterate the full stable instance-slot range (objects live at sparse
+		// slots with gaps), not the dense object count. Gap slots are skipped
+		// in the shader by their invalid (geometryCount == 0) instance data.
+		uint slot_count = vis.scene->objectInstanceCapacity;
+		device->PushConstants(&slot_count, sizeof(slot_count), cmd);
 
-		device->Dispatch((object_count + 63u) / 64u, 1, 1, cmd);
+		device->Dispatch((slot_count + 63u) / 64u, 1, 1, cmd);
 
 		PushBarrier(GPUBarrier::Buffer(&vis.scene->impostorBuffer, ResourceState::UNORDERED_ACCESS, ResourceState::SHADER_RESOURCE | ResourceState::INDIRECT_ARGUMENT));
 		FlushBarriers(cmd);
@@ -5609,7 +5614,7 @@ void UpdateRenderDataAsync(
 			Entity entity = vis.scene->emitters.GetEntity(emitterIndex);
 			const TransformComponent& transform = *vis.scene->transforms.GetComponent(entity);
 			const MeshComponent* mesh = vis.scene->meshes.GetComponent(emitter.meshID);
-			const uint32_t instanceIndex = uint32_t(vis.scene->objects.GetCount() + vis.scene->hairs.GetCount()) + emitterIndex;
+			const uint32_t instanceIndex = vis.scene->objectInstanceCapacity + uint32_t(vis.scene->hairs.GetCount()) + emitterIndex;
 
 			emitter.UpdateGPU(instanceIndex, mesh, cmd);
 		}
@@ -8814,7 +8819,7 @@ void DrawDebugWorld(
 
 			GraphicsDevice::GPUAllocation mem = device->AllocateGPU(sizeof(ShaderMeshInstancePointer), cmd);
 			ShaderMeshInstancePointer poi;
-			poi.Create((uint)scene.objects.GetIndex(x.objectEntity));
+			poi.Create(object.gpuInstanceIndex); // stable GPU instance slot
 			std::memcpy(mem.data, &poi, sizeof(poi));
 
 			device->BindIndexBuffer(&mesh.generalBuffer, mesh.GetIndexFormat(), mesh.ib.offset, cmd);
@@ -10018,7 +10023,7 @@ void PaintDecals(const Scene& scene, CommandList cmd)
 		PaintDecalCB cb = {};
 		XMStoreFloat4x4(&cb.g_xPaintDecalMatrix, XMMatrixInverse(nullptr, XMLoadFloat4x4(&paint.decalMatrix)));
 		cb.g_xPaintDecalTexture = device->GetDescriptorIndex(&paint.in_texture, SubresourceType::SRV);
-		cb.g_xPaintDecalInstanceID = (uint)scene.objects.GetIndex(paint.objectEntity);
+		cb.g_xPaintDecalInstanceID = object.gpuInstanceIndex; // stable GPU instance slot
 		cb.g_xPaintDecalSlopeBlendPower = paint.slopeBlendPower;
 
 		device->BindPipelineState(&PSO_paintdecal, cmd);
@@ -11271,7 +11276,7 @@ void RefreshLightmaps(const Scene& scene, CommandList cmd)
 			push.vb_pos_wind = mesh.vb_pos_wind.descriptor_srv;
 			push.vb_nor = mesh.vb_nor.descriptor_srv;
 			push.vb_atl = mesh.vb_atl.descriptor_srv;
-			push.instanceIndex = objectIndex;
+			push.instanceIndex = object.gpuInstanceIndex; // stable GPU instance slot
 			device->PushConstants(&push, sizeof(push), cmd);
 
 			RaytracingCB cb = {};
@@ -11397,7 +11402,7 @@ void RefreshWetmaps(const Visibility& vis, CommandList cmd)
 		if (push.wetmap < 0)
 			continue;
 
-		push.instanceID = objectIndex;
+		push.instanceID = object.gpuInstanceIndex; // stable GPU instance slot
 		device->PushConstants(&push, sizeof(push), cmd);
 
 		device->Dispatch((vertexCount + 63u) / 64u, 1, 1, cmd);
@@ -11417,7 +11422,7 @@ void RefreshWetmaps(const Visibility& vis, CommandList cmd)
 		if (push.wetmap < 0)
 			continue;
 
-		push.instanceID = uint32_t(vis.scene->objects.GetCount() + hairIndex);
+		push.instanceID = vis.scene->objectInstanceCapacity + hairIndex;
 		device->PushConstants(&push, sizeof(push), cmd);
 
 		device->Dispatch((vertexCount + 63u) / 64u, 1, 1, cmd);

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -129,6 +129,90 @@ namespace wi::scene
 			}
 		}
 
+		// Lazy incremental compaction of the instance slot range. Capacity only
+		// grows during normal operation, so a scene that sheds most of a large
+		// object peak (e.g. streaming a big region out) would otherwise keep
+		// paying to zero + build the wasted trailing slots every frame. Reclaim
+		// them by relocating objects out of the highest occupied slots into the
+		// lowest free holes, then trimming the now-free tail off the capacity.
+		//
+		// A relocation changes an object's stable slot, which re-invalidates
+		// its GPU caches (surfels) - the very churn stable slots exist to avoid
+		// - so this is deliberately conservative: it only runs once the waste
+		// is large (both a ratio and an absolute floor), and moves at most a
+		// small capped number of objects per frame so the churn stays tiny and
+		// spread out.
+		{
+			const uint32_t liveCount = (uint32_t)objects.GetCount();
+			constexpr uint32_t MIN_COMPACT_SLACK = 1024; // skip small waste
+			constexpr uint32_t MAX_RELOCATIONS_PER_FRAME = 128; // bound churn
+
+			if (liveCount == 0)
+			{
+				// Nothing alive: drop straight to an empty range.
+				objectInstanceCapacity = 0;
+				instanceSlotOwners.clear();
+				freeInstanceSlots.clear();
+			}
+			else if (objectInstanceCapacity > liveCount * 2 &&
+				objectInstanceCapacity - liveCount >= MIN_COMPACT_SLACK)
+			{
+				// Two pointers: low walks up to free holes, high walks down to
+				// occupied slots. Move the topmost objects into the lowest
+				// holes until they meet (fully compacted) or the per-frame cap
+				// is hit.
+				uint32_t low = 0;
+				uint32_t high = objectInstanceCapacity;
+				uint32_t relocated = 0;
+				while (relocated < MAX_RELOCATIONS_PER_FRAME)
+				{
+					while (low < objectInstanceCapacity &&
+						instanceSlotOwners[low] != INVALID_ENTITY)
+					{
+						++low;
+					}
+					do
+					{
+						--high;
+					} while (high > low &&
+						instanceSlotOwners[high] == INVALID_ENTITY);
+					if (low >= high)
+					{
+						break; // all holes are above the occupied slots
+					}
+
+					const Entity entity = instanceSlotOwners[high];
+					ObjectComponent* object = objects.GetComponent(entity);
+					assert(object != nullptr && "compaction slot owner must be live");
+					object->gpuInstanceIndex = low;
+					instanceSlotOwners[low] = entity;
+					instanceSlotOwners[high] = INVALID_ENTITY;
+					++relocated;
+					++low;
+				}
+
+				// Trim the free tail, then rebuild the free list for the holes
+				// that remain below the new (possibly still partial) capacity.
+				uint32_t newCapacity = objectInstanceCapacity;
+				while (newCapacity > 0 &&
+					instanceSlotOwners[newCapacity - 1] == INVALID_ENTITY)
+				{
+					--newCapacity;
+				}
+				objectInstanceCapacity = newCapacity;
+				instanceSlotOwners.resize(newCapacity);
+
+				freeInstanceSlots.clear();
+				for (uint32_t slot = 0; slot < newCapacity; ++slot)
+				{
+					if (instanceSlotOwners[slot] == INVALID_ENTITY)
+					{
+						freeInstanceSlots.push_back(slot);
+					}
+				}
+			}
+		}
+
 		// Objects occupy the stable slot range [0, objectInstanceCapacity);
 		// hairs, emitters, impostor and rain instances append after it.
 		instanceArraySize = objectInstanceCapacity + hairs.GetCount() + emitters.GetCount();

--- a/WickedEngine/wiScene.cpp
+++ b/WickedEngine/wiScene.cpp
@@ -72,7 +72,66 @@ namespace wi::scene
 
 		StartBuildTopDownHierarchy();
 
-		instanceArraySize = objects.GetCount() + hairs.GetCount() + emitters.GetCount();
+		// Reconcile the stable per-object instance slots before the (later)
+		// parallel object update job reads ObjectComponent::gpuInstanceIndex to
+		// place instance data. Single-threaded so the free-list is not raced.
+		{
+			const size_t objectCount = objects.GetCount();
+
+			// Mark which existing slots are still validly owned this frame.
+			instanceSlotClaimed.assign(objectInstanceCapacity, false);
+			for (size_t i = 0; i < objectCount; ++i)
+			{
+				const uint32_t slot = objects[i].gpuInstanceIndex;
+				if (slot < objectInstanceCapacity &&
+					instanceSlotOwners[slot] == objects.GetEntity(i))
+				{
+					instanceSlotClaimed[slot] = true;
+				}
+			}
+
+			// Return slots whose owner was removed / relocated to the pool.
+			for (uint32_t slot = 0; slot < objectInstanceCapacity; ++slot)
+			{
+				if (instanceSlotOwners[slot] != INVALID_ENTITY &&
+					!instanceSlotClaimed[slot])
+				{
+					instanceSlotOwners[slot] = INVALID_ENTITY;
+					freeInstanceSlots.push_back(slot);
+				}
+			}
+
+			// Assign every object still lacking a valid slot a recycled or new
+			// one. Capacity only grows, so surviving objects keep their slot.
+			for (size_t i = 0; i < objectCount; ++i)
+			{
+				ObjectComponent& object = objects[i];
+				const Entity entity = objects.GetEntity(i);
+				const uint32_t slot = object.gpuInstanceIndex;
+				if (slot < objectInstanceCapacity &&
+					instanceSlotOwners[slot] == entity)
+				{
+					continue; // already holds a valid slot
+				}
+				uint32_t newSlot;
+				if (!freeInstanceSlots.empty())
+				{
+					newSlot = freeInstanceSlots.back();
+					freeInstanceSlots.pop_back();
+				}
+				else
+				{
+					newSlot = objectInstanceCapacity++;
+					instanceSlotOwners.push_back(INVALID_ENTITY);
+				}
+				object.gpuInstanceIndex = newSlot;
+				instanceSlotOwners[newSlot] = entity;
+			}
+		}
+
+		// Objects occupy the stable slot range [0, objectInstanceCapacity);
+		// hairs, emitters, impostor and rain instances append after it.
+		instanceArraySize = objectInstanceCapacity + hairs.GetCount() + emitters.GetCount();
 		if (impostors.GetCount() > 0)
 		{
 			impostorInstanceOffset = uint32_t(instanceArraySize);
@@ -4664,7 +4723,12 @@ namespace wi::scene
 				inst.SetUserStencilRef(object.userStencilRef);
 				inst.rimHighlight = wi::math::pack_half4(XMFLOAT4(object.rimHighlightColor.x * object.rimHighlightColor.w, object.rimHighlightColor.y * object.rimHighlightColor.w, object.rimHighlightColor.z * object.rimHighlightColor.w, object.rimHighlightFalloff));
 
-				std::memcpy(instanceArrayMapped + args.jobIndex, &inst, sizeof(inst)); // memcpy whole structure into mapped pointer to avoid read from uncached memory
+				// Write to the object's stable GPU instance slot (not the
+				// ComponentManager index), so cached instance indices survive
+				// unrelated object add/remove churn.
+				const uint32_t instanceSlot = object.gpuInstanceIndex;
+
+				std::memcpy(instanceArrayMapped + instanceSlot, &inst, sizeof(inst)); // memcpy whole structure into mapped pointer to avoid read from uncached memory
 
 				if (TLAS_instancesMapped != nullptr)
 				{
@@ -4677,7 +4741,7 @@ namespace wi::scene
 							instance.transform[i][j] = worldMatrix.m[j][i];
 						}
 					}
-					instance.instance_id = args.jobIndex;
+					instance.instance_id = instanceSlot;
 					instance.instance_mask = layerMask == 0 ? 0 : 0xFF;
 					if (!object.IsRenderable() || !mesh.IsRenderable())
 					{
@@ -4711,7 +4775,7 @@ namespace wi::scene
 						instance.flags |= RaytracingAccelerationStructureDesc::TopLevel::Instance::FLAG_TRIANGLE_FRONT_COUNTERCLOCKWISE;
 					}
 
-					void* dest = (void*)((size_t)TLAS_instancesMapped + (size_t)args.jobIndex * device->GetTopLevelAccelerationStructureInstanceSize());
+					void* dest = (void*)((size_t)TLAS_instancesMapped + (size_t)instanceSlot * device->GetTopLevelAccelerationStructureInstanceSize());
 					device->WriteTopLevelAccelerationStructureInstance(&instance, dest);
 				}
 
@@ -5142,7 +5206,7 @@ namespace wi::scene
 			}
 			inst.transformPrev = inst.transform;
 
-			const size_t instanceIndex = objects.GetCount() + args.jobIndex;
+			const size_t instanceIndex = objectInstanceCapacity + args.jobIndex;
 			std::memcpy(instanceArrayMapped + instanceIndex, &inst, sizeof(inst));
 
 			if (TLAS_instancesMapped != nullptr)
@@ -5246,7 +5310,7 @@ namespace wi::scene
 			inst.baseGeometryOffset = inst.geometryOffset;
 			inst.baseGeometryCount = inst.geometryCount;
 
-			const size_t instanceIndex = objects.GetCount() + hairs.GetCount() + args.jobIndex;
+			const size_t instanceIndex = objectInstanceCapacity + hairs.GetCount() + args.jobIndex;
 			std::memcpy(instanceArrayMapped + instanceIndex, &inst, sizeof(inst));
 
 			if (TLAS_instancesMapped != nullptr)

--- a/WickedEngine/wiScene.h
+++ b/WickedEngine/wiScene.h
@@ -126,6 +126,21 @@ namespace wi::scene
 		size_t instanceArraySize = 0;
 		wi::graphics::GPUBuffer instanceBuffer;
 
+		// Stable per-object GPU instance slot allocator. Objects occupy the
+		// instance array range [0, objectInstanceCapacity); each object keeps
+		// its slot (ObjectComponent::gpuInstanceIndex) for its whole lifetime
+		// so GPU caches that store an instance index (e.g. surfel GI) are not
+		// invalidated when unrelated objects are added/removed (the objects
+		// ComponentManager relocates entries on removal via swap-with-last).
+		// instanceSlotOwners[slot] holds the owning entity (INVALID_ENTITY when
+		// free); freeInstanceSlots is the recycled-slot stack. Capacity only
+		// grows (never compacted), keeping slots maximally stable. Hairs,
+		// emitters, impostor and rain instances append after this range.
+		wi::vector<wi::ecs::Entity> instanceSlotOwners;
+		wi::vector<uint32_t> freeInstanceSlots;
+		uint32_t objectInstanceCapacity = 0;
+		wi::vector<bool> instanceSlotClaimed; // per-frame reconciliation scratch
+
 		// Geometries for bindless visiblity indexing:
 		//	contains in order:
 		//		1) meshes * mesh.subsetCount

--- a/WickedEngine/wiScene_Components.h
+++ b/WickedEngine/wiScene_Components.h
@@ -1198,6 +1198,16 @@ namespace wi::scene
 		mutable bool wetmap_cleared = false;
 		bool mesh_blend_required = false;
 
+		// Persistent GPU instance slot for this object, assigned by the Scene's
+		// stable-slot allocator and held for the object's lifetime (unlike the
+		// ComponentManager array index, which the swap-with-last removal
+		// churns). Keeping it stable lets GPU-side caches that store an
+		// instance index - most notably the surfel GI cache, which validates by
+		// entity uid - keep resolving to the same entity across unrelated scene
+		// edits (terrain streaming), instead of being mass-invalidated. ~0u =
+		// not yet assigned.
+		uint32_t gpuInstanceIndex = ~0u;
+
 		// these will only be valid for a single frame:
 		uint32_t mesh_index = ~0u;
 		uint32_t sort_bits = 0;


### PR DESCRIPTION
Decouple GPU instance slots from ComponentManager array indices to fix surfel GI churn during terrain streaming, and add lazy compaction to reclaim per-frame overhead when objects are shed.

### Core fix: stable instance slots

Surfels blink out and re-converge every time terrain streams (adds/removes props) because surfel GI caches `instanceIndex`, validated by entity `uid`. Terrain removal via swap-with-last relocates objects, changing their index, so cached surfels point at wrong entities and die.

Now objects get persistent GPU instance slots that stay bound for their lifetime. Surfel caches survive unrelated object add/remove churn. Slots live at sparse positions in `[0, objectInstanceCapacity)` with gaps (invalid, `uid=0`); hairs/emitters/impostor/rain append after. Reconciliation before the parallel object job marks, sweeps, and assigns slots,  microseconds in steady state.

### Lazy incremental compaction

Capacity never shrinks (design choice for maximal stability). A scene that sheds a large object peak would pay to zero/process wasted trailing slots every frame. Incremental compaction reclaims them: two-pointer relocation moves top-slot objects into bottom holes, then trim. Conservative tuning (only when waste > 2× live count and ≥1024; max 128 relocations/frame) keeps churn tiny and spread out.