### PR TITLE
Fix UI flicker in env probe panel

### DIFF
--- a/WickedEngine/wiGUI.cpp
+++ b/WickedEngine/wiGUI.cpp
@@ -1189,6 +1189,20 @@ namespace wi::gui
 		}
 		scrollbar_length = std::max(0.0f, scrollbar_length);
 
+		// Decide whether the scrollbar is required, with hysteresis. Reserving
+		// the scrollbar's width shrinks the content area, and width-derived
+		// content (aspect-scaled previews) then gets shorter, which can make it
+		// fit and hide the scrollbar, which widens the content again - a
+		// per-frame on/off flicker. Once shown, keep it shown until the content
+		// fits by a margin (scrollbar_hysteresis), which breaks that loop. With
+		// hysteresis 0 this reduces to the old "content taller than the visible
+		// area" test.
+		const float content_over_area = list_length - safe_area;
+		const float required_threshold = scrollbar_required
+			? (scrollbar_size - scrollbar_hysteresis)
+			: scrollbar_size;
+		scrollbar_required = content_over_area > required_threshold;
+
 		if (IsEnabled() && dt > 0)
 		{
 			if (state == FOCUS)
@@ -4674,6 +4688,10 @@ namespace wi::gui
 			scrollbar_horizontal.SetPos(XMFLOAT2(translation.x + control_size, translation.y + scale.y - control_size));
 			scrollbar_horizontal.AttachTo(this);
 			scrollbar_horizontal.SetSafeArea(control_size * 2);
+			// Keep the scrollbar reserved until content fits by its own
+			// reserved width, so aspect-scaled content can't flicker it on/off
+			// each frame.
+			scrollbar_horizontal.SetHysteresis(control_size);
 		}
 		if (scrollbar_vertical.parent != nullptr)
 		{
@@ -4681,6 +4699,10 @@ namespace wi::gui
 			scrollbar_vertical.SetSize(XMFLOAT2(control_size, GetWidgetAreaSize().y - control_size));
 			scrollbar_vertical.SetPos(XMFLOAT2(translation.x + scale.x - control_size, translation.y + control_size));
 			scrollbar_vertical.AttachTo(this);
+			// See the horizontal scrollbar above: hysteresis prevents an on/off
+			// oscillation when reserving the scrollbar width shortens
+			// width-derived content (e.g. add_fullwidth_aspect previews).
+			scrollbar_vertical.SetHysteresis(control_size);
 		}
 
 		if (onResize)

--- a/WickedEngine/wiGUI.h
+++ b/WickedEngine/wiGUI.h
@@ -438,6 +438,10 @@ namespace wi::gui
 		float overscroll = 0;
 		bool vertical = true;
 		float safe_area = 0;
+		// Sticky required-state and the margin that keeps it sticky. See
+		// SetHysteresis and Update for why this exists.
+		bool scrollbar_required = false;
+		float scrollbar_hysteresis = 0;
 		XMFLOAT2 grab_pos = {};
 		float grab_delta = 0;
 
@@ -462,10 +466,17 @@ namespace wi::gui
 		//	1: full extra offset
 		void SetOverScroll(float amount) { overscroll = amount; }
 		// Check whether the scrollbar is required (when the items don't fit and scrolling could be used)
-		bool IsScrollbarRequired() const { return scrollbar_granularity < 1; }
+		bool IsScrollbarRequired() const { return scrollbar_required; }
 		// Check whether the scrollbar is at the beginning
 		bool IsScrolledToBegin() const { return scrollbar_delta <= 0; }
 		void SetSafeArea(float value) { safe_area = value; }
+		// Hysteresis margin (in list-length units) applied to the
+		// required-state: once shown, the scrollbar stays shown until the
+		// content fits with this much extra room. Set it to the width the
+		// scrollbar reserves so a width-derived content height (aspect-scaled
+		// previews) can't oscillate the scrollbar on/off every frame. 0
+		// disables hysteresis.
+		void SetHysteresis(float value) { scrollbar_hysteresis = value; }
 
 		enum SCROLLBAR_STATE
 		{


### PR DESCRIPTION
Fix UI flicker in env probe panel (and other scrollable windows with aspect-scaled content).

When the vertical scrollbar appeared, it shrank the content width → the cubemap preview (height = width × 3/4 aspect) got shorter → content fit the window → scrollbar disappeared → width grew → preview taller → overflow → scrollbar reappeared. This on/off oscillation flickered every frame.

**Fix:** Implement scrollbar hysteresis. Once the scrollbar appears, keep it shown until content fits with a margin equal to the scrollbar's own width. This breaks the width-feedback loop without introducing a permanent gutter.

- Add `ScrollBar::scrollbar_required` (sticky state) and `scrollbar_hysteresis` (margin threshold).
- `ScrollBar::Update()` now computes required-state with hysteresis.
- `Window::ResizeLayout()` sets `hysteresis = control_size` on both scrollbars.
- `IsScrollbarRequired()` returns the sticky flag instead of raw `granularity < 1`.

Fixes flicker in env probe panel, object inspector, and other windows with aspect-scaled previews.