### PR TITLE
Env Probe Undo-Restore Crash Fix

### DIFF
--- a/WickedEngine/wiGraphics.h
+++ b/WickedEngine/wiGraphics.h
@@ -2013,6 +2013,15 @@ namespace wi::graphics
 	//	plane can be specified optionally, the value ~0u means all planes
 	constexpr size_t ComputeTextureMemorySizeInBytes(const TextureDesc& desc, uint32_t plane = ~0u)
 	{
+		// An uninitialized / not-yet-created texture (e.g. a component whose
+		// GPU resource has not been built yet) has an UNKNOWN format and no
+		// memory footprint. Return early so we don't hit GetFormatStride's
+		// unhandled- format assert on a legitimately empty descriptor.
+		if (desc.format == Format::UNKNOWN)
+		{
+			return 0;
+		}
+
 		size_t size = 0;
 		const uint32_t bytes_per_block = GetFormatStride(desc.format, plane);
 		const uint32_t pixels_per_block = GetFormatBlockSize(desc.format);


### PR DESCRIPTION
Deserializing a deleted env probe marks it dirty but doesn't create its GPU texture until the next scene update via `CreateRenderData()`. This leaves the probe's `TextureDesc` with `format == UNKNOWN`. The editor's `EnvProbeWindow::SetEntity` immediately queries `GetMemorySizeInBytes()` for display, which feeds the UNKNOWN format into `GetFormatStride()`'s unhandled-format assert.

**Fix:** `ComputeTextureMemorySizeInBytes()` now returns 0 for UNKNOWN format. An uncreated texture has no memory footprint, so this is semantically correct. This generalizes to all components querying GPU memory for not-yet-created resources.