### PR TITLE
Refactor, Harden, and Document CommonInclude.h

### DIFF
--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -5,6 +5,7 @@
 
 #include <cassert>
 #include <cfloat>
+#include <cmath>
 #include <cstdint>
 #include <type_traits>
 
@@ -66,9 +67,8 @@ constexpr T saturate(T x)
 template <typename T>
 constexpr T frac(T x)
 {
-	T f = x - T(int(x));
-	f = f < 0 ? (1 + f) : f;
-	return f;
+	static_assert(std::is_floating_point_v<T>, "frac only supports floating-point types");
+	return x - std::floor(x);
 }
 
 template <typename T>

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -206,7 +206,7 @@ struct StackVector
 	{
 		return 31u - (unsigned int)bit_index;
 	}
-	return 0;
+	return 32u;
 }
 [[nodiscard]] inline unsigned long firstbithigh(unsigned long value) noexcept
 {
@@ -215,7 +215,7 @@ struct StackVector
 	{
 		return 31ul - bit_index;
 	}
-	return 0;
+	return 32ul;
 }
 [[nodiscard]] inline unsigned long long firstbithigh(unsigned long long value) noexcept
 {
@@ -224,7 +224,7 @@ struct StackVector
 	{
 		return 63ull - bit_index;
 	}
-	return 0;
+	return 64ull;
 }
 [[nodiscard]] inline unsigned int firstbitlow(unsigned int value) noexcept
 {
@@ -233,7 +233,7 @@ struct StackVector
 	{
 		return (unsigned int)bit_index;
 	}
-	return 0;
+	return 32u;
 }
 [[nodiscard]] inline unsigned long firstbitlow(unsigned long value) noexcept
 {
@@ -242,7 +242,7 @@ struct StackVector
 	{
 		return bit_index;
 	}
-	return 0;
+	return 32ul;
 }
 [[nodiscard]] inline unsigned long firstbitlow(unsigned long long value) noexcept
 {
@@ -251,7 +251,7 @@ struct StackVector
 	{
 		return bit_index;
 	}
-	return 0;
+	return 64ul;
 }
 #else
 // Linux, PlayStation:
@@ -303,7 +303,7 @@ struct StackVector
 {
 	if (value == 0)
 	{
-		return 0;
+		return 32u;
 	}
 	return __builtin_clz(value);
 }
@@ -311,7 +311,7 @@ struct StackVector
 {
 	if (value == 0)
 	{
-		return 0;
+		return sizeof(unsigned long) * 8;
 	}
 	return __builtin_clzl(value);
 }
@@ -319,7 +319,7 @@ struct StackVector
 {
 	if (value == 0)
 	{
-		return 0;
+		return 64ull;
 	}
 	return __builtin_clzll(value);
 }
@@ -327,7 +327,7 @@ struct StackVector
 {
 	if (value == 0)
 	{
-		return 0;
+		return 32u;
 	}
 	return __builtin_ctz(value);
 }
@@ -335,7 +335,7 @@ struct StackVector
 {
 	if (value == 0)
 	{
-		return 0;
+		return sizeof(unsigned long) * 8;
 	}
 	return __builtin_ctzl(value);
 }
@@ -343,7 +343,7 @@ struct StackVector
 {
 	if (value == 0)
 	{
-		return 0;
+		return 64ull;
 	}
 	return __builtin_ctzll(value);
 }

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -298,7 +298,7 @@ inline unsigned long long countbits(unsigned long long value)
 {
 	return __builtin_popcountll(value);
 }
-inline unsigned long firstbithigh(unsigned int value)
+inline unsigned int firstbithigh(unsigned int value)
 {
 	if (value == 0)
 	{
@@ -314,7 +314,7 @@ inline unsigned long firstbithigh(unsigned long value)
 	}
 	return __builtin_clzl(value);
 }
-inline unsigned long firstbithigh(unsigned long long value)
+inline unsigned long long firstbithigh(unsigned long long value)
 {
 	if (value == 0)
 	{
@@ -322,7 +322,7 @@ inline unsigned long firstbithigh(unsigned long long value)
 	}
 	return __builtin_clzll(value);
 }
-inline unsigned long firstbitlow(unsigned int value)
+inline unsigned int firstbitlow(unsigned int value)
 {
 	if (value == 0)
 	{
@@ -338,7 +338,7 @@ inline unsigned long firstbitlow(unsigned long value)
 	}
 	return __builtin_ctzl(value);
 }
-inline unsigned long firstbitlow(unsigned long long value)
+inline unsigned long long firstbitlow(unsigned long long value)
 {
 	if (value == 0)
 	{

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -114,6 +114,14 @@ template <typename T>
 
 template <typename Vec4, typename Vec2>
 [[nodiscard]] constexpr auto bilinear(Vec4 gather, Vec2 pixel_frac) noexcept
+	-> std::enable_if_t<
+		std::is_arithmetic_v<decltype(gather.x)> &&
+		std::is_arithmetic_v<decltype(gather.y)> &&
+		std::is_arithmetic_v<decltype(gather.z)> &&
+		std::is_arithmetic_v<decltype(gather.w)> &&
+		std::is_arithmetic_v<decltype(pixel_frac.x)> &&
+		std::is_arithmetic_v<decltype(pixel_frac.y)>,
+		decltype(gather.x)>
 {
 	using T = decltype(gather.x);
 	const T top_row = lerp(gather.w, gather.z, pixel_frac.x);

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -40,7 +40,7 @@ constexpr T align(T value, T alignment)
 template<typename T>
 constexpr bool is_aligned(T value, T alignment)
 {
-	return align(value, alignment) == value;
+	return (value & (alignment - 1)) == 0;
 }
 
 template <typename T>

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -101,17 +101,18 @@ constexpr auto bilinear(Vec4 gather, Vec2 pixel_frac)
 }
 
 // Stack allocated string utility:
-template <unsigned capacity = 256>
+template <unsigned Capacity = 256>
 struct StackString
 {
-	char chars[capacity] = {};
+	char chars[Capacity] = {};
 	unsigned cnt = 0;
-	static_assert(capacity > 1);
+	static_assert(Capacity > 1);
 	constexpr operator const char* () const { return chars; }
 	constexpr const char* const c_str() const { return chars; }
-	constexpr void push_back(const char* str) { if (!str) return; while (*str != 0 && (cnt < (capacity - 1))) { chars[cnt++] = *str; str++; } }
+	constexpr void push_back(const char* str) { if (!str) return; while (*str != 0 && (cnt < (Capacity - 1))) { chars[cnt++] = *str; str++; } }
 	constexpr unsigned size() const { return cnt; }
 	constexpr unsigned length() const { return cnt; }
+	constexpr unsigned capacity() const { return Capacity; }
 	constexpr bool empty() const { return cnt == 0; }
 	constexpr StackString() = default;
 	constexpr StackString(const StackString&) = default;
@@ -128,6 +129,7 @@ struct StackVector
 	constexpr void resize(unsigned size) { assert(size <= count); last = size; }
 	constexpr unsigned size() const { return last; }
 	constexpr bool empty() const { return last == 0; }
+	constexpr unsigned capacity() const { return count; }
 	constexpr void push_back(const T& item) { assert(last < count); items[last++] = item; }
 	constexpr void push_back(T&& item) { assert(last < count); items[last++] = static_cast<T&&>(item); }
 	constexpr void pop_back() { if (!empty()) items[--last] = {}; }

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -398,7 +398,7 @@ constexpr bool has_flag(E lhs, E rhs)
 	return (lhs & rhs) == rhs;
 }
 template<typename T, typename U>
-constexpr void set_flag(T& flags, const U flag, const bool set)
+constexpr void set_flag(T& flags, U flag, bool set)
 {
 	if (set)
 	{

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -35,63 +35,63 @@
 // Simple common math helpers:
 
 template<typename T>
-constexpr T align(T value, T alignment)
+[[nodiscard]] constexpr T align(T value, T alignment) noexcept
 {
 	return ((value - 1) | (alignment - 1)) + 1;
 }
 
 template<typename T>
-constexpr bool is_aligned(T value, T alignment)
+[[nodiscard]] constexpr bool is_aligned(T value, T alignment) noexcept
 {
 	return (value & (alignment - 1)) == 0;
 }
 
 template <typename T>
-constexpr T sqr(T x) { return x * x; }
+[[nodiscard]] constexpr T sqr(T x) noexcept { return x * x; }
 
 template <typename T>
-constexpr T pow4(T x) { return sqr(sqr(x)); }
+[[nodiscard]] constexpr T pow4(T x) noexcept { return sqr(sqr(x)); }
 
 template <typename T>
-constexpr T clamp(T x, T a, T b)
+[[nodiscard]] constexpr T clamp(T x, T a, T b) noexcept
 {
 	return x < a ? a : (x > b ? b : x);
 }
 
 template <typename T>
-constexpr T saturate(T x)
+[[nodiscard]] constexpr T saturate(T x) noexcept
 {
 	return clamp(x, T(0), T(1));
 }
 
 template <typename T>
-constexpr T frac(T x)
+[[nodiscard]] constexpr T frac(T x) noexcept
 {
 	static_assert(std::is_floating_point_v<T>, "frac only supports floating-point types");
 	return x - std::floor(x);
 }
 
 template <typename T>
-constexpr T lerp(T x, T y, T a)
+[[nodiscard]] constexpr T lerp(T x, T y, T a) noexcept
 {
 	return x * (1 - a) + y * a;
 }
 
 template <typename T>
-constexpr T inverse_lerp(T value1, T value2, T pos)
+[[nodiscard]] constexpr T inverse_lerp(T value1, T value2, T pos) noexcept
 {
 	return value2 == value1 ? T(0) : ((pos - value1) / (value2 - value1));
 }
 
 template <typename T>
-constexpr T smoothstep(T edge0, T edge1, T x)
+[[nodiscard]] constexpr T smoothstep(T edge0, T edge1, T x) noexcept
 {
 	const T t = saturate((x - edge0) / (edge1 - edge0));
 	return t * t * (T(3) - T(2) * t);
 }
 
 template <typename Vec4, typename Vec2>
-constexpr auto bilinear(Vec4 gather, Vec2 pixel_frac)
+[[nodiscard]] constexpr auto bilinear(Vec4 gather, Vec2 pixel_frac) noexcept
 {
 	using T = decltype(gather.x);
 	const T top_row = lerp(gather.w, gather.z, pixel_frac.x);
@@ -106,13 +106,13 @@ struct StackString
 	char chars[Capacity] = {};
 	unsigned cnt = 0;
 	static_assert(Capacity > 1);
-	constexpr operator const char* () const { return chars; }
-	constexpr const char* const c_str() const { return chars; }
-	constexpr void push_back(const char* str) { if (!str) return; while (*str != 0 && (cnt < (Capacity - 1))) { chars[cnt++] = *str; str++; } }
-	constexpr unsigned size() const { return cnt; }
-	constexpr unsigned length() const { return cnt; }
-	constexpr unsigned capacity() const { return Capacity; }
-	constexpr bool empty() const { return cnt == 0; }
+	[[nodiscard]] constexpr operator const char* () const noexcept { return chars; }
+	[[nodiscard]] constexpr const char* const c_str() const noexcept { return chars; }
+	constexpr void push_back(const char* str) noexcept { if (!str) return; while (*str != 0 && (cnt < (Capacity - 1))) { chars[cnt++] = *str; str++; } }
+	[[nodiscard]] constexpr unsigned size() const noexcept { return cnt; }
+	[[nodiscard]] constexpr unsigned length() const noexcept { return cnt; }
+	[[nodiscard]] constexpr unsigned capacity() const noexcept { return Capacity; }
+	[[nodiscard]] constexpr bool empty() const noexcept { return cnt == 0; }
 	constexpr StackString() = default;
 	constexpr StackString(const StackString&) = default;
 	constexpr StackString(StackString&&) = default;
@@ -125,25 +125,25 @@ struct StackVector
 {
 	T items[count] = {};
 	unsigned last = 0;
-	constexpr void set_size(unsigned size) { assert(size <= count); last = size; }
-	constexpr unsigned size() const { return last; }
-	constexpr bool empty() const { return last == 0; }
-	constexpr unsigned capacity() const { return count; }
-	constexpr void push_back(const T& item) { assert(last < count); items[last++] = item; }
-	constexpr void push_back(T&& item) { assert(last < count); items[last++] = static_cast<T&&>(item); }
-	constexpr void pop_back() { if (!empty()) items[--last] = {}; }
-	constexpr void clear() { for (unsigned i = 0; i < last; ++i) items[i] = {}; last = 0; }
-	constexpr T* data() { return items; }
-	constexpr const T* data() const { return items; }
-	constexpr T* begin() { return items; }
-	constexpr T* end() { return items + last; }
-	constexpr const T& back() const { assert(!empty()); return items[last - 1]; }
-	constexpr T& back() { assert(!empty()); return items[last - 1]; }
-	constexpr const T& front() const { assert(!empty()); return items[0]; }
-	constexpr T& front() { assert(!empty()); return items[0]; }
-	constexpr T& emplace_back() { push_back({}); return back(); }
-	constexpr const T& operator[](unsigned index) const { assert(index < last); return items[index]; }
-	constexpr T& operator[](unsigned index) { assert(index < last); return items[index]; }
+	constexpr void set_size(unsigned size) noexcept { assert(size <= count); last = size; }
+	[[nodiscard]] constexpr unsigned size() const noexcept { return last; }
+	[[nodiscard]] constexpr bool empty() const noexcept { return last == 0; }
+	[[nodiscard]] constexpr unsigned capacity() const noexcept { return count; }
+	constexpr void push_back(const T& item) noexcept { assert(last < count); items[last++] = item; }
+	constexpr void push_back(T&& item) noexcept { assert(last < count); items[last++] = static_cast<T&&>(item); }
+	constexpr void pop_back() noexcept { if (!empty()) items[--last] = {}; }
+	constexpr void clear() noexcept { for (unsigned i = 0; i < last; ++i) items[i] = {}; last = 0; }
+	[[nodiscard]] constexpr T* data() noexcept { return items; }
+	[[nodiscard]] constexpr const T* data() const noexcept { return items; }
+	[[nodiscard]] constexpr T* begin() noexcept { return items; }
+	[[nodiscard]] constexpr T* end() noexcept { return items + last; }
+	constexpr const T& back() const noexcept { assert(!empty()); return items[last - 1]; }
+	constexpr T& back() noexcept { assert(!empty()); return items[last - 1]; }
+	constexpr const T& front() const noexcept { assert(!empty()); return items[0]; }
+	constexpr T& front() noexcept { assert(!empty()); return items[0]; }
+	constexpr T& emplace_back() noexcept { push_back({}); return back(); }
+	constexpr const T& operator[](unsigned index) const noexcept { assert(index < last); return items[index]; }
+	constexpr T& operator[](unsigned index) noexcept { assert(index < last); return items[index]; }
 };
 
 // CPU intrinsics:
@@ -153,51 +153,51 @@ struct StackVector
 #if defined(_M_ARM64)
 #include <arm64intr.h>
 #endif // _M_ARM64
-inline long AtomicAnd(volatile long* ptr, long mask)
+[[nodiscard]] inline long AtomicAnd(volatile long* ptr, long mask) noexcept
 {
 	return _InterlockedAnd(ptr, mask);
 }
-inline long long AtomicAnd(volatile long long* ptr, long long mask)
+[[nodiscard]] inline long long AtomicAnd(volatile long long* ptr, long long mask) noexcept
 {
 	return _InterlockedAnd64(ptr, mask);
 }
-inline long AtomicOr(volatile long* ptr, long mask)
+[[nodiscard]] inline long AtomicOr(volatile long* ptr, long mask) noexcept
 {
 	return _InterlockedOr(ptr, mask);
 }
-inline long long AtomicOr(volatile long long* ptr, long long mask)
+[[nodiscard]] inline long long AtomicOr(volatile long long* ptr, long long mask) noexcept
 {
 	return _InterlockedOr64(ptr, mask);
 }
-inline long AtomicXor(volatile long* ptr, long mask)
+[[nodiscard]] inline long AtomicXor(volatile long* ptr, long mask) noexcept
 {
 	return _InterlockedXor(ptr, mask);
 }
-inline long long AtomicXor(volatile long long* ptr, long long mask)
+[[nodiscard]] inline long long AtomicXor(volatile long long* ptr, long long mask) noexcept
 {
 	return _InterlockedXor64(ptr, mask);
 }
-inline long AtomicAdd(volatile long* ptr, long val)
+[[nodiscard]] inline long AtomicAdd(volatile long* ptr, long val) noexcept
 {
 	return _InterlockedExchangeAdd(ptr, val);
 }
-inline long long AtomicAdd(volatile long long* ptr, long long val)
+[[nodiscard]] inline long long AtomicAdd(volatile long long* ptr, long long val) noexcept
 {
 	return _InterlockedExchangeAdd64(ptr, val);
 }
-inline unsigned int countbits(unsigned int value)
+[[nodiscard]] inline unsigned int countbits(unsigned int value) noexcept
 {
 	return __popcnt(value);
 }
-inline unsigned long countbits(unsigned long value)
+[[nodiscard]] inline unsigned long countbits(unsigned long value) noexcept
 {
 	return (unsigned long)__popcnt64((unsigned long long)value);
 }
-inline unsigned long long countbits(unsigned long long value)
+[[nodiscard]] inline unsigned long long countbits(unsigned long long value) noexcept
 {
 	return __popcnt64(value);
 }
-inline unsigned int firstbithigh(unsigned int value)
+[[nodiscard]] inline unsigned int firstbithigh(unsigned int value) noexcept
 {
 	unsigned long bit_index;
 	if (_BitScanReverse(&bit_index, (unsigned long)value))
@@ -206,7 +206,7 @@ inline unsigned int firstbithigh(unsigned int value)
 	}
 	return 0;
 }
-inline unsigned long firstbithigh(unsigned long value)
+[[nodiscard]] inline unsigned long firstbithigh(unsigned long value) noexcept
 {
 	unsigned long bit_index;
 	if (_BitScanReverse64(&bit_index, (unsigned long long)value))
@@ -215,7 +215,7 @@ inline unsigned long firstbithigh(unsigned long value)
 	}
 	return 0;
 }
-inline unsigned long firstbithigh(unsigned long long value)
+[[nodiscard]] inline unsigned long long firstbithigh(unsigned long long value) noexcept
 {
 	unsigned long bit_index;
 	if (_BitScanReverse64(&bit_index, value))
@@ -224,7 +224,7 @@ inline unsigned long firstbithigh(unsigned long long value)
 	}
 	return 0;
 }
-inline unsigned int firstbitlow(unsigned int value)
+[[nodiscard]] inline unsigned int firstbitlow(unsigned int value) noexcept
 {
 	unsigned long bit_index;
 	if (_BitScanForward(&bit_index, value))
@@ -233,7 +233,7 @@ inline unsigned int firstbitlow(unsigned int value)
 	}
 	return 0;
 }
-inline unsigned long firstbitlow(unsigned long value)
+[[nodiscard]] inline unsigned long firstbitlow(unsigned long value) noexcept
 {
 	unsigned long bit_index;
 	if (_BitScanForward64(&bit_index, (unsigned long long)value))
@@ -242,7 +242,7 @@ inline unsigned long firstbitlow(unsigned long value)
 	}
 	return 0;
 }
-inline unsigned long firstbitlow(unsigned long long value)
+[[nodiscard]] inline unsigned long firstbitlow(unsigned long long value) noexcept
 {
 	unsigned long bit_index;
 	if (_BitScanForward64(&bit_index, value))
@@ -253,51 +253,51 @@ inline unsigned long firstbitlow(unsigned long long value)
 }
 #else
 // Linux, PlayStation:
-inline long AtomicAnd(volatile long* ptr, long mask)
+[[nodiscard]] inline long AtomicAnd(volatile long* ptr, long mask) noexcept
 {
 	return __atomic_fetch_and(ptr, mask, __ATOMIC_SEQ_CST);
 }
-inline long long AtomicAnd(volatile long long* ptr, long long mask)
+[[nodiscard]] inline long long AtomicAnd(volatile long long* ptr, long long mask) noexcept
 {
 	return __atomic_fetch_and(ptr, mask, __ATOMIC_SEQ_CST);
 }
-inline long AtomicOr(volatile long* ptr, long mask)
+[[nodiscard]] inline long AtomicOr(volatile long* ptr, long mask) noexcept
 {
 	return __atomic_fetch_or(ptr, mask, __ATOMIC_SEQ_CST);
 }
-inline long long AtomicOr(volatile long long* ptr, long long mask)
+[[nodiscard]] inline long long AtomicOr(volatile long long* ptr, long long mask) noexcept
 {
 	return __atomic_fetch_or(ptr, mask, __ATOMIC_SEQ_CST);
 }
-inline long AtomicXor(volatile long* ptr, long mask)
+[[nodiscard]] inline long AtomicXor(volatile long* ptr, long mask) noexcept
 {
 	return __atomic_fetch_xor(ptr, mask, __ATOMIC_SEQ_CST);
 }
-inline long long AtomicXor(volatile long long* ptr, long long mask)
+[[nodiscard]] inline long long AtomicXor(volatile long long* ptr, long long mask) noexcept
 {
 	return __atomic_fetch_xor(ptr, mask, __ATOMIC_SEQ_CST);
 }
-inline long AtomicAdd(volatile long* ptr, long val)
+[[nodiscard]] inline long AtomicAdd(volatile long* ptr, long val) noexcept
 {
 	return __atomic_fetch_add(ptr, val, __ATOMIC_SEQ_CST);
 }
-inline long long AtomicAdd(volatile long long* ptr, long long val)
+[[nodiscard]] inline long long AtomicAdd(volatile long long* ptr, long long val) noexcept
 {
 	return __atomic_fetch_add(ptr, val, __ATOMIC_SEQ_CST);
 }
-inline unsigned int countbits(unsigned int value)
+[[nodiscard]] inline unsigned int countbits(unsigned int value) noexcept
 {
 	return __builtin_popcount(value);
 }
-inline unsigned long countbits(unsigned long value)
+[[nodiscard]] inline unsigned long countbits(unsigned long value) noexcept
 {
 	return __builtin_popcountl(value);
 }
-inline unsigned long long countbits(unsigned long long value)
+[[nodiscard]] inline unsigned long long countbits(unsigned long long value) noexcept
 {
 	return __builtin_popcountll(value);
 }
-inline unsigned int firstbithigh(unsigned int value)
+[[nodiscard]] inline unsigned int firstbithigh(unsigned int value) noexcept
 {
 	if (value == 0)
 	{
@@ -305,7 +305,7 @@ inline unsigned int firstbithigh(unsigned int value)
 	}
 	return __builtin_clz(value);
 }
-inline unsigned long firstbithigh(unsigned long value)
+[[nodiscard]] inline unsigned long firstbithigh(unsigned long value) noexcept
 {
 	if (value == 0)
 	{
@@ -313,7 +313,7 @@ inline unsigned long firstbithigh(unsigned long value)
 	}
 	return __builtin_clzl(value);
 }
-inline unsigned long long firstbithigh(unsigned long long value)
+[[nodiscard]] inline unsigned long long firstbithigh(unsigned long long value) noexcept
 {
 	if (value == 0)
 	{
@@ -321,7 +321,7 @@ inline unsigned long long firstbithigh(unsigned long long value)
 	}
 	return __builtin_clzll(value);
 }
-inline unsigned int firstbitlow(unsigned int value)
+[[nodiscard]] inline unsigned int firstbitlow(unsigned int value) noexcept
 {
 	if (value == 0)
 	{
@@ -329,7 +329,7 @@ inline unsigned int firstbitlow(unsigned int value)
 	}
 	return __builtin_ctz(value);
 }
-inline unsigned long firstbitlow(unsigned long value)
+[[nodiscard]] inline unsigned long firstbitlow(unsigned long value) noexcept
 {
 	if (value == 0)
 	{
@@ -337,7 +337,7 @@ inline unsigned long firstbitlow(unsigned long value)
 	}
 	return __builtin_ctzl(value);
 }
-inline unsigned long long firstbitlow(unsigned long long value)
+[[nodiscard]] inline unsigned long long firstbitlow(unsigned long long value) noexcept
 {
 	if (value == 0)
 	{
@@ -347,11 +347,11 @@ inline unsigned long long firstbitlow(unsigned long long value)
 }
 #endif // _WIN32
 
-inline long AtomicLoad(const volatile long* ptr)
+[[nodiscard]] inline long AtomicLoad(const volatile long* ptr) noexcept
 {
 	return AtomicOr((volatile long*)ptr, 0);
 }
-inline long long AtomicLoad(const volatile long long* ptr)
+[[nodiscard]] inline long long AtomicLoad(const volatile long long* ptr) noexcept
 {
 	return AtomicOr((volatile long long*)ptr, 0);
 }
@@ -398,12 +398,12 @@ constexpr E operator~(E rhs)
 	return rhs;
 }
 template<typename E, EnableIfBitmaskOps<E> = 0>
-constexpr bool has_flag(E lhs, E rhs)
+[[nodiscard]] constexpr bool has_flag(E lhs, E rhs) noexcept
 {
 	return (lhs & rhs) == rhs;
 }
 template<typename T, typename U>
-constexpr void set_flag(T& flags, U flag, bool set)
+constexpr void set_flag(T& flags, U flag, bool set) noexcept
 {
 	if (set)
 	{
@@ -415,7 +415,7 @@ constexpr void set_flag(T& flags, U flag, bool set)
 	}
 }
 // Extract file name from a path at compile-time
-constexpr const char* relative_path(const char* path)
+[[nodiscard]] constexpr const char* relative_path(const char* path) noexcept
 {
 	const char* startPosition = path;
 	for (const char* currentCharacter = path; *currentCharacter != '\0'; ++currentCharacter)
@@ -434,7 +434,7 @@ constexpr const char* relative_path(const char* path)
 	return startPosition;
 }
 
-constexpr auto relative_path_storage(const char* path)
+[[nodiscard]] constexpr auto relative_path_storage(const char* path) noexcept
 {
 	StackString ret;
 	ret.push_back(relative_path(path));
@@ -442,7 +442,7 @@ constexpr auto relative_path_storage(const char* path)
 }
 
 // Convert string literal to StackString at compile-time
-constexpr auto to_stack_string(const char* str)
+[[nodiscard]] constexpr auto to_stack_string(const char* str) noexcept
 {
 	StackString ret;
 	ret.push_back(str);

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -4,6 +4,7 @@
 // This is a helper include file pasted into all engine headers, try to keep it minimal!
 // Do not include engine features in this file!
 
+#include <cassert>
 #include <cfloat>
 #include <cstdint>
 #include <type_traits>
@@ -123,24 +124,24 @@ struct StackVector
 {
 	T items[count] = {};
 	unsigned last = 0;
-	constexpr void resize(unsigned size) { last = size; }
+	constexpr void resize(unsigned size) { assert(size <= count); last = size; }
 	constexpr unsigned size() const { return last; }
 	constexpr bool empty() const { return last == 0; }
-	constexpr void push_back(const T& item) { items[last++] = item; }
-	constexpr void push_back(T&& item) { items[last++] = static_cast<T&&>(item); }
+	constexpr void push_back(const T& item) { assert(last < count); items[last++] = item; }
+	constexpr void push_back(T&& item) { assert(last < count); items[last++] = static_cast<T&&>(item); }
 	constexpr void pop_back() { if (!empty()) items[--last] = {}; }
 	constexpr void clear() { for (unsigned i = 0; i < last; ++i) items[i] = {}; last = 0; }
 	constexpr T* data() { return items; }
 	constexpr const T* data() const { return items; }
 	constexpr T* begin() { return items; }
 	constexpr T* end() { return items + last; }
-	constexpr const T& back() const { return items[last - 1]; }
-	constexpr T& back() { return items[last - 1]; }
-	constexpr const T& front() const { return items[0]; }
-	constexpr T& front() { return items[0]; }
+	constexpr const T& back() const { assert(!empty()); return items[last - 1]; }
+	constexpr T& back() { assert(!empty()); return items[last - 1]; }
+	constexpr const T& front() const { assert(!empty()); return items[0]; }
+	constexpr T& front() { assert(!empty()); return items[0]; }
 	constexpr T& emplace_back() { push_back({}); return back(); }
-	constexpr const T& operator[](unsigned index) const { return items[index]; }
-	constexpr T& operator[](unsigned index) { return items[index]; }
+	constexpr const T& operator[](unsigned index) const { assert(index < last); return items[index]; }
+	constexpr T& operator[](unsigned index) { assert(index < last); return items[index]; }
 };
 
 // CPU intrinsics:

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -126,7 +126,7 @@ struct StackVector
 {
 	T items[count] = {};
 	unsigned last = 0;
-	constexpr void resize(unsigned size) { assert(size <= count); last = size; }
+	constexpr void set_size(unsigned size) { assert(size <= count); last = size; }
 	constexpr unsigned size() const { return last; }
 	constexpr bool empty() const { return last == 0; }
 	constexpr unsigned capacity() const { return count; }

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -4,7 +4,6 @@
 // Do not include engine features in this file!
 
 #include <cassert>
-#include <cfloat>
 #include <cmath>
 #include <cstdint>
 #include <type_traits>

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -34,7 +34,7 @@
 template<typename T>
 constexpr T align(T value, T alignment)
 {
-	return ((value + alignment - T(1)) / alignment) * alignment;
+	return ((value - 1) | (alignment - 1)) + 1;
 }
 
 template<typename T>

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -37,13 +37,34 @@
 template<typename T>
 [[nodiscard]] constexpr T align(T value, T alignment) noexcept
 {
-	return ((value - 1) | (alignment - 1)) + 1;
+	// Fast path for power-of-2 alignments (most common in graphics):
+	// Uses bitwise operations: (value + alignment - 1) & ~(alignment - 1)
+	// General case for arbitrary alignment:
+	// Uses division: ((value + alignment - 1) / alignment) * alignment
+	const T mask = alignment - 1;
+
+	if ((alignment & mask) == 0) // power of 2
+	{
+		return (value + mask) & ~mask;
+	}
+
+	// General case - safe for any alignment
+	return ((value + alignment - 1) / alignment) * alignment;
 }
 
 template<typename T>
 [[nodiscard]] constexpr bool is_aligned(T value, T alignment) noexcept
 {
-	return (value & (alignment - 1)) == 0;
+	// Fast path for power-of-2 alignments (most common in graphics)
+	const T mask = alignment - 1;
+
+	if ((alignment & mask) == 0) // power of 2
+	{
+		return (value & mask) == 0;
+	}
+
+	// General case
+	return value % alignment == 0;
 }
 
 template <typename T>

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -387,33 +387,33 @@ template<typename E>
 using EnableIfBitmaskOps = std::enable_if_t<enable_bitmask_operators<E>::value, int>;
 
 template<typename E, EnableIfBitmaskOps<E> = 0>
-constexpr E operator|(E lhs, E rhs)
+constexpr E operator|(E lhs, E rhs) noexcept
 {
 	using U = std::underlying_type_t<E>;
 	return static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
 }
 template<typename E, EnableIfBitmaskOps<E> = 0>
-constexpr E operator|=(E& lhs, E rhs)
+constexpr E operator|=(E& lhs, E rhs) noexcept
 {
 	using U = std::underlying_type_t<E>;
 	lhs = static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
 	return lhs;
 }
 template<typename E, EnableIfBitmaskOps<E> = 0>
-constexpr E operator&(E lhs, E rhs)
+constexpr E operator&(E lhs, E rhs) noexcept
 {
 	using U = std::underlying_type_t<E>;
 	return static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
 }
 template<typename E, EnableIfBitmaskOps<E> = 0>
-constexpr E operator&=(E& lhs, E rhs)
+constexpr E operator&=(E& lhs, E rhs) noexcept
 {
 	using U = std::underlying_type_t<E>;
 	lhs = static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
 	return lhs;
 }
 template<typename E, EnableIfBitmaskOps<E> = 0>
-constexpr E operator~(E rhs)
+constexpr E operator~(E rhs) noexcept
 {
 	using U = std::underlying_type_t<E>;
 	rhs = static_cast<E>(~static_cast<U>(rhs));

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -287,7 +287,7 @@ inline unsigned int countbits(unsigned int value)
 {
 	return __builtin_popcount(value);
 }
-inline unsigned long long countbits(unsigned long value)
+inline unsigned long countbits(unsigned long value)
 {
 	return __builtin_popcountl(value);
 }

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -1,13 +1,29 @@
-#pragma once
+/**
+ * WickedEngine Common Include Header
+ *
+ * This header provides core utilities, math helpers, containers, atomic
+ * operations, and bit manipulation functions used throughout the WickedEngine.
+ * It is designed to be minimal and included in every engine header.
+ *
+ * WARNING: Do not include engine features in this file!
+ */
 
-// This is a helper include file pasted into all engine headers, try to keep it minimal!
-// Do not include engine features in this file!
+#pragma once
 
 #include <cassert>
 #include <cmath>
 #include <cstdint>
 #include <type_traits>
 
+/**
+ * Array size helper macro.
+ *
+ * Returns the number of elements in a statically-sized array.
+ *
+ * @param a - Array expression (not a pointer).
+ *
+ * @return Number of elements in the array.
+ */
 #define arraysize(a) (sizeof(a) / sizeof((a)[0]))
 
 #ifdef _WIN32
@@ -31,8 +47,30 @@
 #define WI_DISABLE_DEPRECATED_END _Pragma("GCC diagnostic pop")
 #endif // _MSC_VER
 
-// Simple common math helpers:
+/*
+################################################################################
+Math Helpers
+################################################################################
+*/
 
+/**
+ * Aligns a value up to the specified alignment.
+ *
+ * Supports both power-of-2 and arbitrary alignments.
+ * For power-of-2 alignments, uses fast bitwise operations.
+ * For arbitrary alignments, uses division-based approach.
+ *
+ * \[
+ * \text{align}(v, a) = \lceil \frac{v}{a} \rceil \times a
+ * \]
+ *
+ * @param[in] value - Value to align up.
+ * @param[in] alignment - Alignment boundary (must be > 0).
+ *
+ * @return The smallest multiple of `alignment` that is >= `value`.
+ *
+ * @note Fast path for power-of-2 alignments uses bitwise operations.
+ */
 template<typename T>
 [[nodiscard]] constexpr T align(T value, T alignment) noexcept
 {
@@ -51,6 +89,16 @@ template<typename T>
 	return ((value + alignment - 1) / alignment) * alignment;
 }
 
+/**
+ * Checks if a value is aligned to the specified alignment.
+ *
+ * Supports both power-of-2 and arbitrary alignments.
+ *
+ * @param[in] value - Value to check.
+ * @param[in] alignment - Alignment boundary (must be > 0).
+ *
+ * @return true if `value` is a multiple of `alignment`, false otherwise.
+ */
 template<typename T>
 [[nodiscard]] constexpr bool is_aligned(T value, T alignment) noexcept
 {
@@ -66,24 +114,63 @@ template<typename T>
 	return value % alignment == 0;
 }
 
+/**
+ * Computes the square of a value.
+ *
+ * @param[in] x - Input value.
+ *
+ * @return \f$ x^2 \f$
+ */
 template <typename T>
 [[nodiscard]] constexpr T sqr(T x) noexcept { return x * x; }
 
+/**
+ * Computes the fourth power of a value.
+ *
+ * @param[in] x - Input value.
+ *
+ * @return \f$ x^4 \f$
+ */
 template <typename T>
 [[nodiscard]] constexpr T pow4(T x) noexcept { return sqr(sqr(x)); }
 
+/**
+ * Clamps a value between two bounds.
+ *
+ * @param[in] x - Value to clamp.
+ * @param[in] a - Lower bound.
+ * @param[in] b - Upper bound.
+ *
+ * @return Value clamped to range [a, b].
+ */
 template <typename T>
 [[nodiscard]] constexpr T clamp(T x, T a, T b) noexcept
 {
 	return x < a ? a : (x > b ? b : x);
 }
 
+/**
+ * Clamps a value to the [0, 1] range.
+ *
+ * @param[in] x - Value to saturate.
+ *
+ * @return Value clamped to [0, 1].
+ */
 template <typename T>
 [[nodiscard]] constexpr T saturate(T x) noexcept
 {
 	return clamp(x, T(0), T(1));
 }
 
+/**
+ * Returns the fractional part of a floating-point value.
+ *
+ * Returns value in range [0, 1).
+ *
+ * @param[in] x - Input value (must be floating-point).
+ *
+ * @return Fractional part of x.
+ */
 template <typename T>
 [[nodiscard]] constexpr T frac(T x) noexcept
 {
@@ -91,12 +178,34 @@ template <typename T>
 	return x - std::floor(x);
 }
 
+/**
+ * Linear interpolation between two values.
+ *
+ * Uses numerically stable formula: \f$ x + a \times (y - x) \f$
+ *
+ * @param[in] x - Start value.
+ * @param[in] y - End value.
+ * @param[in] a - Interpolation factor in [0, 1].
+ *
+ * @return Interpolated value.
+ */
 template <typename T>
 [[nodiscard]] constexpr T lerp(T x, T y, T a) noexcept
 {
 	return x + a * (y - x);
 }
 
+/**
+ * Computes the interpolation factor between two values.
+ *
+ * Returns 0 if value1 == value2 (zero range).
+ *
+ * @param[in] value1 - Start value.
+ * @param[in] value2 - End value.
+ * @param[in] pos - Position to find factor for.
+ *
+ * @return Factor a such that lerp(value1, value2, a) == pos.
+ */
 template <typename T>
 [[nodiscard]] constexpr T inverse_lerp(T value1, T value2, T pos) noexcept
 {
@@ -105,6 +214,19 @@ template <typename T>
 	return value2 == value1 ? T(0) : ((pos - value1) / (value2 - value1));
 }
 
+/**
+ * Smooth Hermite interpolation between 0 and 1.
+ *
+ * \[
+ * f(t) = t^2(3 - 2t)
+ * \]
+ *
+ * @param[in] edge0 - Lower edge.
+ * @param[in] edge1 - Upper edge.
+ * @param[in] x - Input value.
+ *
+ * @return Smooth interpolated value in [0, 1].
+ */
 template <typename T>
 [[nodiscard]] constexpr T smoothstep(T edge0, T edge1, T x) noexcept
 {
@@ -112,6 +234,20 @@ template <typename T>
 	return t * t * (T(3) - T(2) * t);
 }
 
+/**
+ * Bilinear interpolation on a 2x2 grid.
+ *
+ * Interpolates between four corner values using a 2D fractional position.
+ *
+ * @param[in] gather - 4-component vector containing corner values
+ *                     [bottom-left, bottom-right, top-left, top-right].
+ * @param[in] pixel_frac - 2D fractional position in [0, 1] x [0, 1].
+ *
+ * @return Bilinearly interpolated value.
+ *
+ * @note Vec4 must have .x, .y, .z, .w arithmetic members.
+ * @note Vec2 must have .x, .y arithmetic members.
+ */
 template <typename Vec4, typename Vec2>
 [[nodiscard]] constexpr auto bilinear(Vec4 gather, Vec2 pixel_frac) noexcept
 	-> std::enable_if_t<
@@ -129,109 +265,486 @@ template <typename Vec4, typename Vec2>
 	return lerp(top_row, bottom_row, pixel_frac.y);
 }
 
-// Stack allocated string utility:
+/**
+ * Stack-allocated string utility with fixed capacity.
+ *
+ * A lightweight string container that stores characters on the stack.
+ * Capacity is fixed at compile-time via template parameter.
+ * Not dynamically resizable - use with care for large strings.
+ *
+ * @tparam Capacity - Maximum number of characters (including null terminator).
+ *         Must be > 1.
+ *
+ * Example usage:
+ * ```cpp
+ * StackString<64> str = "hello";
+ * str += " world";
+ * str += '!';
+ * printf("%s\n", str.c_str()); // "hello world!"
+ * ```
+ */
 template <unsigned Capacity = 256>
 struct StackString
 {
 	char chars[Capacity] = {};
 	unsigned cnt = 0;
 	static_assert(Capacity > 1);
+	
+	/**
+	 * Implicit conversion to C-string.
+	 *
+	 * @return Null-terminated C-string pointer.
+	 */
 	[[nodiscard]] constexpr operator const char* () const noexcept { return chars; }
+	
+	/**
+	 * Returns the C-string pointer.
+	 *
+	 * @return Null-terminated C-string pointer.
+	 */
 	[[nodiscard]] constexpr const char* const c_str() const noexcept { return chars; }
+	
+	/**
+	 * Appends a null-terminated string.
+	 *
+	 * @param[in] str - Null-terminated string to append. nullptr is ignored.
+	 */
 	constexpr void push_back(const char* str) noexcept { if (!str) return; while (*str != 0 && (cnt < (Capacity - 1))) { chars[cnt++] = *str; str++; } }
+	
+	/**
+	 * Appends a single character.
+	 *
+	 * @param[in] c - Character to append.
+	 */
 	constexpr void push_back(char c) noexcept { if (cnt < (Capacity - 1)) { chars[cnt++] = c; } }
+	
+	/**
+	 * Appends a single character (operator overload).
+	 *
+	 * @param[in] c - Character to append.
+	 *
+	 * @return Reference to this StackString for chaining.
+	 */
 	[[nodiscard]] constexpr StackString& operator+=(char c) noexcept { push_back(c); return *this; }
+	
+	/**
+	 * Appends a null-terminated string (operator overload).
+	 *
+	 * @param[in] str - Null-terminated string to append.
+	 *
+	 * @return Reference to this StackString for chaining.
+	 */
 	[[nodiscard]] constexpr StackString& operator+=(const char* str) noexcept { push_back(str); return *this; }
+	
+	/**
+	 * Returns the current string length (number of characters).
+	 *
+	 * @return Number of characters in the string.
+	 */
 	[[nodiscard]] constexpr unsigned size() const noexcept { return cnt; }
+	
+	/**
+	 * Returns the current string length (alias for size()).
+	 *
+	 * @return Number of characters in the string.
+	 */
 	[[nodiscard]] constexpr unsigned length() const noexcept { return cnt; }
+	
+	/**
+	 * Returns the compile-time capacity of the string.
+	 *
+	 * @return Maximum number of characters (including null terminator).
+	 */
 	[[nodiscard]] constexpr unsigned capacity() const noexcept { return Capacity; }
+	
+	/**
+	 * Checks if the string is empty.
+	 *
+	 * @return true if string length is 0, false otherwise.
+	 */
 	[[nodiscard]] constexpr bool empty() const noexcept { return cnt == 0; }
+	
 	constexpr StackString() = default;
 	constexpr StackString(const StackString&) = default;
 	constexpr StackString(StackString&&) = default;
+	
+	/**
+	 * Constructs from a C-string.
+	 *
+	 * @param[in] str - Null-terminated string to copy.
+	 */
 	constexpr StackString(const char* str) { push_back(str); }
 };
 
-// Stack allocated simplified vector container:
+/**
+ * Stack-allocated simplified vector container with fixed capacity.
+ *
+ * A lightweight vector container that stores elements on the stack.
+ * Capacity is fixed at compile-time via template parameter.
+ * Provides basic vector operations with bounds checking via asserts.
+ *
+ * @tparam T - Element type.
+ * @tparam count - Maximum number of elements. Must be > 0.
+ *
+ * Example usage:
+ * ```cpp
+ * StackVector<int, 32> vec;
+ * vec.push_back(1);
+ * vec.push_back(2);
+ * vec.push_back(3);
+ * for (int v : vec) { printf("%d ", v); } // 1 2 3
+ * ```
+ */
 template<typename T, unsigned count>
 struct StackVector
 {
 	T items[count] = {};
 	unsigned last = 0;
+	
+	/**
+	 * Sets the logical size of the vector.
+	 *
+	 * @param[in] size - New logical size. Must not exceed compile-time
+	 *                   capacity.
+	 */
 	constexpr void set_size(unsigned size) noexcept { assert(size <= count); last = size; }
+	
+	/**
+	 * Returns the current number of elements.
+	 *
+	 * @return Number of elements in the vector.
+	 */
 	[[nodiscard]] constexpr unsigned size() const noexcept { return last; }
+	
+	/**
+	 * Checks if the vector is empty.
+	 *
+	 * @return true if size is 0, false otherwise.
+	 */
 	[[nodiscard]] constexpr bool empty() const noexcept { return last == 0; }
+	
+	/**
+	 * Returns the compile-time capacity of the vector.
+	 *
+	 * @return Maximum number of elements.
+	 */
 	[[nodiscard]] constexpr unsigned capacity() const noexcept { return count; }
+	
+	/**
+	 * Appends an element by copy.
+	 *
+	 * @param[in] item - Element to append.
+	 *
+	 * @note Asserts if vector is full.
+	 */
 	constexpr void push_back(const T& item) noexcept { assert(last < count); items[last++] = item; }
+	
+	/**
+	 * Appends an element by move.
+	 *
+	 * @param[in] item - Element to append (rvalue reference).
+	 *
+	 * @note Asserts if vector is full.
+	 */
 	constexpr void push_back(T&& item) noexcept { assert(last < count); items[last++] = static_cast<T&&>(item); }
+	
+	/**
+	 * Removes the last element.
+	 *
+	 * @note No-op if vector is empty.
+	 */
 	constexpr void pop_back() noexcept { if (!empty()) items[--last] = {}; }
+	
+	/**
+	 * Clears all elements (sets size to 0).
+	 */
 	constexpr void clear() noexcept { for (unsigned i = 0; i < last; ++i) items[i] = {}; last = 0; }
+	
+	/**
+	 * Returns pointer to the first element.
+	 *
+	 * @return Pointer to the first element.
+	 */
 	[[nodiscard]] constexpr T* data() noexcept { return items; }
+	
+	/**
+	 * Returns const pointer to the first element.
+	 *
+	 * @return Const pointer to the first element.
+	 */
 	[[nodiscard]] constexpr const T* data() const noexcept { return items; }
+	
+	/**
+	 * Returns iterator to the first element.
+	 *
+	 * @return Pointer to the first element.
+	 */
 	[[nodiscard]] constexpr T* begin() noexcept { return items; }
+	
+	/**
+	 * Returns iterator past the last element.
+	 *
+	 * @return Pointer past the last element.
+	 */
 	[[nodiscard]] constexpr T* end() noexcept { return items + last; }
+	
+	/**
+	 * Returns reference to the last element.
+	 *
+	 * @return Reference to the last element.
+	 *
+	 * @note Asserts if vector is empty.
+	 */
 	constexpr const T& back() const noexcept { assert(!empty()); return items[last - 1]; }
+	
+	/**
+	 * Returns mutable reference to the last element.
+	 *
+	 * @return Reference to the last element.
+	 *
+	 * @note Asserts if vector is empty.
+	 */
 	constexpr T& back() noexcept { assert(!empty()); return items[last - 1]; }
+	
+	/**
+	 * Returns reference to the first element.
+	 *
+	 * @return Reference to the first element.
+	 *
+	 * @note Asserts if vector is empty.
+	 */
 	constexpr const T& front() const noexcept { assert(!empty()); return items[0]; }
+	
+	/**
+	 * Returns mutable reference to the first element.
+	 *
+	 * @return Reference to the first element.
+	 *
+	 * @note Asserts if vector is empty.
+	 */
 	constexpr T& front() noexcept { assert(!empty()); return items[0]; }
+	
+	/**
+	 * Constructs an element in-place at the end.
+	 *
+	 * @return Reference to the newly constructed element.
+	 */
 	constexpr T& emplace_back() noexcept { push_back({}); return back(); }
+	
+	/**
+	 * Returns const reference to element at index.
+	 *
+	 * @param[in] index - Element index.
+	 *
+	 * @return Const reference to element.
+	 *
+	 * @note Asserts if index >= size().
+	 */
 	constexpr const T& operator[](unsigned index) const noexcept { assert(index < last); return items[index]; }
+	
+	/**
+	 * Returns mutable reference to element at index.
+	 *
+	 * @param[in] index - Element index.
+	 *
+	 * @return Reference to element.
+	 *
+	 * @note Asserts if index >= size().
+	 */
 	constexpr T& operator[](unsigned index) noexcept { assert(index < last); return items[index]; }
+	
+	/**
+	 * Returns const reference to element at index (bounds-checked alias).
+	 *
+	 * @param[in] index - Element index.
+	 *
+	 * @return Const reference to element.
+	 *
+	 * @note Asserts if index >= size().
+	 */
 	constexpr const T& at(unsigned index) const noexcept { assert(index < last); return items[index]; }
+	
+	/**
+	 * Returns mutable reference to element at index (bounds-checked alias).
+	 *
+	 * @param[in] index - Element index.
+	 *
+	 * @return Reference to element.
+	 *
+	 * @note Asserts if index >= size().
+	 */
 	constexpr T& at(unsigned index) noexcept { assert(index < last); return items[index]; }
 };
 
-// CPU intrinsics:
-#if defined(_WIN32)
+/*
+################################################################################
+CPU Intrinsics
+################################################################################
+*/
+
 // Windows, Xbox:
+#if defined(_WIN32)
 #include <intrin.h>
 #if defined(_M_ARM64)
 #include <arm64intr.h>
 #endif // _M_ARM64
+
+/**
+ * Atomically performs bitwise AND on a 32-bit value.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] mask - Bitmask to AND with.
+ *
+ * @return The original value before the operation.
+ */
 [[nodiscard]] inline long AtomicAnd(volatile long* ptr, long mask) noexcept
 {
 	return _InterlockedAnd(ptr, mask);
 }
+
+/**
+ * Atomically performs bitwise AND on a 64-bit value.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] mask - Bitmask to AND with.
+ *
+ * @return The original value before the operation.
+ */
 [[nodiscard]] inline long long AtomicAnd(volatile long long* ptr, long long mask) noexcept
 {
 	return _InterlockedAnd64(ptr, mask);
 }
+
+/**
+ * Atomically performs bitwise OR on a 32-bit value.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] mask - Bitmask to OR with.
+ *
+ * @return The original value before the operation.
+ */
 [[nodiscard]] inline long AtomicOr(volatile long* ptr, long mask) noexcept
 {
 	return _InterlockedOr(ptr, mask);
 }
+
+/**
+ * Atomically performs bitwise OR on a 64-bit value.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] mask - Bitmask to OR with.
+ *
+ * @return The original value before the operation.
+ */
 [[nodiscard]] inline long long AtomicOr(volatile long long* ptr, long long mask) noexcept
 {
 	return _InterlockedOr64(ptr, mask);
 }
+
+/**
+ * Atomically performs bitwise XOR on a 32-bit value.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] mask - Bitmask to XOR with.
+ *
+ * @return The original value before the operation.
+ */
 [[nodiscard]] inline long AtomicXor(volatile long* ptr, long mask) noexcept
 {
 	return _InterlockedXor(ptr, mask);
 }
+
+/**
+ * Atomically performs bitwise XOR on a 64-bit value.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] mask - Bitmask to XOR with.
+ *
+ * @return The original value before the operation.
+ */
 [[nodiscard]] inline long long AtomicXor(volatile long long* ptr, long long mask) noexcept
 {
 	return _InterlockedXor64(ptr, mask);
 }
+
+/**
+ * Atomically adds a value to a 32-bit integer.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] val - Value to add.
+ *
+ * @return The original value before the addition.
+ */
 [[nodiscard]] inline long AtomicAdd(volatile long* ptr, long val) noexcept
 {
 	return _InterlockedExchangeAdd(ptr, val);
 }
+
+/**
+ * Atomically adds a value to a 64-bit integer.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] val - Value to add.
+ *
+ * @return The original value before the addition.
+ */
 [[nodiscard]] inline long long AtomicAdd(volatile long long* ptr, long long val) noexcept
 {
 	return _InterlockedExchangeAdd64(ptr, val);
 }
+/*
+################################################################################
+Bit Manipulation (Windows)
+################################################################################
+*/
+
+/**
+ * Counts the number of set bits (population count) in a 32-bit value.
+ *
+ * @param[in] value - 32-bit integer.
+ *
+ * @return Number of set bits (0-32).
+ */
 [[nodiscard]] inline unsigned int countbits(unsigned int value) noexcept
 {
 	return __popcnt(value);
 }
+
+/**
+ * Counts the number of set bits (population count) in a 64-bit value.
+ *
+ * @param[in] value - 64-bit integer.
+ *
+ * @return Number of set bits (0-64).
+ */
 [[nodiscard]] inline unsigned long countbits(unsigned long value) noexcept
 {
 	return (unsigned long)__popcnt64((unsigned long long)value);
 }
+
+/**
+ * Counts the number of set bits (population count) in a 64-bit value.
+ *
+ * @param[in] value - 64-bit integer.
+ *
+ * @return Number of set bits (0-64).
+ */
 [[nodiscard]] inline unsigned long long countbits(unsigned long long value) noexcept
 {
 	return __popcnt64(value);
 }
+
+/**
+ * Finds the index of the most significant set bit (0-based from MSB).
+ *
+ * Returns bit width (32) if value is 0.
+ *
+ * @param[in] value - 32-bit integer.
+ *
+ * @return Index of most significant set bit (0-31), or 32 if value is 0.
+ *
+ * @note Returns bit width for 0 input to distinguish from bit 0 being set.
+ */
 [[nodiscard]] inline unsigned int firstbithigh(unsigned int value) noexcept
 {
 	unsigned long bit_index;
@@ -241,6 +754,16 @@ struct StackVector
 	}
 	return 32u;
 }
+
+/**
+ * Finds the index of the most significant set bit in a 64-bit value.
+ *
+ * Returns bit width (32) if value is 0.
+ *
+ * @param[in] value - 64-bit integer (on Windows, unsigned long is 32-bit).
+ *
+ * @return Index of most significant set bit (0-31), or 32 if value is 0.
+ */
 [[nodiscard]] inline unsigned long firstbithigh(unsigned long value) noexcept
 {
 	unsigned long bit_index;
@@ -250,6 +773,16 @@ struct StackVector
 	}
 	return 32ul;
 }
+
+/**
+ * Finds the index of the most significant set bit in a 64-bit value.
+ *
+ * Returns bit width (64) if value is 0.
+ *
+ * @param[in] value - 64-bit integer.
+ *
+ * @return Index of most significant set bit (0-63), or 64 if value is 0.
+ */
 [[nodiscard]] inline unsigned long long firstbithigh(unsigned long long value) noexcept
 {
 	unsigned long bit_index;
@@ -259,6 +792,16 @@ struct StackVector
 	}
 	return 64ull;
 }
+
+/**
+ * Finds the index of the least significant set bit (0-based from LSB).
+ *
+ * Returns bit width (32) if value is 0.
+ *
+ * @param[in] value - 32-bit integer.
+ *
+ * @return Index of least significant set bit (0-31), or 32 if value is 0.
+ */
 [[nodiscard]] inline unsigned int firstbitlow(unsigned int value) noexcept
 {
 	unsigned long bit_index;
@@ -268,6 +811,17 @@ struct StackVector
 	}
 	return 32u;
 }
+
+/**
+ * Finds the index of the least significant set bit in a 64-bit value (on
+ * Windows, unsigned long is 32-bit).
+ *
+ * Returns bit width (32) if value is 0.
+ *
+ * @param[in] value - 64-bit integer (on Windows, unsigned long is 32-bit).
+ *
+ * @return Index of least significant set bit (0-31), or 32 if value is 0.
+ */
 [[nodiscard]] inline unsigned long firstbitlow(unsigned long value) noexcept
 {
 	unsigned long bit_index;
@@ -277,6 +831,16 @@ struct StackVector
 	}
 	return 32ul;
 }
+
+/**
+ * Finds the index of the least significant set bit in a 64-bit value.
+ *
+ * Returns bit width (64) if value is 0.
+ *
+ * @param[in] value - 64-bit integer.
+ *
+ * @return Index of least significant set bit (0-63), or 64 if value is 0.
+ */
 [[nodiscard]] inline unsigned long firstbitlow(unsigned long long value) noexcept
 {
 	unsigned long bit_index;
@@ -288,50 +852,170 @@ struct StackVector
 }
 #else
 // Linux, PlayStation:
+
+/*
+################################################################################
+Atomic Operations (Linux/PlayStation)
+################################################################################
+*/
+
+/**
+ * Atomically performs bitwise AND on a 32-bit value.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] mask - Bitmask to AND with.
+ *
+ * @return The original value before the operation.
+ */
 [[nodiscard]] inline long AtomicAnd(volatile long* ptr, long mask) noexcept
 {
 	return __atomic_fetch_and(ptr, mask, __ATOMIC_SEQ_CST);
 }
+
+/**
+ * Atomically performs bitwise AND on a 64-bit value.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] mask - Bitmask to AND with.
+ *
+ * @return The original value before the operation.
+ */
 [[nodiscard]] inline long long AtomicAnd(volatile long long* ptr, long long mask) noexcept
 {
 	return __atomic_fetch_and(ptr, mask, __ATOMIC_SEQ_CST);
 }
+
+/**
+ * Atomically performs bitwise OR on a 32-bit value.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] mask - Bitmask to OR with.
+ *
+ * @return The original value before the operation.
+ */
 [[nodiscard]] inline long AtomicOr(volatile long* ptr, long mask) noexcept
 {
 	return __atomic_fetch_or(ptr, mask, __ATOMIC_SEQ_CST);
 }
+
+/**
+ * Atomically performs bitwise OR on a 64-bit value.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] mask - Bitmask to OR with.
+ *
+ * @return The original value before the operation.
+ */
 [[nodiscard]] inline long long AtomicOr(volatile long long* ptr, long long mask) noexcept
 {
 	return __atomic_fetch_or(ptr, mask, __ATOMIC_SEQ_CST);
 }
+
+/**
+ * Atomically performs bitwise XOR on a 32-bit value.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] mask - Bitmask to XOR with.
+ *
+ * @return The original value before the operation.
+ */
 [[nodiscard]] inline long AtomicXor(volatile long* ptr, long mask) noexcept
 {
 	return __atomic_fetch_xor(ptr, mask, __ATOMIC_SEQ_CST);
 }
+
+/**
+ * Atomically performs bitwise XOR on a 64-bit value.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] mask - Bitmask to XOR with.
+ *
+ * @return The original value before the operation.
+ */
 [[nodiscard]] inline long long AtomicXor(volatile long long* ptr, long long mask) noexcept
 {
 	return __atomic_fetch_xor(ptr, mask, __ATOMIC_SEQ_CST);
 }
+
+/**
+ * Atomically adds a value to a 32-bit integer.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] val - Value to add.
+ *
+ * @return The original value before the addition.
+ */
 [[nodiscard]] inline long AtomicAdd(volatile long* ptr, long val) noexcept
 {
 	return __atomic_fetch_add(ptr, val, __ATOMIC_SEQ_CST);
 }
+
+/**
+ * Atomically adds a value to a 64-bit integer.
+ *
+ * @param[in,out] ptr - Pointer to the value.
+ * @param[in] val - Value to add.
+ *
+ * @return The original value before the addition.
+ */
 [[nodiscard]] inline long long AtomicAdd(volatile long long* ptr, long long val) noexcept
 {
 	return __atomic_fetch_add(ptr, val, __ATOMIC_SEQ_CST);
 }
+
+/*
+################################################################################
+Bit Manipulation (Linux/PlayStation)
+################################################################################
+*/
+
+/**
+ * Counts the number of set bits (population count) in a 32-bit value.
+ *
+ * @param[in] value - 32-bit integer.
+ *
+ * @return Number of set bits (0-32).
+ */
 [[nodiscard]] inline unsigned int countbits(unsigned int value) noexcept
 {
 	return __builtin_popcount(value);
 }
+
+/**
+ * Counts the number of set bits (population count) in a 64-bit value.
+ *
+ * @param[in] value - 64-bit integer.
+ *
+ * @return Number of set bits (0-64).
+ */
 [[nodiscard]] inline unsigned long countbits(unsigned long value) noexcept
 {
 	return __builtin_popcountl(value);
 }
+
+/**
+ * Counts the number of set bits (population count) in a 64-bit value.
+ *
+ * @param[in] value - 64-bit integer.
+ *
+ * @return Number of set bits (0-64).
+ */
 [[nodiscard]] inline unsigned long long countbits(unsigned long long value) noexcept
 {
 	return __builtin_popcountll(value);
 }
+
+/**
+ * Finds the index of the most significant set bit (0-based from MSB).
+ *
+ * Returns bit width (32) if value is 0.
+ *
+ * @param[in] value - 32-bit integer.
+ *
+ * @return Index of most significant set bit (0-31), or 32 if value is 0.
+ *
+ * @note Returns bit width for 0 input to distinguish from bit 0 being set.
+ */
 [[nodiscard]] inline unsigned int firstbithigh(unsigned int value) noexcept
 {
 	if (value == 0)
@@ -340,6 +1024,16 @@ struct StackVector
 	}
 	return __builtin_clz(value);
 }
+
+/**
+ * Finds the index of the most significant set bit in a 64-bit value.
+ *
+ * Returns bit width (size of unsigned long * 8) if value is 0.
+ *
+ * @param[in] value - 64-bit integer.
+ *
+ * @return Index of most significant set bit, or bit width if value is 0.
+ */
 [[nodiscard]] inline unsigned long firstbithigh(unsigned long value) noexcept
 {
 	if (value == 0)
@@ -348,6 +1042,16 @@ struct StackVector
 	}
 	return __builtin_clzl(value);
 }
+
+/**
+ * Finds the index of the most significant set bit in a 64-bit value.
+ *
+ * Returns bit width (64) if value is 0.
+ *
+ * @param[in] value - 64-bit integer.
+ *
+ * @return Index of most significant set bit (0-63), or 64 if value is 0.
+ */
 [[nodiscard]] inline unsigned long long firstbithigh(unsigned long long value) noexcept
 {
 	if (value == 0)
@@ -356,6 +1060,16 @@ struct StackVector
 	}
 	return __builtin_clzll(value);
 }
+
+/**
+ * Finds the index of the least significant set bit (0-based from LSB).
+ *
+ * Returns bit width (32) if value is 0.
+ *
+ * @param[in] value - 32-bit integer.
+ *
+ * @return Index of least significant set bit (0-31), or 32 if value is 0.
+ */
 [[nodiscard]] inline unsigned int firstbitlow(unsigned int value) noexcept
 {
 	if (value == 0)
@@ -364,6 +1078,16 @@ struct StackVector
 	}
 	return __builtin_ctz(value);
 }
+
+/**
+ * Finds the index of the least significant set bit in a 64-bit value.
+ *
+ * Returns bit width (size of unsigned long * 8) if value is 0.
+ *
+ * @param[in] value - 64-bit integer.
+ *
+ * @return Index of least significant set bit, or bit width if value is 0.
+ */
 [[nodiscard]] inline unsigned long firstbitlow(unsigned long value) noexcept
 {
 	if (value == 0)
@@ -372,6 +1096,16 @@ struct StackVector
 	}
 	return __builtin_ctzl(value);
 }
+
+/**
+ * Finds the index of the least significant set bit in a 64-bit value.
+ *
+ * Returns bit width (64) if value is 0.
+ *
+ * @param[in] value - 64-bit integer.
+ *
+ * @return Index of least significant set bit (0-63), or 64 if value is 0.
+ */
 [[nodiscard]] inline unsigned long long firstbitlow(unsigned long long value) noexcept
 {
 	if (value == 0)
@@ -382,29 +1116,91 @@ struct StackVector
 }
 #endif // _WIN32
 
+/*
+################################################################################
+Atomic Load
+################################################################################
+*/
+
+/**
+ * Atomically loads a 32-bit value.
+ *
+ * Implemented as atomic OR with 0.
+ *
+ * @param[in] ptr - Pointer to the value.
+ *
+ * @return The loaded value.
+ */
 [[nodiscard]] inline long AtomicLoad(const volatile long* ptr) noexcept
 {
 	return AtomicOr((volatile long*)ptr, 0);
 }
+
+/**
+ * Atomically loads a 64-bit value.
+ *
+ * Implemented as atomic OR with 0.
+ *
+ * @param[in] ptr - Pointer to the value.
+ *
+ * @return The loaded value.
+ */
 [[nodiscard]] inline long long AtomicLoad(const volatile long long* ptr) noexcept
 {
 	return AtomicOr((volatile long long*)ptr, 0);
 }
 
+/*
+################################################################################
+Bitmask Operators
+################################################################################
+*/
+
 // Enable enum flags:
 //	https://www.justsoftwaresolutions.co.uk/cplusplus/using-enum-classes-as-bitfields.html
+
+/**
+ * Trait to enable bitmask operators for an enum type.
+ *
+ * Specialize this to `std::true_type` for enums that should support bitmask
+ * operations.
+ *
+ * @tparam E - Enum type.
+ */
 template<typename E>
 struct enable_bitmask_operators : std::false_type {};
 
+/**
+ * SFINAE helper for enabling bitmask operators.
+ *
+ * @tparam E - Enum type.
+ */
 template<typename E>
 using EnableIfBitmaskOps = std::enable_if_t<enable_bitmask_operators<E>::value, int>;
 
+/**
+ * Bitwise OR for bitmask enums.
+ *
+ * @param[in] lhs - Left-hand side.
+ * @param[in] rhs - Right-hand side.
+ *
+ * @return Result of bitwise OR.
+ */
 template<typename E, EnableIfBitmaskOps<E> = 0>
 constexpr E operator|(E lhs, E rhs) noexcept
 {
 	using U = std::underlying_type_t<E>;
 	return static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
 }
+
+/**
+ * Bitwise OR-assign for bitmask enums.
+ *
+ * @param[in,out] lhs - Left-hand side (modified).
+ * @param[in] rhs - Right-hand side.
+ *
+ * @return Reference to modified lhs.
+ */
 template<typename E, EnableIfBitmaskOps<E> = 0>
 constexpr E operator|=(E& lhs, E rhs) noexcept
 {
@@ -412,12 +1208,30 @@ constexpr E operator|=(E& lhs, E rhs) noexcept
 	lhs = static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
 	return lhs;
 }
+
+/**
+ * Bitwise AND for bitmask enums.
+ *
+ * @param[in] lhs - Left-hand side.
+ * @param[in] rhs - Right-hand side.
+ *
+ * @return Result of bitwise AND.
+ */
 template<typename E, EnableIfBitmaskOps<E> = 0>
 constexpr E operator&(E lhs, E rhs) noexcept
 {
 	using U = std::underlying_type_t<E>;
 	return static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
 }
+
+/**
+ * Bitwise AND-assign for bitmask enums.
+ *
+ * @param[in,out] lhs - Left-hand side (modified).
+ * @param[in] rhs - Right-hand side.
+ *
+ * @return Reference to modified lhs.
+ */
 template<typename E, EnableIfBitmaskOps<E> = 0>
 constexpr E operator&=(E& lhs, E rhs) noexcept
 {
@@ -425,6 +1239,14 @@ constexpr E operator&=(E& lhs, E rhs) noexcept
 	lhs = static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
 	return lhs;
 }
+
+/**
+ * Bitwise NOT for bitmask enums.
+ *
+ * @param[in] rhs - Value to invert.
+ *
+ * @return Result of bitwise NOT.
+ */
 template<typename E, EnableIfBitmaskOps<E> = 0>
 constexpr E operator~(E rhs) noexcept
 {
@@ -432,11 +1254,28 @@ constexpr E operator~(E rhs) noexcept
 	rhs = static_cast<E>(~static_cast<U>(rhs));
 	return rhs;
 }
+
+/**
+ * Checks if all bits in rhs are set in lhs.
+ *
+ * @param[in] lhs - Value to test.
+ * @param[in] rhs - Bitmask to check.
+ *
+ * @return true if all bits in rhs are set in lhs.
+ */
 template<typename E, EnableIfBitmaskOps<E> = 0>
 [[nodiscard]] constexpr bool has_flag(E lhs, E rhs) noexcept
 {
 	return (lhs & rhs) == rhs;
 }
+
+/**
+ * Sets or clears a flag in a bitmask.
+ *
+ * @param[in,out] flags - Bitmask to modify.
+ * @param[in] flag - Flag to set or clear.
+ * @param[in] set - true to set, false to clear.
+ */
 template<typename T, typename U>
 constexpr void set_flag(T& flags, U flag, bool set) noexcept
 {
@@ -449,7 +1288,31 @@ constexpr void set_flag(T& flags, U flag, bool set) noexcept
 		flags &= ~static_cast<T>(flag);
 	}
 }
-// Extract file name from a path at compile-time
+/*
+################################################################################
+Path Utilities
+################################################################################
+*/
+
+/**
+ * Extracts the file name from a path at compile-time.
+ *
+ * Returns a pointer into the input string. The input must be a string literal
+ * (e.g., __FILE__) for the result to have valid lifetime. For owned strings,
+ * use relative_path_storage().
+ *
+ * @param[in] path - Null-terminated path string (e.g., __FILE__).
+ *
+ * @return Pointer to the file name portion of the path.
+ *
+ * @warning Returns pointer into input string. Input must be a string literal
+ *          for the returned pointer to remain valid.
+ *
+ * Example usage:
+ * ```cpp
+ * const char* filename = relative_path(__FILE__); // "CommonInclude.h"
+ * ```
+ */
 [[nodiscard]] constexpr const char* relative_path(const char* path) noexcept
 {
 	const char* startPosition = path;
@@ -469,6 +1332,16 @@ constexpr void set_flag(T& flags, U flag, bool set) noexcept
 	return startPosition;
 }
 
+/**
+ * Extracts the file name from a path and stores it in a StackString.
+ *
+ * Unlike relative_path(), this returns an owned copy in a StackString, so the
+ * input can be any null-terminated string (not just string literals).
+ *
+ * @param[in] path - Null-terminated path string.
+ *
+ * @return StackString containing the file name.
+ */
 [[nodiscard]] constexpr auto relative_path_storage(const char* path) noexcept
 {
 	StackString ret;
@@ -476,7 +1349,28 @@ constexpr void set_flag(T& flags, U flag, bool set) noexcept
 	return ret;
 }
 
-// Convert string literal to StackString at compile-time
+/*
+################################################################################
+String Utilities
+################################################################################
+*/
+
+/**
+ * Converts a string literal to a StackString at compile-time.
+ *
+ * Creates a StackString from a string literal. Useful for compile-time string
+ * manipulation.
+ *
+ * @param[in] str - Null-terminated string literal.
+ *
+ * @return StackString containing the string.
+ *
+ * Example usage:
+ * ```cpp
+ * auto str = to_stack_string("hello world");
+ * // str is StackString containing "hello world"
+ * ```
+ */
 [[nodiscard]] constexpr auto to_stack_string(const char* str) noexcept
 {
 	StackString ret;

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -10,9 +10,11 @@
 
 #define arraysize(a) (sizeof(a) / sizeof((a)[0]))
 
+#ifdef _WIN32
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif // NOMINMAX
+#endif // _WIN32
 
 #if defined(__GNUC__) || defined(__clang__)
 #define __forceinline __attribute__((always_inline)) inline

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -40,11 +40,17 @@
 #endif // defined(__GNUC__) || defined(__clang__)
 
 #ifdef _MSC_VER
-#define WI_DISABLE_DEPRECATED_BEGIN __pragma(warning(push)) __pragma(warning(disable: 4996))
-#define WI_DISABLE_DEPRECATED_END __pragma(warning(pop))
+#define WI_DISABLE_DEPRECATED_BEGIN \
+	__pragma(warning(push)) \
+	__pragma(warning(disable: 4996))
+#define WI_DISABLE_DEPRECATED_END \
+	__pragma(warning(pop))
 #else
-#define WI_DISABLE_DEPRECATED_BEGIN _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#define WI_DISABLE_DEPRECATED_END _Pragma("GCC diagnostic pop")
+#define WI_DISABLE_DEPRECATED_BEGIN \
+	_Pragma("GCC diagnostic push") \
+	_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define WI_DISABLE_DEPRECATED_END \
+	_Pragma("GCC diagnostic pop")
 #endif // _MSC_VER
 
 /*
@@ -122,7 +128,10 @@ template<typename T>
  * @return \f$ x^2 \f$
  */
 template <typename T>
-[[nodiscard]] constexpr T sqr(T x) noexcept { return x * x; }
+[[nodiscard]] constexpr T sqr(T x) noexcept
+{
+	return x * x;
+}
 
 /**
  * Computes the fourth power of a value.
@@ -132,7 +141,10 @@ template <typename T>
  * @return \f$ x^4 \f$
  */
 template <typename T>
-[[nodiscard]] constexpr T pow4(T x) noexcept { return sqr(sqr(x)); }
+[[nodiscard]] constexpr T pow4(T x) noexcept
+{
+	return sqr(sqr(x));
+}
 
 /**
  * Clamps a value between two bounds.
@@ -174,7 +186,11 @@ template <typename T>
 template <typename T>
 [[nodiscard]] constexpr T frac(T x) noexcept
 {
-	static_assert(std::is_floating_point_v<T>, "frac only supports floating-point types");
+	static_assert(
+		std::is_floating_point_v<T>,
+		"frac only supports floating-point types"
+	);
+
 	return x - std::floor(x);
 }
 
@@ -231,6 +247,7 @@ template <typename T>
 [[nodiscard]] constexpr T smoothstep(T edge0, T edge1, T x) noexcept
 {
 	const T t = saturate((x - edge0) / (edge1 - edge0));
+
 	return t * t * (T(3) - T(2) * t);
 }
 
@@ -260,8 +277,10 @@ template <typename Vec4, typename Vec2>
 		decltype(gather.x)>
 {
 	using T = decltype(gather.x);
-	const T top_row = lerp(gather.w, gather.z, pixel_frac.x);
+
+	const T top_row    = lerp(gather.w, gather.z, pixel_frac.x);
 	const T bottom_row = lerp(gather.x, gather.y, pixel_frac.x);
+
 	return lerp(top_row, bottom_row, pixel_frac.y);
 }
 
@@ -295,28 +314,52 @@ struct StackString
 	 *
 	 * @return Null-terminated C-string pointer.
 	 */
-	[[nodiscard]] constexpr operator const char* () const noexcept { return chars; }
+	[[nodiscard]] constexpr operator const char* () const noexcept
+	{
+		return chars;
+	}
 	
 	/**
 	 * Returns the C-string pointer.
 	 *
 	 * @return Null-terminated C-string pointer.
 	 */
-	[[nodiscard]] constexpr const char* const c_str() const noexcept { return chars; }
+	[[nodiscard]] constexpr const char* const c_str() const noexcept
+	{
+		return chars;
+	}
 	
 	/**
 	 * Appends a null-terminated string.
 	 *
 	 * @param[in] str - Null-terminated string to append. nullptr is ignored.
 	 */
-	constexpr void push_back(const char* str) noexcept { if (!str) return; while (*str != 0 && (cnt < (Capacity - 1))) { chars[cnt++] = *str; str++; } }
+	constexpr void push_back(const char* str) noexcept
+	{
+		if (!str)
+		{
+			return;
+		}
+
+		while (*str != 0 && (cnt < (Capacity - 1)))
+		{
+			chars[cnt++] = *str;
+			str++;
+		}
+	}
 	
 	/**
 	 * Appends a single character.
 	 *
 	 * @param[in] c - Character to append.
 	 */
-	constexpr void push_back(char c) noexcept { if (cnt < (Capacity - 1)) { chars[cnt++] = c; } }
+	constexpr void push_back(char c) noexcept
+	{
+		if (cnt < (Capacity - 1))
+		{
+			chars[cnt++] = c;
+		}
+	}
 	
 	/**
 	 * Appends a single character (operator overload).
@@ -325,7 +368,12 @@ struct StackString
 	 *
 	 * @return Reference to this StackString for chaining.
 	 */
-	[[nodiscard]] constexpr StackString& operator+=(char c) noexcept { push_back(c); return *this; }
+	[[nodiscard]] constexpr StackString& operator+=(char c) noexcept
+	{
+		push_back(c);
+
+		return *this;
+	}
 	
 	/**
 	 * Appends a null-terminated string (operator overload).
@@ -334,38 +382,72 @@ struct StackString
 	 *
 	 * @return Reference to this StackString for chaining.
 	 */
-	[[nodiscard]] constexpr StackString& operator+=(const char* str) noexcept { push_back(str); return *this; }
+	[[nodiscard]] constexpr StackString& operator+=(const char* str) noexcept
+	{
+		push_back(str);
+
+		return *this;
+	}
 	
 	/**
 	 * Returns the current string length (number of characters).
 	 *
 	 * @return Number of characters in the string.
 	 */
-	[[nodiscard]] constexpr unsigned size() const noexcept { return cnt; }
+	[[nodiscard]] constexpr unsigned size() const noexcept
+	{
+		return cnt;
+	}
 	
 	/**
 	 * Returns the current string length (alias for size()).
 	 *
 	 * @return Number of characters in the string.
 	 */
-	[[nodiscard]] constexpr unsigned length() const noexcept { return cnt; }
+	[[nodiscard]] constexpr unsigned length() const noexcept
+	{
+		return cnt;
+	}
 	
 	/**
 	 * Returns the compile-time capacity of the string.
 	 *
 	 * @return Maximum number of characters (including null terminator).
 	 */
-	[[nodiscard]] constexpr unsigned capacity() const noexcept { return Capacity; }
+	[[nodiscard]] constexpr unsigned capacity() const noexcept
+	{
+		return Capacity;
+	}
 	
 	/**
 	 * Checks if the string is empty.
 	 *
 	 * @return true if string length is 0, false otherwise.
 	 */
-	[[nodiscard]] constexpr bool empty() const noexcept { return cnt == 0; }
+	[[nodiscard]] constexpr bool empty() const noexcept
+	{
+		return cnt == 0;
+	}
 	
+	/**
+	 * Default constructor.
+	 *
+	 * Creates an empty string.
+	 */
 	constexpr StackString() = default;
+
+	/**
+	 * Copy constructor.
+	 *
+	 * Performs memberwise copy of the string data.
+	 */
 	constexpr StackString(const StackString&) = default;
+
+	/**
+	 * Move constructor.
+	 *
+	 * Performs memberwise move of the string data.
+	 */
 	constexpr StackString(StackString&&) = default;
 	
 	/**
@@ -373,7 +455,10 @@ struct StackString
 	 *
 	 * @param[in] str - Null-terminated string to copy.
 	 */
-	constexpr StackString(const char* str) { push_back(str); }
+	constexpr StackString(const char* str)
+	{
+		push_back(str);
+	}
 };
 
 /**
@@ -407,28 +492,42 @@ struct StackVector
 	 * @param[in] size - New logical size. Must not exceed compile-time
 	 *                   capacity.
 	 */
-	constexpr void set_size(unsigned size) noexcept { assert(size <= count); last = size; }
+	constexpr void set_size(unsigned size) noexcept
+	{
+		assert(size <= count);
+
+		last = size;
+	}
 	
 	/**
 	 * Returns the current number of elements.
 	 *
 	 * @return Number of elements in the vector.
 	 */
-	[[nodiscard]] constexpr unsigned size() const noexcept { return last; }
+	[[nodiscard]] constexpr unsigned size() const noexcept
+	{
+		return last;
+	}
 	
 	/**
 	 * Checks if the vector is empty.
 	 *
 	 * @return true if size is 0, false otherwise.
 	 */
-	[[nodiscard]] constexpr bool empty() const noexcept { return last == 0; }
+	[[nodiscard]] constexpr bool empty() const noexcept
+	{
+		return last == 0;
+	}
 	
 	/**
 	 * Returns the compile-time capacity of the vector.
 	 *
 	 * @return Maximum number of elements.
 	 */
-	[[nodiscard]] constexpr unsigned capacity() const noexcept { return count; }
+	[[nodiscard]] constexpr unsigned capacity() const noexcept
+	{
+		return count;
+	}
 	
 	/**
 	 * Appends an element by copy.
@@ -437,7 +536,12 @@ struct StackVector
 	 *
 	 * @note Asserts if vector is full.
 	 */
-	constexpr void push_back(const T& item) noexcept { assert(last < count); items[last++] = item; }
+	constexpr void push_back(const T& item) noexcept
+	{
+		assert(last < count);
+
+		items[last++] = item;
+	}
 	
 	/**
 	 * Appends an element by move.
@@ -446,47 +550,78 @@ struct StackVector
 	 *
 	 * @note Asserts if vector is full.
 	 */
-	constexpr void push_back(T&& item) noexcept { assert(last < count); items[last++] = static_cast<T&&>(item); }
+	constexpr void push_back(T&& item) noexcept
+	{
+		assert(last < count);
+
+		items[last++] = static_cast<T&&>(item);
+	}
 	
 	/**
 	 * Removes the last element.
 	 *
 	 * @note No-op if vector is empty.
 	 */
-	constexpr void pop_back() noexcept { if (!empty()) items[--last] = {}; }
+	constexpr void pop_back() noexcept
+	{
+		if (!empty())
+		{
+			items[--last] = {};
+		}
+	}
 	
 	/**
 	 * Clears all elements (sets size to 0).
 	 */
-	constexpr void clear() noexcept { for (unsigned i = 0; i < last; ++i) items[i] = {}; last = 0; }
+	constexpr void clear() noexcept
+	{
+		for (unsigned i = 0; i < last; ++i)
+		{
+			items[i] = {};
+		}
+
+		last = 0;
+	}
 	
 	/**
 	 * Returns pointer to the first element.
 	 *
 	 * @return Pointer to the first element.
 	 */
-	[[nodiscard]] constexpr T* data() noexcept { return items; }
+	[[nodiscard]] constexpr T* data() noexcept
+	{
+		return items;
+	}
 	
 	/**
 	 * Returns const pointer to the first element.
 	 *
 	 * @return Const pointer to the first element.
 	 */
-	[[nodiscard]] constexpr const T* data() const noexcept { return items; }
+	[[nodiscard]] constexpr const T* data() const noexcept
+	{
+		return items;
+	}
 	
 	/**
 	 * Returns iterator to the first element.
 	 *
 	 * @return Pointer to the first element.
 	 */
-	[[nodiscard]] constexpr T* begin() noexcept { return items; }
+	[[nodiscard]] constexpr T* begin() noexcept
+	{
+		return items;
+	}
 	
 	/**
 	 * Returns iterator past the last element.
 	 *
 	 * @return Pointer past the last element.
 	 */
-	[[nodiscard]] constexpr T* end() noexcept { return items + last; }
+	[[nodiscard]] constexpr T* end() noexcept
+	{
+		return items + last;
+	}
 	
 	/**
 	 * Returns reference to the last element.
@@ -495,7 +630,12 @@ struct StackVector
 	 *
 	 * @note Asserts if vector is empty.
 	 */
-	constexpr const T& back() const noexcept { assert(!empty()); return items[last - 1]; }
+	constexpr const T& back() const noexcept
+	{
+		assert(!empty());
+
+		return items[last - 1];
+	}
 	
 	/**
 	 * Returns mutable reference to the last element.
@@ -504,7 +644,12 @@ struct StackVector
 	 *
 	 * @note Asserts if vector is empty.
 	 */
-	constexpr T& back() noexcept { assert(!empty()); return items[last - 1]; }
+	constexpr T& back() noexcept
+	{
+		assert(!empty());
+
+		return items[last - 1];
+	}
 	
 	/**
 	 * Returns reference to the first element.
@@ -513,7 +658,12 @@ struct StackVector
 	 *
 	 * @note Asserts if vector is empty.
 	 */
-	constexpr const T& front() const noexcept { assert(!empty()); return items[0]; }
+	constexpr const T& front() const noexcept
+	{
+		assert(!empty());
+
+		return items[0];
+	}
 	
 	/**
 	 * Returns mutable reference to the first element.
@@ -522,14 +672,24 @@ struct StackVector
 	 *
 	 * @note Asserts if vector is empty.
 	 */
-	constexpr T& front() noexcept { assert(!empty()); return items[0]; }
+	constexpr T& front() noexcept
+	{
+		assert(!empty());
+
+		return items[0];
+	}
 	
 	/**
 	 * Constructs an element in-place at the end.
 	 *
 	 * @return Reference to the newly constructed element.
 	 */
-	constexpr T& emplace_back() noexcept { push_back({}); return back(); }
+	constexpr T& emplace_back() noexcept
+	{
+		push_back({});
+
+		return back();
+	}
 	
 	/**
 	 * Returns const reference to element at index.
@@ -540,7 +700,12 @@ struct StackVector
 	 *
 	 * @note Asserts if index >= size().
 	 */
-	constexpr const T& operator[](unsigned index) const noexcept { assert(index < last); return items[index]; }
+	constexpr const T& operator[](unsigned index) const noexcept
+	{
+		assert(index < last);
+
+		return items[index];
+	}
 	
 	/**
 	 * Returns mutable reference to element at index.
@@ -551,7 +716,12 @@ struct StackVector
 	 *
 	 * @note Asserts if index >= size().
 	 */
-	constexpr T& operator[](unsigned index) noexcept { assert(index < last); return items[index]; }
+	constexpr T& operator[](unsigned index) noexcept
+	{
+		assert(index < last);
+
+		return items[index];
+	}
 	
 	/**
 	 * Returns const reference to element at index (bounds-checked alias).
@@ -562,7 +732,12 @@ struct StackVector
 	 *
 	 * @note Asserts if index >= size().
 	 */
-	constexpr const T& at(unsigned index) const noexcept { assert(index < last); return items[index]; }
+	constexpr const T& at(unsigned index) const noexcept
+	{
+		assert(index < last);
+
+		return items[index];
+	}
 	
 	/**
 	 * Returns mutable reference to element at index (bounds-checked alias).
@@ -573,8 +748,14 @@ struct StackVector
 	 *
 	 * @note Asserts if index >= size().
 	 */
-	constexpr T& at(unsigned index) noexcept { assert(index < last); return items[index]; }
-};
+	constexpr T& at(unsigned index) noexcept
+	{
+		assert(index < last);
+
+		return items[index];
+	}
+	
+	};
 
 /*
 ################################################################################
@@ -597,7 +778,10 @@ CPU Intrinsics
  *
  * @return The original value before the operation.
  */
-[[nodiscard]] inline long AtomicAnd(volatile long* ptr, long mask) noexcept
+[[nodiscard]] inline long AtomicAnd(
+	volatile long* ptr,
+	long mask
+) noexcept
 {
 	return _InterlockedAnd(ptr, mask);
 }
@@ -610,7 +794,10 @@ CPU Intrinsics
  *
  * @return The original value before the operation.
  */
-[[nodiscard]] inline long long AtomicAnd(volatile long long* ptr, long long mask) noexcept
+[[nodiscard]] inline long long AtomicAnd(
+	volatile long long* ptr,
+	long long mask
+) noexcept
 {
 	return _InterlockedAnd64(ptr, mask);
 }
@@ -623,7 +810,10 @@ CPU Intrinsics
  *
  * @return The original value before the operation.
  */
-[[nodiscard]] inline long AtomicOr(volatile long* ptr, long mask) noexcept
+[[nodiscard]] inline long AtomicOr(
+	volatile long* ptr,
+	long mask
+) noexcept
 {
 	return _InterlockedOr(ptr, mask);
 }
@@ -636,7 +826,10 @@ CPU Intrinsics
  *
  * @return The original value before the operation.
  */
-[[nodiscard]] inline long long AtomicOr(volatile long long* ptr, long long mask) noexcept
+[[nodiscard]] inline long long AtomicOr(
+	volatile long long* ptr,
+	long long mask
+) noexcept
 {
 	return _InterlockedOr64(ptr, mask);
 }
@@ -649,7 +842,10 @@ CPU Intrinsics
  *
  * @return The original value before the operation.
  */
-[[nodiscard]] inline long AtomicXor(volatile long* ptr, long mask) noexcept
+[[nodiscard]] inline long AtomicXor(
+	volatile long* ptr,
+	long mask
+) noexcept
 {
 	return _InterlockedXor(ptr, mask);
 }
@@ -662,7 +858,10 @@ CPU Intrinsics
  *
  * @return The original value before the operation.
  */
-[[nodiscard]] inline long long AtomicXor(volatile long long* ptr, long long mask) noexcept
+[[nodiscard]] inline long long AtomicXor(
+	volatile long long* ptr,
+	long long mask
+) noexcept
 {
 	return _InterlockedXor64(ptr, mask);
 }
@@ -675,7 +874,10 @@ CPU Intrinsics
  *
  * @return The original value before the addition.
  */
-[[nodiscard]] inline long AtomicAdd(volatile long* ptr, long val) noexcept
+[[nodiscard]] inline long AtomicAdd(
+	volatile long* ptr,
+	long val
+) noexcept
 {
 	return _InterlockedExchangeAdd(ptr, val);
 }
@@ -688,10 +890,14 @@ CPU Intrinsics
  *
  * @return The original value before the addition.
  */
-[[nodiscard]] inline long long AtomicAdd(volatile long long* ptr, long long val) noexcept
+[[nodiscard]] inline long long AtomicAdd(
+	volatile long long* ptr,
+	long long val
+) noexcept
 {
 	return _InterlockedExchangeAdd64(ptr, val);
 }
+
 /*
 ################################################################################
 Bit Manipulation (Windows)
@@ -729,7 +935,9 @@ Bit Manipulation (Windows)
  *
  * @return Number of set bits (0-64).
  */
-[[nodiscard]] inline unsigned long long countbits(unsigned long long value) noexcept
+[[nodiscard]] inline unsigned long long countbits(
+	unsigned long long value
+) noexcept
 {
 	return __popcnt64(value);
 }
@@ -748,10 +956,12 @@ Bit Manipulation (Windows)
 [[nodiscard]] inline unsigned int firstbithigh(unsigned int value) noexcept
 {
 	unsigned long bit_index;
+
 	if (_BitScanReverse(&bit_index, (unsigned long)value))
 	{
 		return 31u - (unsigned int)bit_index;
 	}
+
 	return 32u;
 }
 
@@ -767,10 +977,12 @@ Bit Manipulation (Windows)
 [[nodiscard]] inline unsigned long firstbithigh(unsigned long value) noexcept
 {
 	unsigned long bit_index;
+
 	if (_BitScanReverse64(&bit_index, (unsigned long long)value))
 	{
 		return 31ul - bit_index;
 	}
+
 	return 32ul;
 }
 
@@ -783,13 +995,17 @@ Bit Manipulation (Windows)
  *
  * @return Index of most significant set bit (0-63), or 64 if value is 0.
  */
-[[nodiscard]] inline unsigned long long firstbithigh(unsigned long long value) noexcept
+[[nodiscard]] inline unsigned long long firstbithigh(
+	unsigned long long value
+) noexcept
 {
 	unsigned long bit_index;
+
 	if (_BitScanReverse64(&bit_index, value))
 	{
 		return 63ull - bit_index;
 	}
+
 	return 64ull;
 }
 
@@ -805,10 +1021,12 @@ Bit Manipulation (Windows)
 [[nodiscard]] inline unsigned int firstbitlow(unsigned int value) noexcept
 {
 	unsigned long bit_index;
+
 	if (_BitScanForward(&bit_index, value))
 	{
 		return (unsigned int)bit_index;
 	}
+
 	return 32u;
 }
 
@@ -825,10 +1043,12 @@ Bit Manipulation (Windows)
 [[nodiscard]] inline unsigned long firstbitlow(unsigned long value) noexcept
 {
 	unsigned long bit_index;
+
 	if (_BitScanForward64(&bit_index, (unsigned long long)value))
 	{
 		return bit_index;
 	}
+
 	return 32ul;
 }
 
@@ -841,17 +1061,20 @@ Bit Manipulation (Windows)
  *
  * @return Index of least significant set bit (0-63), or 64 if value is 0.
  */
-[[nodiscard]] inline unsigned long firstbitlow(unsigned long long value) noexcept
+[[nodiscard]] inline unsigned long firstbitlow(
+	unsigned long long value
+) noexcept
 {
 	unsigned long bit_index;
+
 	if (_BitScanForward64(&bit_index, value))
 	{
 		return bit_index;
 	}
+
 	return 64ul;
 }
 #else
-// Linux, PlayStation:
 
 /*
 ################################################################################
@@ -867,7 +1090,10 @@ Atomic Operations (Linux/PlayStation)
  *
  * @return The original value before the operation.
  */
-[[nodiscard]] inline long AtomicAnd(volatile long* ptr, long mask) noexcept
+[[nodiscard]] inline long AtomicAnd(
+	volatile long* ptr,
+	long mask
+) noexcept
 {
 	return __atomic_fetch_and(ptr, mask, __ATOMIC_SEQ_CST);
 }
@@ -880,7 +1106,10 @@ Atomic Operations (Linux/PlayStation)
  *
  * @return The original value before the operation.
  */
-[[nodiscard]] inline long long AtomicAnd(volatile long long* ptr, long long mask) noexcept
+[[nodiscard]] inline long long AtomicAnd(
+	volatile long long* ptr,
+	long long mask
+) noexcept
 {
 	return __atomic_fetch_and(ptr, mask, __ATOMIC_SEQ_CST);
 }
@@ -893,7 +1122,10 @@ Atomic Operations (Linux/PlayStation)
  *
  * @return The original value before the operation.
  */
-[[nodiscard]] inline long AtomicOr(volatile long* ptr, long mask) noexcept
+[[nodiscard]] inline long AtomicOr(
+	volatile long* ptr,
+	long mask
+) noexcept
 {
 	return __atomic_fetch_or(ptr, mask, __ATOMIC_SEQ_CST);
 }
@@ -906,7 +1138,10 @@ Atomic Operations (Linux/PlayStation)
  *
  * @return The original value before the operation.
  */
-[[nodiscard]] inline long long AtomicOr(volatile long long* ptr, long long mask) noexcept
+[[nodiscard]] inline long long AtomicOr(
+	volatile long long* ptr,
+	long long mask
+) noexcept
 {
 	return __atomic_fetch_or(ptr, mask, __ATOMIC_SEQ_CST);
 }
@@ -919,7 +1154,10 @@ Atomic Operations (Linux/PlayStation)
  *
  * @return The original value before the operation.
  */
-[[nodiscard]] inline long AtomicXor(volatile long* ptr, long mask) noexcept
+[[nodiscard]] inline long AtomicXor(
+	volatile long* ptr,
+	long mask
+) noexcept
 {
 	return __atomic_fetch_xor(ptr, mask, __ATOMIC_SEQ_CST);
 }
@@ -932,7 +1170,10 @@ Atomic Operations (Linux/PlayStation)
  *
  * @return The original value before the operation.
  */
-[[nodiscard]] inline long long AtomicXor(volatile long long* ptr, long long mask) noexcept
+[[nodiscard]] inline long long AtomicXor(
+	volatile long long* ptr,
+	long long mask
+) noexcept
 {
 	return __atomic_fetch_xor(ptr, mask, __ATOMIC_SEQ_CST);
 }
@@ -945,7 +1186,10 @@ Atomic Operations (Linux/PlayStation)
  *
  * @return The original value before the addition.
  */
-[[nodiscard]] inline long AtomicAdd(volatile long* ptr, long val) noexcept
+[[nodiscard]] inline long AtomicAdd(
+	volatile long* ptr,
+	long val
+) noexcept
 {
 	return __atomic_fetch_add(ptr, val, __ATOMIC_SEQ_CST);
 }
@@ -958,7 +1202,10 @@ Atomic Operations (Linux/PlayStation)
  *
  * @return The original value before the addition.
  */
-[[nodiscard]] inline long long AtomicAdd(volatile long long* ptr, long long val) noexcept
+[[nodiscard]] inline long long AtomicAdd(
+	volatile long long* ptr,
+	long long val
+) noexcept
 {
 	return __atomic_fetch_add(ptr, val, __ATOMIC_SEQ_CST);
 }
@@ -1000,7 +1247,9 @@ Bit Manipulation (Linux/PlayStation)
  *
  * @return Number of set bits (0-64).
  */
-[[nodiscard]] inline unsigned long long countbits(unsigned long long value) noexcept
+[[nodiscard]] inline unsigned long long countbits(
+	unsigned long long value
+) noexcept
 {
 	return __builtin_popcountll(value);
 }
@@ -1022,6 +1271,7 @@ Bit Manipulation (Linux/PlayStation)
 	{
 		return 32u;
 	}
+
 	return __builtin_clz(value);
 }
 
@@ -1040,6 +1290,7 @@ Bit Manipulation (Linux/PlayStation)
 	{
 		return sizeof(unsigned long) * 8;
 	}
+
 	return __builtin_clzl(value);
 }
 
@@ -1052,12 +1303,15 @@ Bit Manipulation (Linux/PlayStation)
  *
  * @return Index of most significant set bit (0-63), or 64 if value is 0.
  */
-[[nodiscard]] inline unsigned long long firstbithigh(unsigned long long value) noexcept
+[[nodiscard]] inline unsigned long long firstbithigh(
+	unsigned long long value
+) noexcept
 {
 	if (value == 0)
 	{
 		return 64ull;
 	}
+
 	return __builtin_clzll(value);
 }
 
@@ -1076,6 +1330,7 @@ Bit Manipulation (Linux/PlayStation)
 	{
 		return 32u;
 	}
+
 	return __builtin_ctz(value);
 }
 
@@ -1094,6 +1349,7 @@ Bit Manipulation (Linux/PlayStation)
 	{
 		return sizeof(unsigned long) * 8;
 	}
+
 	return __builtin_ctzl(value);
 }
 
@@ -1106,12 +1362,15 @@ Bit Manipulation (Linux/PlayStation)
  *
  * @return Index of least significant set bit (0-63), or 64 if value is 0.
  */
-[[nodiscard]] inline unsigned long long firstbitlow(unsigned long long value) noexcept
+[[nodiscard]] inline unsigned long long firstbitlow(
+	unsigned long long value
+) noexcept
 {
 	if (value == 0)
 	{
 		return 64ull;
 	}
+
 	return __builtin_ctzll(value);
 }
 #endif // _WIN32
@@ -1131,7 +1390,9 @@ Atomic Load
  *
  * @return The loaded value.
  */
-[[nodiscard]] inline long AtomicLoad(const volatile long* ptr) noexcept
+[[nodiscard]] inline long AtomicLoad(
+	const volatile long* ptr
+) noexcept
 {
 	return AtomicOr((volatile long*)ptr, 0);
 }
@@ -1145,7 +1406,9 @@ Atomic Load
  *
  * @return The loaded value.
  */
-[[nodiscard]] inline long long AtomicLoad(const volatile long long* ptr) noexcept
+[[nodiscard]] inline long long AtomicLoad(
+	const volatile long long* ptr
+) noexcept
 {
 	return AtomicOr((volatile long long*)ptr, 0);
 }
@@ -1176,7 +1439,9 @@ struct enable_bitmask_operators : std::false_type {};
  * @tparam E - Enum type.
  */
 template<typename E>
-using EnableIfBitmaskOps = std::enable_if_t<enable_bitmask_operators<E>::value, int>;
+using EnableIfBitmaskOps = std::enable_if_t<
+	enable_bitmask_operators<E>::value, int
+>;
 
 /**
  * Bitwise OR for bitmask enums.
@@ -1190,6 +1455,7 @@ template<typename E, EnableIfBitmaskOps<E> = 0>
 constexpr E operator|(E lhs, E rhs) noexcept
 {
 	using U = std::underlying_type_t<E>;
+
 	return static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
 }
 
@@ -1205,7 +1471,9 @@ template<typename E, EnableIfBitmaskOps<E> = 0>
 constexpr E operator|=(E& lhs, E rhs) noexcept
 {
 	using U = std::underlying_type_t<E>;
+
 	lhs = static_cast<E>(static_cast<U>(lhs) | static_cast<U>(rhs));
+
 	return lhs;
 }
 
@@ -1221,6 +1489,7 @@ template<typename E, EnableIfBitmaskOps<E> = 0>
 constexpr E operator&(E lhs, E rhs) noexcept
 {
 	using U = std::underlying_type_t<E>;
+
 	return static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
 }
 
@@ -1236,7 +1505,9 @@ template<typename E, EnableIfBitmaskOps<E> = 0>
 constexpr E operator&=(E& lhs, E rhs) noexcept
 {
 	using U = std::underlying_type_t<E>;
+
 	lhs = static_cast<E>(static_cast<U>(lhs) & static_cast<U>(rhs));
+
 	return lhs;
 }
 
@@ -1251,7 +1522,9 @@ template<typename E, EnableIfBitmaskOps<E> = 0>
 constexpr E operator~(E rhs) noexcept
 {
 	using U = std::underlying_type_t<E>;
+
 	rhs = static_cast<E>(~static_cast<U>(rhs));
+
 	return rhs;
 }
 
@@ -1288,6 +1561,7 @@ constexpr void set_flag(T& flags, U flag, bool set) noexcept
 		flags &= ~static_cast<T>(flag);
 	}
 }
+
 /*
 ################################################################################
 Path Utilities
@@ -1316,6 +1590,7 @@ Path Utilities
 [[nodiscard]] constexpr const char* relative_path(const char* path) noexcept
 {
 	const char* startPosition = path;
+
 	for (const char* currentCharacter = path; *currentCharacter != '\0'; ++currentCharacter)
 	{
 		if (*currentCharacter == '\\' || *currentCharacter == '/')
@@ -1346,6 +1621,7 @@ Path Utilities
 {
 	StackString ret;
 	ret.push_back(relative_path(path));
+
 	return ret;
 }
 
@@ -1375,5 +1651,6 @@ String Utilities
 {
 	StackString ret;
 	ret.push_back(str);
+
 	return ret;
 }

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -92,10 +92,11 @@ constexpr T smoothstep(T edge0, T edge1, T x)
 }
 
 template <typename Vec4, typename Vec2>
-constexpr float bilinear(Vec4 gather, Vec2 pixel_frac)
+constexpr auto bilinear(Vec4 gather, Vec2 pixel_frac)
 {
-	const float top_row = lerp(gather.w, gather.z, pixel_frac.x);
-	const float bottom_row = lerp(gather.x, gather.y, pixel_frac.x);
+	using T = decltype(gather.x);
+	const T top_row = lerp(gather.w, gather.z, pixel_frac.x);
+	const T bottom_row = lerp(gather.x, gather.y, pixel_frac.x);
 	return lerp(top_row, bottom_row, pixel_frac.y);
 }
 

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -169,6 +169,8 @@ struct StackVector
 	constexpr T& emplace_back() noexcept { push_back({}); return back(); }
 	constexpr const T& operator[](unsigned index) const noexcept { assert(index < last); return items[index]; }
 	constexpr T& operator[](unsigned index) noexcept { assert(index < last); return items[index]; }
+	constexpr const T& at(unsigned index) const noexcept { assert(index < last); return items[index]; }
+	constexpr T& at(unsigned index) noexcept { assert(index < last); return items[index]; }
 };
 
 // CPU intrinsics:

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -127,7 +127,7 @@ struct StackVector
 	constexpr void push_back(const T& item) { items[last++] = item; }
 	constexpr void push_back(T&& item) { items[last++] = static_cast<T&&>(item); }
 	constexpr void pop_back() { if (!empty()) items[--last] = {}; }
-	constexpr void clear() { for (unsigned i = 0; i < count; ++i) items[i] = {}; last = 0; }
+	constexpr void clear() { for (unsigned i = 0; i < last; ++i) items[i] = {}; last = 0; }
 	constexpr T* data() { return items; }
 	constexpr const T* data() const { return items; }
 	constexpr T* begin() { return items; }

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -436,8 +436,8 @@ constexpr auto relative_path_storage(const char* path)
 	return ret;
 }
 
-// Extract function name from a string at compile-time
-constexpr auto extract_function_name(const char* str)
+// Convert string literal to StackString at compile-time
+constexpr auto to_stack_string(const char* str)
 {
 	StackString ret;
 	ret.push_back(str);

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -8,7 +8,7 @@
 #include <cstdint>
 #include <type_traits>
 
-#define arraysize(a) (sizeof(a) / sizeof(a[0]))
+#define arraysize(a) (sizeof(a) / sizeof((a)[0]))
 
 #ifndef NOMINMAX
 #define NOMINMAX

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -12,7 +12,6 @@
 
 #include <cassert>
 #include <cmath>
-#include <cstdint>
 #include <type_traits>
 
 /**

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -304,8 +304,14 @@ template <typename Vec4, typename Vec2>
 template <unsigned Capacity = 256>
 struct StackString
 {
+	/** Character storage buffer (including null terminator). */
 	char chars[Capacity] = {};
+
+	/**
+	 * Current number of characters in the string (excludes null terminator).
+	 */
 	unsigned cnt = 0;
+
 	static_assert(Capacity > 1);
 	
 	/**
@@ -482,7 +488,10 @@ struct StackString
 template<typename T, unsigned count>
 struct StackVector
 {
+	/** Element storage array (fixed compile-time capacity). */
 	T items[count] = {};
+
+	/** Current number of elements in the vector (logical size). */
 	unsigned last = 0;
 	
 	/**
@@ -1619,6 +1628,7 @@ Path Utilities
 [[nodiscard]] constexpr auto relative_path_storage(const char* path) noexcept
 {
 	StackString ret;
+
 	ret.push_back(relative_path(path));
 
 	return ret;
@@ -1649,6 +1659,7 @@ String Utilities
 [[nodiscard]] constexpr auto to_stack_string(const char* str) noexcept
 {
 	StackString ret;
+
 	ret.push_back(str);
 
 	return ret;

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -88,8 +88,8 @@ constexpr T smoothstep(T edge0, T edge1, T x)
 	return t * t * (T(3) - T(2) * t);
 }
 
-template <typename float4, typename float2>
-constexpr float bilinear(float4 gather, float2 pixel_frac)
+template <typename Vec4, typename Vec2>
+constexpr float bilinear(Vec4 gather, Vec2 pixel_frac)
 {
 	const float top_row = lerp(gather.w, gather.z, pixel_frac.x);
 	const float bottom_row = lerp(gather.x, gather.y, pixel_frac.x);

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -397,7 +397,7 @@ constexpr E operator~(E rhs)
 	rhs = static_cast<E>(~static_cast<U>(rhs));
 	return rhs;
 }
-template<typename E>
+template<typename E, EnableIfBitmaskOps<E> = 0>
 constexpr bool has_flag(E lhs, E rhs)
 {
 	return (lhs & rhs) == rhs;

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -74,7 +74,7 @@ template <typename T>
 template <typename T>
 [[nodiscard]] constexpr T lerp(T x, T y, T a) noexcept
 {
-	return x * (1 - a) + y * a;
+	return x + a * (y - x);
 }
 
 template <typename T>

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -1,5 +1,4 @@
-#ifndef WICKEDENGINE_COMMONINCLUDE_H
-#define WICKEDENGINE_COMMONINCLUDE_H
+#pragma once
 
 // This is a helper include file pasted into all engine headers, try to keep it minimal!
 // Do not include engine features in this file!
@@ -449,5 +448,3 @@ constexpr auto to_stack_string(const char* str)
 	ret.push_back(str);
 	return ret;
 }
-
-#endif //WICKEDENGINE_COMMONINCLUDE_H

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -107,7 +107,7 @@ struct StackString
 	static_assert(capacity > 1);
 	constexpr operator const char* () const { return chars; }
 	constexpr const char* const c_str() const { return chars; }
-	constexpr void push_back(const char* str) { while (*str != 0 && (cnt < (capacity - 1))) { chars[cnt++] = *str; str++; } }
+	constexpr void push_back(const char* str) { if (!str) return; while (*str != 0 && (cnt < (capacity - 1))) { chars[cnt++] = *str; str++; } }
 	constexpr unsigned size() const { return cnt; }
 	constexpr unsigned length() const { return cnt; }
 	constexpr bool empty() const { return cnt == 0; }

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -21,7 +21,7 @@
 #define __forceinline __attribute__((always_inline)) inline
 #define NO_SANITIZE(x) __attribute__((no_sanitize(x)))
 #else
-#define NO_SANITIZE(x)
+#define NO_SANITIZE(x) (void)(x)
 #endif // defined(__GNUC__) || defined(__clang__)
 
 #ifdef _MSC_VER

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -131,6 +131,9 @@ struct StackString
 	[[nodiscard]] constexpr operator const char* () const noexcept { return chars; }
 	[[nodiscard]] constexpr const char* const c_str() const noexcept { return chars; }
 	constexpr void push_back(const char* str) noexcept { if (!str) return; while (*str != 0 && (cnt < (Capacity - 1))) { chars[cnt++] = *str; str++; } }
+	constexpr void push_back(char c) noexcept { if (cnt < (Capacity - 1)) { chars[cnt++] = c; } }
+	[[nodiscard]] constexpr StackString& operator+=(char c) noexcept { push_back(c); return *this; }
+	[[nodiscard]] constexpr StackString& operator+=(const char* str) noexcept { push_back(str); return *this; }
 	[[nodiscard]] constexpr unsigned size() const noexcept { return cnt; }
 	[[nodiscard]] constexpr unsigned length() const noexcept { return cnt; }
 	[[nodiscard]] constexpr unsigned capacity() const noexcept { return Capacity; }

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -80,6 +80,8 @@ template <typename T>
 template <typename T>
 [[nodiscard]] constexpr T inverse_lerp(T value1, T value2, T pos) noexcept
 {
+	// If value1 == value2, range is zero - return 0 as safe fallback.
+	// This handles degenerate cases (zero-size AABBs, flat terrain, etc.)
 	return value2 == value1 ? T(0) : ((pos - value1) / (value2 - value1));
 }
 

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -106,7 +106,7 @@ struct StackString
 	constexpr operator const char* () const { return chars; }
 	constexpr const char* const c_str() const { return chars; }
 	constexpr void push_back(const char* str) { while (*str != 0 && (cnt < (capacity - 1))) { chars[cnt++] = *str; str++; } }
-	constexpr unsigned size() const { return capacity; }
+	constexpr unsigned size() const { return cnt; }
 	constexpr unsigned length() const { return cnt; }
 	constexpr bool empty() const { return cnt == 0; }
 	constexpr StackString() = default;

--- a/WickedEngine/CommonInclude.h
+++ b/WickedEngine/CommonInclude.h
@@ -70,7 +70,7 @@ constexpr T frac(T x)
 }
 
 template <typename T>
-constexpr float lerp(T x, T y, T a)
+constexpr T lerp(T x, T y, T a)
 {
 	return x * (1 - a) + y * a;
 }

--- a/WickedEngine/wiAudio.cpp
+++ b/WickedEngine/wiAudio.cpp
@@ -26,7 +26,7 @@
 #define fourccDPDS 'sdpd'
 
 #define xaudio_assert(cond, fname) { wilog_assert(cond, "XAudio2 error: %s failed with %s (%s:%d)", fname, wi::helper::GetPlatformErrorString(hr).c_str(), relative_path(__FILE__), __LINE__); }
-#define xaudio_check(call) [&]() { HRESULT hr = call; xaudio_assert(SUCCEEDED(hr), extract_function_name(#call).c_str()); return hr; }()
+#define xaudio_check(call) [&]() { HRESULT hr = call; xaudio_assert(SUCCEEDED(hr), to_stack_string(#call).c_str()); return hr; }()
 
 namespace wi::audio
 {

--- a/WickedEngine/wiGraphicsDevice_DX12.h
+++ b/WickedEngine/wiGraphicsDevice_DX12.h
@@ -37,7 +37,7 @@
 #include <mutex>
 
 #define dx12_assert(cond, fname) { wilog_assert(cond, "DX12 error: %s failed with %s (%s:%d)", fname, wi::helper::GetPlatformErrorString(hr).c_str(), relative_path(__FILE__), __LINE__); }
-#define dx12_check(call) [&]() { HRESULT hr = call; dx12_assert(SUCCEEDED(hr), extract_function_name(#call).c_str()); return hr; }()
+#define dx12_check(call) [&]() { HRESULT hr = call; dx12_assert(SUCCEEDED(hr), to_stack_string(#call).c_str()); return hr; }()
 
 namespace wi::graphics
 {

--- a/WickedEngine/wiGraphicsDevice_Vulkan.h
+++ b/WickedEngine/wiGraphicsDevice_Vulkan.h
@@ -30,7 +30,7 @@
 #include <algorithm>
 
 #define vulkan_assert(cond, fname) { wilog_assert(cond, "Vulkan error: %s failed with %s (%s:%d)", fname, string_VkResult(res), relative_path(__FILE__), __LINE__); }
-#define vulkan_check(call) [&]() { VkResult res = call; vulkan_assert((res >= VK_SUCCESS), extract_function_name(#call).c_str()); return res; }()
+#define vulkan_check(call) [&]() { VkResult res = call; vulkan_assert((res >= VK_SUCCESS), to_stack_string(#call).c_str()); return res; }()
 
 namespace wi::graphics::vulkan_internal
 {


### PR DESCRIPTION
### Summary
Comprehensive refactor of `WickedEngine/CommonInclude.h`.

---

### Changes

#### Bug Fixes & Correctness
- **StackString::size()**: Fixed to return `cnt` (active length) instead of `Capacity`
- **arraysize macro**: Added parentheses around `__VA_ARGS__` for correct precedence
- **align()**: Hybrid bitwise/division for arbitrary alignment (not just power-of-2)
- **is_aligned()**: Bitwise check for power-of-2, division fallback for arbitrary
- **StackVector::clear()**: Only zeros active elements (`last` items), not full capacity
- **StackVector::resize → set_size**: Renamed to avoid `std::vector` confusion
- **countbits(unsigned long)**: Return type fixed to `unsigned long`
- **lerp/bilinear**: Return component type `T` instead of vector type
- **firstbithigh/firstbitlow**: Return bit width (32/64) for input 0 (distinguishes from bit 0)
- **bilinear**: Template params `float4/float2` → generic `Vec4/Vec2` with SFINAE constraints
- **set_flag**: Removed redundant `const` on flag parameter
- **NOMINMAX**: Wrapped in `_WIN32` guard
- **StackString::push_back**: Added nullptr check
- **StackVector**: Added bounds checking asserts in debug builds
- **inverse_lerp**: Zero-range fallback documented (returns 0 for degenerate cases)
- **frac()**: Constrained to floating-point via `static_assert`, uses `std::floor`
- **has_flag**: Constrained to bitmask-enabled types via `enable_bitmask_operators`

#### API Additions
- **capacity()**: Added to `StackString` and `StackVector`
- **StackVector::at()**: Bounds-checked accessor
- **StackString::operator+=**: For `char` and `const char*`
- **to_stack_string()**: Replaces `extract_function_name()`, constexpr construct from literal
- **relative_path_storage()**: Owned copy alternative to `relative_path()`

#### Removals & Deduplication
- Removed unused includes

#### Attributes & Safety
- Added `[[nodiscard]]` and `noexcept` for hardening

#### Documentation
- Fully documented the file

#### Call Site Updates
- `wiGraphicsDevice_Vulkan.h`
- `wiGraphicsDevice_DX12.h`
- `wiAudio.cpp`
- Updated to use `to_stack_string()` instead of removed `extract_function_name()`